### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Pending
 
-### Breaking changes
+## v0.1.2
+
+### Improvements
+
+- `#[tagged_blob(...)]` macro now supports `const` variables in addition to string literals
+
+## v0.1.1
 
 ### Features
 
@@ -14,8 +20,5 @@
 - Derive `Debug`, `Snafu` on `enum TaggedBlobError`
 - Updated `tagged-base64` reference url to reflect the Espresso Systems name change
 - Add `HashToGroup` support for both SW and TE curves
-- `#[tagged_blob(...)]` macro now supports `const` variables in addition to string literals
-
-### Bugfixes
 
 ## v0.1.0 (Initial release of Jellyfish plonk prove system)

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jf-plonk"
 description = "UltraPlonk implementation"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2018"
 license = "MIT"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jf-primitives"
 description = "Cryptographic primitives"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2018"
 license = "MIT"

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jf-rescue"
 description = "Rescue hash function"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2018"
 license = "MIT"

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jf-utils"
 description = "Utilities for Jellyfish cryptographic library"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2018"
 license = "MIT"

--- a/utilities_derive/Cargo.toml
+++ b/utilities_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jf-utils-derive"
 description = "Procedural macros for deriving serialization code for Jellyfish types"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Small version bump to get #72 released, as the `tagged_blob` macro change is needed for CAP and CAPE.

Looking at the `CHANGELOG.md`, it looks like there were several features mentioned as "pending" there but they were already released. I've marked those as `0.1.1`.