### PR TITLE
a comment on lookup table creation api

### DIFF
--- a/plonk/src/circuit/customized/ecc/msm.rs
+++ b/plonk/src/circuit/customized/ecc/msm.rs
@@ -335,6 +335,9 @@ where
 
     // create circuit
     let range_size = F::from((1 << c) as u32);
+    for &var in decomposed_scalar_vars.iter() {
+        circuit.range_gate(var, c)?;
+    }
     circuit.decompose_vars_gate(decomposed_scalar_vars.clone(), scalar_var, range_size)?;
 
     Ok(decomposed_scalar_vars)

--- a/plonk/src/circuit/customized/ultraplonk/lookup_table.rs
+++ b/plonk/src/circuit/customized/ultraplonk/lookup_table.rs
@@ -20,6 +20,10 @@ impl<F: PrimeField> PlonkCircuit<F> {
     /// and create a list of variable tuples to be looked up:
     ///     [lookup_vars\[0\], ..., lookup_vars[m - 1]];
     ///
+    /// **For each input lookup variable tuple `(lookup_var.0, lookup_var.1,
+    /// lookup_var.2)`, we require the key index `lookup_var.0` to be
+    /// range-checked before so that it doesn't exceed the table size.**
+    ///
     /// w.l.o.g we assume n = m as we can pad with dummy tuples when n != m
     pub fn create_table_and_lookup_variables(
         &mut self,

--- a/plonk/src/circuit/customized/ultraplonk/lookup_table.rs
+++ b/plonk/src/circuit/customized/ultraplonk/lookup_table.rs
@@ -20,9 +20,11 @@ impl<F: PrimeField> PlonkCircuit<F> {
     /// and create a list of variable tuples to be looked up:
     ///     [lookup_vars\[0\], ..., lookup_vars[m - 1]];
     ///
-    /// **For each input lookup variable tuple `(lookup_var.0, lookup_var.1,
-    /// lookup_var.2)`, we require the key index `lookup_var.0` to be
-    /// range-checked before so that it doesn't exceed the table size.**
+    /// **For each variable tuple `(lookup_var.0, lookup_var.1, lookup_var.2)`
+    /// to be looked up, the index variable `lookup_var.0` is required to be
+    /// in range [0, n) (either constrained by a range-check gate or other
+    /// circuits), so that one can't set it out of bounds and thus do a
+    /// lookup into one of the *other* tables. **
     ///
     /// w.l.o.g we assume n = m as we can pad with dummy tuples when n != m
     pub fn create_table_and_lookup_variables(

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/gadgets.rs
@@ -150,7 +150,7 @@ where
                 &mut result,
                 v_and_uv_basis
                     .next()
-                    .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                    .ok_or(PlonkError::IteratorOutOfRange)?,
                 wire_eval,
                 &non_native_field_info.modulus_fp_elem,
             )?;
@@ -161,7 +161,7 @@ where
                 &mut result,
                 v_and_uv_basis
                     .next()
-                    .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                    .ok_or(PlonkError::IteratorOutOfRange)?,
                 sigma_eval,
                 &non_native_field_info.modulus_fp_elem,
             )?;
@@ -172,7 +172,7 @@ where
             &mut result,
             v_and_uv_basis
                 .next()
-                .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                .ok_or(PlonkError::IteratorOutOfRange)?,
             &poly_evals.perm_next_eval,
             &non_native_field_info.modulus_fp_elem,
         )?;

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/poly.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/poly.rs
@@ -457,7 +457,7 @@ where
         let r_0_component = circuit.mod_mul(
             alpha_bases_elem_var
                 .next()
-                .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                .ok_or(PlonkError::IteratorOutOfRange)?,
             &r_plonk_j_fp_elem_var,
             &non_native_field_info.modulus_fp_elem,
         )?;
@@ -533,7 +533,7 @@ where
 
         let current_alpha_bases = alpha_bases_elem_var
             .next()
-            .ok_or_else(|| PlonkError::IteratorOutOfRange)?;
+            .ok_or(PlonkError::IteratorOutOfRange)?;
 
         let mut coeff_fp_elem_var = alpha_2_mul_l1;
         let w_evals = &batch_proof.poly_evals_vec[i].wires_evals;

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -722,7 +722,7 @@ where
                     &mut result,
                     v_and_uv_basis
                         .next()
-                        .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                        .ok_or(PlonkError::IteratorOutOfRange)?,
                     wire_eval,
                 );
             }
@@ -731,7 +731,7 @@ where
                     &mut result,
                     v_and_uv_basis
                         .next()
-                        .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                        .ok_or(PlonkError::IteratorOutOfRange)?,
                     sigma_eval,
                 );
             }
@@ -740,7 +740,7 @@ where
                 &mut result,
                 v_and_uv_basis
                     .next()
-                    .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                    .ok_or(PlonkError::IteratorOutOfRange)?,
                 poly_evals.perm_next_eval,
             );
 
@@ -753,7 +753,7 @@ where
                         &mut result,
                         v_and_uv_basis
                             .next()
-                            .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                            .ok_or(PlonkError::IteratorOutOfRange)?,
                         eval,
                     );
                 }
@@ -763,7 +763,7 @@ where
                         &mut result,
                         v_and_uv_basis
                             .next()
-                            .ok_or_else(|| PlonkError::IteratorOutOfRange)?,
+                            .ok_or(PlonkError::IteratorOutOfRange)?,
                         next_eval,
                     );
                 }


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

An important API comment: the key index of the lookup variable should be range-checked before calling `create_table_and_lookup_variable()`, otherwise one may set it outside the bounds of the array, and thus doing a lookup into one of the _other_ tables.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
