### PR TITLE
mask splitting polys for zk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- Splitting polynomials are masked to ensure zero-knowledge of Plonk (#76)
+
 ## v0.1.2
 
 ### Improvements

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -429,6 +429,7 @@ where
         // Round 3
         challenges.alpha = transcript.get_and_append_challenge::<E>(b"alpha")?;
         let (split_quot_poly_comms, split_quot_polys) = prover.run_3rd_round(
+            prng,
             &prove_keys[0].commit_key,
             prove_keys,
             &challenges,


### PR DESCRIPTION
## Description

Sync with the recent [bug fix of Plonk paper](https://twitter.com/rel_Aztec/status/1542474186664210432?s=20&t=AXa-oonIR5EimKsMyaybWA) on masking the splitting polynomials to ensure successful ZK simulator.

![image](https://user-images.githubusercontent.com/20514086/176741917-782756ea-552f-4110-9c1e-44b760a2adf4.png)

The slight modification in our implementation is that our splitting step degree is `n+2` instead of `n`. (since our splitting polynomials are of degree `= n+1`, see [here](https://github.com/EspressoSystems/jellyfish/blob/main/plonk/src/proof_system/prover.rs#L897) and [here](https://github.com/EspressoSystems/jellyfish/blob/main/plonk/src/proof_system/prover.rs#L897))
@chancharles92 Do you remember why we decide to do this instead of `split_lo + split_mid * X^n + ...` as in the paper?

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [x] ~Wrote unit tests~
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
