### PR TITLE
typo: plookup -> plonkup, fix clippy

### DIFF
--- a/plonk/examples/proof_of_exp.rs
+++ b/plonk/examples/proof_of_exp.rs
@@ -105,7 +105,7 @@ where
     // Step 1:
     // We instantiate a turbo plonk circuit.
     //
-    // Here we only need turbo plonk since we are not using plookups.
+    // Here we only need turbo plonk since we are not using plonkups.
     let mut circuit = PlonkCircuit::<EmbedCurve::BaseField>::new_turbo_plonk();
 
     // Step 2:

--- a/plonk/src/circuit/basic.rs
+++ b/plonk/src/circuit/basic.rs
@@ -504,7 +504,7 @@ impl<F: FftField> Circuit<F> for PlonkCircuit<F> {
         }
     }
 
-    // Plookup-related methods
+    // Plonkup-related methods
     //
     fn support_lookup(&self) -> bool {
         self.plonk_params.plonk_type == PlonkType::UltraPlonk
@@ -1193,7 +1193,7 @@ where
         Ok(DensePolynomial::from_coefficients_vec(pub_input_vec))
     }
 
-    // Plookup-related methods
+    // Plonkup-related methods
     //
     fn compute_range_table_polynomial(&self) -> Result<DensePolynomial<F>, PlonkError> {
         let range_table = self.compute_range_table()?;
@@ -1969,7 +1969,7 @@ pub(crate) mod test {
         assert!(circuit.constant_gate(0, F::one()).is_err());
         assert!(circuit.bool_gate(0).is_err());
         assert!(circuit.equal_gate(0, 0).is_err());
-        // Plookup-related methods
+        // Plonkup-related methods
         assert!(circuit.add_range_check_variable(0).is_err());
 
         Ok(())

--- a/plonk/src/circuit/customized/transcript/mod.rs
+++ b/plonk/src/circuit/customized/transcript/mod.rs
@@ -324,7 +324,7 @@ mod tests {
             k: Vec::new(),
             open_key: open_key.clone(),
             is_merged: false,
-            plookup_vk: None,
+            plonkup_vk: None,
         };
 
         let dummy_vk_var = VerifyingKeyVar::new(&mut circuit, &dummy_vk).unwrap();
@@ -383,7 +383,7 @@ mod tests {
                 k,
                 open_key: open_key.clone(),
                 is_merged: false,
-                plookup_vk: None,
+                plonkup_vk: None,
             };
             let vk_var = VerifyingKeyVar::new(&mut circuit, &vk).unwrap();
 

--- a/plonk/src/circuit/customized/ultraplonk/mod_arith.rs
+++ b/plonk/src/circuit/customized/ultraplonk/mod_arith.rs
@@ -27,7 +27,7 @@ macro_rules! to_big_int {
 /// as the multiplication of two components (e.g. p.0 * q.0)
 /// won't overflow the prime field.
 /// Warning: for performance reasons, when this struct is used,
-/// we will assume 2^m - two_power_m without checking.
+/// we will assume 2^m = two_power_m without checking.
 pub struct FpElem<F: PrimeField> {
     p: (F, F),
     m: usize,
@@ -86,7 +86,7 @@ where
 /// Represent variable of an Fp element:
 ///   elem = witness[vars.0] + 2^m * witness[vars.1]
 /// Warning: for performance reasons, when this struct is used,
-/// we will assume 2^m - two_power_m without checking.
+/// we will assume 2^m = two_power_m without checking.
 pub struct FpElemVar<F: PrimeField> {
     vars: (Variable, Variable),
     m: usize,

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/poly.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/poly.rs
@@ -308,7 +308,7 @@ where
 ///
 /// - input evals: zeta^n, zeta^n-1 and Lagrange evaluated at 1
 ///
-/// Note that this function cannot evaluate plookup verification circuits.
+/// Note that this function cannot evaluate plonkup verification circuits.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn compute_lin_poly_constant_term_circuit<E, F>(
     circuit: &mut PlonkCircuit<F>,
@@ -484,7 +484,7 @@ where
 ///
 /// - input evals: zeta^n, zeta^n-1 and Lagrange evaluated at 1
 ///
-/// Do not compute plookup related variables.
+/// Do not compute plonkup related variables.
 pub(super) fn linearization_scalars_and_bases_circuit<E, F>(
     circuit: &mut PlonkCircuit<F>,
     vks: &[&VerifyingKeyVar<E>],

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/structs.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/structs.rs
@@ -155,9 +155,9 @@ pub struct BatchProofVar<F: PrimeField> {
     /// The list of polynomial evaluations.
     pub(crate) poly_evals_vec: Vec<ProofEvaluationsVar<F>>,
 
-    // /// The list of partial proofs for Plookup argument
+    // /// The list of partial proofs for Plonkup argument
     // not used for plonk verification circuit
-    // pub(crate) plookup_proofs_vec: Vec<Option<PlookupProofVar>>,
+    // pub(crate) plonkup_proofs_vec: Vec<Option<PlonkupProofVar>>,
     /// Splitted quotient polynomial commitments.
     pub(crate) split_quot_poly_comms: Vec<PointVariable>,
 

--- a/plonk/src/circuit/mod.rs
+++ b/plonk/src/circuit/mod.rs
@@ -123,7 +123,7 @@ pub trait Circuit<F: Field> {
     /// Pad the circuit with n dummy gates
     fn pad_gate(&mut self, n: usize);
 
-    /// Plookup-related methods.
+    /// Plonkup-related methods.
     /// Return true if the circuit support lookup gates.
     fn support_lookup(&self) -> bool;
 }
@@ -170,7 +170,7 @@ pub trait Arithmetization<F: FftField>: Circuit<F> {
     /// The IO gates of the circuit are guaranteed to be in the front.
     fn compute_pub_input_polynomial(&self) -> Result<DensePolynomial<F>, PlonkError>;
 
-    /// Plookup-related methods
+    /// Plonkup-related methods
     /// Return default errors if the constraint system does not support lookup
     /// gates.
     ///
@@ -221,7 +221,7 @@ pub trait Arithmetization<F: FftField>: Circuit<F> {
         Err(LookupUnsupported.into())
     }
 
-    /// Compute and return the product polynomial for Plookup arguments.
+    /// Compute and return the product polynomial for Plonkup arguments.
     /// `beta` and `gamma` are random challenges, `sorted_vec` is the sorted
     /// concatenation of the lookup table and the lookup witnesses.
     /// Return an error if the circuit does not support lookup or

--- a/plonk/src/lib.rs
+++ b/plonk/src/lib.rs
@@ -32,7 +32,7 @@ pub mod testing_apis;
 pub enum PlonkType {
     /// TurboPlonk
     TurboPlonk,
-    /// TurboPlonk that supports Plookup
+    /// TurboPlonk that supports Plonkup
     UltraPlonk,
 }
 

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -13,7 +13,7 @@ use crate::{
     circuit::customized::ecc::SWToTEConParam,
     errors::PlonkError,
     proof_system::{
-        structs::{self, BatchProof, PlookupProof, ProofEvaluations, VerifyingKey},
+        structs::{self, BatchProof, PlonkupProof, ProofEvaluations, VerifyingKey},
         verifier,
     },
     transcript::PlonkTranscript,
@@ -331,13 +331,13 @@ where
     pub fn aggregate_evaluations(
         lin_poly_constant: &E::Fr,
         poly_evals_vec: &[ProofEvaluations<E::Fr>],
-        plookup_proofs_vec: &[Option<PlookupProof<E>>],
+        plonkup_proofs_vec: &[Option<PlonkupProof<E>>],
         buffer_v_and_uv_basis: &[E::Fr],
     ) -> Result<E::Fr, PlonkError> {
         verifier::Verifier::<E>::aggregate_evaluations(
             lin_poly_constant,
             poly_evals_vec,
-            plookup_proofs_vec,
+            plonkup_proofs_vec,
             buffer_v_and_uv_basis,
         )
     }

--- a/plonk/src/transcript/mod.rs
+++ b/plonk/src/transcript/mod.rs
@@ -17,7 +17,7 @@ pub use standard::StandardTranscript;
 
 use crate::{
     errors::PlonkError,
-    proof_system::structs::{PlookupEvaluations, ProofEvaluations, VerifyingKey},
+    proof_system::structs::{PlonkupEvaluations, ProofEvaluations, VerifyingKey},
 };
 use ark_ec::{
     short_weierstrass_jacobian::GroupAffine, PairingEngine, SWModelParameters as SWParam,
@@ -166,10 +166,10 @@ pub trait PlonkTranscript<F> {
         )
     }
 
-    /// Append the plookup evaluation to the transcript.
-    fn append_plookup_evaluations<E: PairingEngine>(
+    /// Append the plonkup evaluation to the transcript.
+    fn append_plonkup_evaluations<E: PairingEngine>(
         &mut self,
-        evals: &PlookupEvaluations<E::Fr>,
+        evals: &PlonkupEvaluations<E::Fr>,
     ) -> Result<(), PlonkError> {
         <Self as PlonkTranscript<F>>::append_message(
             self,

--- a/plonk/src/transcript/rescue.rs
+++ b/plonk/src/transcript/rescue.rs
@@ -9,7 +9,7 @@ use super::PlonkTranscript;
 use crate::{
     circuit::customized::ecc::{Point, SWToTEConParam},
     errors::PlonkError,
-    proof_system::structs::{PlookupEvaluations, ProofEvaluations, VerifyingKey},
+    proof_system::structs::{PlonkupEvaluations, ProofEvaluations, VerifyingKey},
 };
 use ark_ec::{
     short_weierstrass_jacobian::GroupAffine, PairingEngine, SWModelParameters as SWParam,
@@ -71,14 +71,14 @@ where
         // selector commitments
         for com in vk.selector_comms.iter() {
             // convert the SW form commitments into TE form
-            let te_point: Point<F> = (&com.0).into();
+            let te_point: Point<F> = com.0.into();
             self.transcript.push(te_point.get_x());
             self.transcript.push(te_point.get_y());
         }
         // sigma commitments
         for com in vk.sigma_comms.iter() {
             // convert the SW form commitments into TE form
-            let te_point: Point<F> = (&com.0).into();
+            let te_point: Point<F> = com.0.into();
             self.transcript.push(te_point.get_x());
             self.transcript.push(te_point.get_y());
         }
@@ -112,7 +112,7 @@ where
         P: SWParam<BaseField = F> + Clone,
     {
         // convert the SW form commitments into TE form
-        let te_point: Point<F> = (&comm.0).into();
+        let te_point: Point<F> = comm.0.into();
         // push the x and y coordinate of comm (in twisted
         // edwards form) to the transcript
 
@@ -149,9 +149,9 @@ where
         Ok(())
     }
 
-    fn append_plookup_evaluations<E: PairingEngine>(
+    fn append_plonkup_evaluations<E: PairingEngine>(
         &mut self,
-        evals: &PlookupEvaluations<E::Fr>,
+        evals: &PlonkupEvaluations<E::Fr>,
     ) -> Result<(), PlonkError> {
         for eval in evals.evals_vec().iter() {
             self.transcript.push(field_switching(eval));

--- a/primitives/src/elgamal.rs
+++ b/primitives/src/elgamal.rs
@@ -111,6 +111,7 @@ where
     P: Parameters + Clone,
 {
     /// Flatten out the ciphertext into a vector of scalars
+    #[allow(clippy::needless_borrow)]
     pub fn to_scalars(&self) -> Vec<P::BaseField> {
         let mut result = vec![];
         let (x, y) = (&self.ephemeral).into();


### PR DESCRIPTION
## Description

- Fixed typos: `Plookup` -> `Plonkup`
- Fixed clippy warning

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [x] ~Wrote unit tests~
- [x] ~Updated relevant documentation in the code~
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
