### PR TITLE
Use affine coordinates for hashing GroupProjective

### DIFF
--- a/primitives/src/elgamal.rs
+++ b/primitives/src/elgamal.rs
@@ -12,6 +12,7 @@ use ark_ec::{
 use ark_ff::UniformRand;
 use ark_serialize::*;
 use ark_std::{
+    hash::{Hash, Hasher},
     rand::{CryptoRng, Rng, RngCore},
     string::ToString,
     vec,
@@ -30,13 +31,24 @@ use zeroize::Zeroize;
 // =====================================================
 /// Encryption key for encryption scheme
 #[derive(Clone, Eq, CanonicalSerialize, CanonicalDeserialize, Default, Zeroize, Derivative)]
-#[derivative(Hash(bound = "P: Parameters"), PartialEq)]
 #[derivative(Debug(bound = "P: Parameters"))]
 pub struct EncKey<P>
 where
     P: Parameters + Clone,
 {
     pub(crate) key: GroupProjective<P>,
+}
+
+impl<P: Parameters + Clone> Hash for EncKey<P> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash(&self.key.into_affine(), state)
+    }
+}
+
+impl<P: Parameters + Clone> PartialEq for EncKey<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key.into_affine() == other.key.into_affine()
+    }
 }
 
 // =====================================================

--- a/primitives/src/schnorr_dsa.rs
+++ b/primitives/src/schnorr_dsa.rs
@@ -130,7 +130,6 @@ where
 #[tagged_blob("SIG")]
 #[derive(Clone, Eq, CanonicalSerialize, CanonicalDeserialize, Derivative)]
 #[derivative(Debug(bound = "P: Parameters"))]
-#[derivative(Hash(bound = "P: Parameters"))]
 #[allow(non_snake_case)]
 pub struct Signature<P>
 where
@@ -140,12 +139,22 @@ where
     pub(crate) R: GroupProjective<P>,
 }
 
+impl<P> Hash for Signature<P>
+where
+    P: Parameters + Clone,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash(&self.s, state);
+        Hash::hash(&self.R.into_affine(), state);
+    }
+}
+
 impl<P> PartialEq for Signature<P>
 where
     P: Parameters + Clone,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.s == other.s && self.R == other.R
+        self.s == other.s && self.R.into_affine() == other.R.into_affine()
     }
 }
 // =====================================================

--- a/utilities_derive/src/lib.rs
+++ b/utilities_derive/src/lib.rs
@@ -49,9 +49,9 @@ use syn::{parse_macro_input, AttributeArgs, Item, NestedMeta};
 ///
 /// The type Nullifier can now be serialized as binary:
 /// ```
-/// # #[macro_use] extern crate jf_utils_derive;
 /// # use ark_serialize::*;
 /// # use ark_std::UniformRand;
+/// # use jf_utils_derive::tagged_blob;
 /// # use rand_chacha::{ChaChaRng, rand_core::SeedableRng};
 /// # #[tagged_blob("NUL")]
 /// # #[derive(Clone, CanonicalSerialize, CanonicalDeserialize, /* any other derives */)]
@@ -61,9 +61,9 @@ use syn::{parse_macro_input, AttributeArgs, Item, NestedMeta};
 /// ```
 /// or as base64:
 /// ```
-/// # #[macro_use] extern crate jf_utils_derive;
 /// # use ark_serialize::*;
 /// # use ark_std::UniformRand;
+/// # use jf_utils_derive::tagged_blob;
 /// # use rand_chacha::{ChaChaRng, rand_core::SeedableRng};
 /// # #[tagged_blob("NUL")]
 /// # #[derive(Clone, CanonicalSerialize, CanonicalDeserialize, /* any other derives */)]


### PR DESCRIPTION
Hash for GroupProjective is broken in the latest release of arkworks,
so we must provide a custom Hash implementation for any type that
contains a GroupProjective which correctly hashes the affine coordinates.

Also,
* ~downgrade sha2 and digest, to be compatible with jellyfish-apps~ this has been undone, I was looking at an old version of jellyfish-apps
* fix a doc bug that for some reason was causing precommit to fail