### PR TITLE
Update: make structs and fields related to proof generation public

### DIFF
--- a/plonk/src/lib.rs
+++ b/plonk/src/lib.rs
@@ -31,7 +31,7 @@ pub mod testing_apis;
 pub mod prelude {
     pub use crate::{
         circuit::{Arithmetization, Circuit, PlonkCircuit},
-        errors::PlonkError,
+        errors::{PlonkError, SnarkError},
         proof_system::{structs::*, PlonkKzgSnark, Snark},
         transcript::{PlonkTranscript, StandardTranscript},
     };

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -37,7 +37,8 @@ impl<E: PairingEngine> UniversalSrs<E> {
     }
 }
 
-pub(crate) type CommitKey<'a, E> = Powers<'a, E>;
+/// Key for committing to and creating evaluation proofs (alias to kzg10::Powers).
+pub type CommitKey<'a, E> = Powers<'a, E>;
 
 /// Key for verifying PCS opening proof (alias to kzg10::VerifierKey).
 pub type OpenKey<E> = VerifierKey<E>;
@@ -48,23 +49,23 @@ pub type OpenKey<E> = VerifierKey<E>;
 #[derivative(Hash(bound = "E:PairingEngine"))]
 pub struct Proof<E: PairingEngine> {
     /// Wire witness polynomials commitments.
-    pub(crate) wires_poly_comms: Vec<Commitment<E>>,
+    pub wires_poly_comms: Vec<Commitment<E>>,
 
     /// The polynomial commitment for the wire permutation argument.
-    pub(crate) prod_perm_poly_comm: Commitment<E>,
+    pub prod_perm_poly_comm: Commitment<E>,
 
     /// Splitted quotient polynomial commitments.
-    pub(crate) split_quot_poly_comms: Vec<Commitment<E>>,
+    pub split_quot_poly_comms: Vec<Commitment<E>>,
 
     /// (Aggregated) proof of evaluations at challenge point `zeta`.
-    pub(crate) opening_proof: Commitment<E>,
+    pub opening_proof: Commitment<E>,
 
     /// (Aggregated) proof of evaluation at challenge point `zeta * g` where `g`
     /// is the root of unity.
-    pub(crate) shifted_opening_proof: Commitment<E>,
+    pub shifted_opening_proof: Commitment<E>,
 
     /// Polynomial evaluations.
-    pub(crate) poly_evals: ProofEvaluations<E::Fr>,
+    pub poly_evals: ProofEvaluations<E::Fr>,
 }
 
 impl<E, P> TryFrom<Vec<E::Fq>> for Proof<E>
@@ -260,14 +261,14 @@ impl<E: PairingEngine> From<Proof<E>> for BatchProof<E> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 pub struct ProofEvaluations<F: Field> {
     /// Wire witness polynomials evaluations at point `zeta`.
-    pub(crate) wires_evals: Vec<F>,
+    pub wires_evals: Vec<F>,
 
     /// Extended permutation (sigma) polynomials evaluations at point `zeta`.
     /// We do not include the last sigma polynomial evaluation.
-    pub(crate) wire_sigma_evals: Vec<F>,
+    pub wire_sigma_evals: Vec<F>,
 
     /// Permutation product polynomial evaluation at point `zeta * g`.
-    pub(crate) perm_next_eval: F,
+    pub perm_next_eval: F,
 }
 
 impl<F: Field> TryFrom<Vec<F>> for ProofEvaluations<F> {
@@ -361,20 +362,20 @@ impl<'a, E: PairingEngine> ProvingKey<'a, E> {
 #[derive(Debug, Clone, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifyingKey<E: PairingEngine> {
     /// The size of the evaluation domain. Should be a power of two.
-    pub(crate) domain_size: usize,
+    pub domain_size: usize,
 
     /// The number of public inputs.
-    pub(crate) num_inputs: usize,
+    pub num_inputs: usize,
 
     /// The permutation polynomial commitments. The commitments are not hiding.
-    pub(crate) sigma_comms: Vec<Commitment<E>>,
+    pub sigma_comms: Vec<Commitment<E>>,
 
     /// The selector polynomial commitments. The commitments are not hiding.
-    pub(crate) selector_comms: Vec<Commitment<E>>,
+    pub selector_comms: Vec<Commitment<E>>,
 
     /// The constants K0, ..., K_num_wire_types that ensure wire subsets are
     /// disjoint.
-    pub(crate) k: Vec<E::Fr>,
+    pub k: Vec<E::Fr>,
 
     /// KZG PCS opening key.
     pub open_key: OpenKey<E>,

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -328,13 +328,13 @@ where
 #[derive(Debug, Clone, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct ProvingKey<'a, E: PairingEngine> {
     /// Extended permutation (sigma) polynomials.
-    pub(crate) sigmas: Vec<DensePolynomial<E::Fr>>,
+    pub sigmas: Vec<DensePolynomial<E::Fr>>,
 
     /// Selector polynomials.
-    pub(crate) selectors: Vec<DensePolynomial<E::Fr>>,
+    pub selectors: Vec<DensePolynomial<E::Fr>>,
 
-    // KZG PCS committing key.
-    pub(crate) commit_key: CommitKey<'a, E>,
+    /// KZG PCS committing key.
+    pub commit_key: CommitKey<'a, E>,
 
     /// The verifying key. It is used by prover to initialize transcripts.
     pub vk: VerifyingKey<E>,
@@ -342,16 +342,16 @@ pub struct ProvingKey<'a, E: PairingEngine> {
 
 impl<'a, E: PairingEngine> ProvingKey<'a, E> {
     /// The size of the evaluation domain. Should be a power of two.
-    pub(crate) fn domain_size(&self) -> usize {
+    pub fn domain_size(&self) -> usize {
         self.vk.domain_size
     }
     /// The number of public inputs.
     #[allow(dead_code)]
-    pub(crate) fn num_inputs(&self) -> usize {
+    pub fn num_inputs(&self) -> usize {
         self.vk.num_inputs
     }
     /// The constants K0, ..., K4 that ensure wire subsets are disjoint.
-    pub(crate) fn k(&self) -> &[E::Fr] {
+    pub fn k(&self) -> &[E::Fr] {
         &self.vk.k
     }
 }

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -37,7 +37,8 @@ impl<E: PairingEngine> UniversalSrs<E> {
     }
 }
 
-/// Key for committing to and creating evaluation proofs (alias to kzg10::Powers).
+/// Key for committing to and creating evaluation proofs
+/// (alias to kzg10::Powers).
 pub type CommitKey<'a, E> = Powers<'a, E>;
 
 /// Key for verifying PCS opening proof (alias to kzg10::VerifierKey).


### PR DESCRIPTION
## Description

As is required by zprice spec, the judges will replace `PlonkKzgSnark` in Line 53 with the crate implemented by the submitter:

https://github.com/EspressoSystems/jellyfish/blob/08f24d47e5ec29b977c4e8035d33dbe18c17a8d0/zprice/README.md?plain=1#L40-L55

However, the fields in `ProvingKey`, `Proof`, and some other structs are currently not visible by third-party crates, making it impossible to get the selector polynomials, construct a proof, etc. in a custom implementation of PLONK prover.

This PR makes the necessary structs and fields public to address this issue.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer