### PR TITLE
Add serde and Display/FromStr for schnorr_dsa::KeyPair

### DIFF
--- a/primitives/src/schnorr_dsa.rs
+++ b/primitives/src/schnorr_dsa.rs
@@ -118,6 +118,7 @@ impl<P: Parameters + Clone> VerKey<P> {
 
 /// Signature secret key pair used to sign messages
 // make sure sk can be zeroized
+#[tagged_blob("SIGNKEYPAIR")]
 #[derive(Clone, Default, CanonicalSerialize, CanonicalDeserialize, PartialEq, Derivative)]
 #[derivative(Debug(bound = "P: Parameters"))]
 pub struct KeyPair<P>


### PR DESCRIPTION
I recently created a CLI utility for generating signing keys. I found that I wanted to print the private key using tagged base 64, so that it can be easily copied and pasted to RPass, for example. For this to work we need to add a `#[tagged_blob()]` annotation.