### PR TITLE
chore: refactor exact instances of `ok_or_else`

### DIFF
--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/gadgets.rs
@@ -148,10 +148,9 @@ where
             add_pcs_eval_circuit(
                 circuit,
                 &mut result,
-                match v_and_uv_basis.next() {
-                    Some(p) => p,
-                    None => return Err(PlonkError::IteratorOutOfRange),
-                },
+                v_and_uv_basis
+                    .next()
+                    .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
                 wire_eval,
                 &non_native_field_info.modulus_fp_elem,
             )?;
@@ -160,10 +159,9 @@ where
             add_pcs_eval_circuit(
                 circuit,
                 &mut result,
-                match v_and_uv_basis.next() {
-                    Some(p) => p,
-                    None => return Err(PlonkError::IteratorOutOfRange),
-                },
+                v_and_uv_basis
+                    .next()
+                    .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
                 sigma_eval,
                 &non_native_field_info.modulus_fp_elem,
             )?;
@@ -172,10 +170,9 @@ where
         add_pcs_eval_circuit(
             circuit,
             &mut result,
-            match v_and_uv_basis.next() {
-                Some(p) => p,
-                None => return Err(PlonkError::IteratorOutOfRange),
-            },
+            v_and_uv_basis
+                .next()
+                .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
             &poly_evals.perm_next_eval,
             &non_native_field_info.modulus_fp_elem,
         )?;

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/poly.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/poly.rs
@@ -455,10 +455,9 @@ where
 
         // preparing data for second statement
         let r_0_component = circuit.mod_mul(
-            match alpha_bases_elem_var.next() {
-                Some(p) => p,
-                None => return Err(PlonkError::IteratorOutOfRange),
-            },
+            alpha_bases_elem_var
+                .next()
+                .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
             &r_plonk_j_fp_elem_var,
             &non_native_field_info.modulus_fp_elem,
         )?;
@@ -532,10 +531,9 @@ where
         // where a_bar, b_bar and c_bar are in w_evals
         // ============================================
 
-        let current_alpha_bases = match alpha_bases_elem_var.next() {
-            Some(p) => p,
-            None => return Err(PlonkError::IteratorOutOfRange),
-        };
+        let current_alpha_bases = alpha_bases_elem_var
+            .next()
+            .ok_or_else(|| PlonkError::IteratorOutOfRange)?;
 
         let mut coeff_fp_elem_var = alpha_2_mul_l1;
         let w_evals = &batch_proof.poly_evals_vec[i].wires_evals;

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -720,30 +720,27 @@ where
             for &wire_eval in poly_evals.wires_evals.iter() {
                 Self::add_pcs_eval(
                     &mut result,
-                    match v_and_uv_basis.next() {
-                        Some(p) => p,
-                        None => return Err(PlonkError::IteratorOutOfRange),
-                    },
+                    v_and_uv_basis
+                        .next()
+                        .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
                     wire_eval,
                 );
             }
             for &sigma_eval in poly_evals.wire_sigma_evals.iter() {
                 Self::add_pcs_eval(
                     &mut result,
-                    match v_and_uv_basis.next() {
-                        Some(p) => p,
-                        None => return Err(PlonkError::IteratorOutOfRange),
-                    },
+                    v_and_uv_basis
+                        .next()
+                        .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
                     sigma_eval,
                 );
             }
             // evaluations at point `zeta * g`
             Self::add_pcs_eval(
                 &mut result,
-                match v_and_uv_basis.next() {
-                    Some(p) => p,
-                    None => return Err(PlonkError::IteratorOutOfRange),
-                },
+                v_and_uv_basis
+                    .next()
+                    .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
                 poly_evals.perm_next_eval,
             );
 
@@ -754,10 +751,9 @@ where
                 for &eval in evals.evals_vec().iter() {
                     Self::add_pcs_eval(
                         &mut result,
-                        match v_and_uv_basis.next() {
-                            Some(p) => p,
-                            None => return Err(PlonkError::IteratorOutOfRange),
-                        },
+                        v_and_uv_basis
+                            .next()
+                            .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
                         eval,
                     );
                 }
@@ -765,10 +761,9 @@ where
                 for &next_eval in evals.next_evals_vec().iter() {
                     Self::add_pcs_eval(
                         &mut result,
-                        match v_and_uv_basis.next() {
-                            Some(p) => p,
-                            None => return Err(PlonkError::IteratorOutOfRange),
-                        },
+                        v_and_uv_basis
+                            .next()
+                            .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
                         next_eval,
                     );
                 }


### PR DESCRIPTION
## Description

Small PR refactoring to `.ok_or_else`. Tool-aided by [comby-rust](https://github.com/huitseeker/comby-rust)