### PR TITLE
update Snark -> UniversalSNARK trait

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,9 @@ on:
   pull_request:
     branches:
       - main
+      - cap-rollup
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: "0 0 * * 1"
   workflow_dispatch:
 
 jobs:
@@ -65,8 +66,8 @@ jobs:
         run: cargo test --no-run -- --ignored
 
       - name: Test
-        run: bash ./scripts/run_tests.sh      
-      
+        run: bash ./scripts/run_tests.sh
+
       - name: Example
         run: cargo run --release --example proof_of_exp
 

--- a/plonk/benches/bench.rs
+++ b/plonk/benches/bench.rs
@@ -16,7 +16,7 @@ use ark_ff::PrimeField;
 use jf_plonk::{
     circuit::{Circuit, PlonkCircuit},
     errors::PlonkError,
-    proof_system::{PlonkKzgSnark, Snark},
+    proof_system::{PlonkKzgSnark, UniversalSNARK},
     transcript::StandardTranscript,
     PlonkType,
 };

--- a/plonk/examples/proof_of_exp.rs
+++ b/plonk/examples/proof_of_exp.rs
@@ -22,7 +22,7 @@ use ark_std::{rand::SeedableRng, UniformRand};
 use jf_plonk::{
     circuit::{customized::ecc::Point, Arithmetization, Circuit, PlonkCircuit},
     errors::PlonkError,
-    proof_system::{PlonkKzgSnark, Snark},
+    proof_system::{PlonkKzgSnark, UniversalSNARK},
     transcript::StandardTranscript,
 };
 use jf_utils::fr_to_fq;

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/gadgets.rs
@@ -462,7 +462,7 @@ mod test {
         circuit::Circuit,
         proof_system::{
             batch_arg::{new_mergeable_circuit_for_test, BatchArgument},
-            PlonkKzgSnark,
+            PlonkKzgSnark, UniversalSNARK,
         },
         transcript::{PlonkTranscript, RescueTranscript},
     };

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/mod.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/mod.rs
@@ -321,7 +321,7 @@ mod test {
         proof_system::{
             batch_arg::{new_mergeable_circuit_for_test, BatchArgument},
             structs::BatchProof,
-            PlonkKzgSnark,
+            PlonkKzgSnark, UniversalSNARK,
         },
         transcript::{PlonkTranscript, RescueTranscript},
     };

--- a/plonk/src/errors.rs
+++ b/plonk/src/errors.rs
@@ -44,6 +44,8 @@ pub enum PlonkError {
     PublicInputsDoNotMatch,
 }
 
+impl ark_std::error::Error for PlonkError {}
+
 #[cfg(feature = "std")]
 impl std::error::Error for PlonkError {}
 

--- a/plonk/src/proof_system/batch_arg.rs
+++ b/plonk/src/proof_system/batch_arg.rs
@@ -42,7 +42,7 @@ pub struct Instance<E: PairingEngine> {
     _circuit_type: MergeableCircuitType,
 }
 
-impl<'a, E: PairingEngine> Instance<E> {
+impl<E: PairingEngine> Instance<E> {
     /// Get verification key by reference.
     pub fn verify_key_ref(&self) -> &VerifyingKey<E> {
         &self.prove_key.vk

--- a/plonk/src/proof_system/batch_arg.rs
+++ b/plonk/src/proof_system/batch_arg.rs
@@ -11,7 +11,7 @@ use crate::{
     proof_system::{
         structs::{BatchProof, OpenKey, ProvingKey, ScalarsAndBases, UniversalSrs, VerifyingKey},
         verifier::Verifier,
-        PlonkKzgSnark,
+        PlonkKzgSnark, UniversalSNARK,
     },
     transcript::PlonkTranscript,
     MergeableCircuitType,
@@ -30,19 +30,19 @@ use jf_rescue::RescueParameter;
 use jf_utils::multi_pairing;
 
 /// A batching argument.
-pub struct BatchArgument<'a, E: PairingEngine>(PhantomData<&'a E>);
+pub struct BatchArgument<E: PairingEngine>(PhantomData<E>);
 
 /// A circuit instance that consists of the corresponding proving
 /// key/verification key/circuit.
 #[derive(Clone)]
-pub struct Instance<'a, E: PairingEngine> {
+pub struct Instance<E: PairingEngine> {
     // TODO: considering giving instance an ID
-    prove_key: ProvingKey<'a, E>, // the verification key can be obtained inside the proving key.
+    prove_key: ProvingKey<E>, // the verification key can be obtained inside the proving key.
     circuit: PlonkCircuit<E::Fr>,
     _circuit_type: MergeableCircuitType,
 }
 
-impl<'a, E: PairingEngine> Instance<'a, E> {
+impl<'a, E: PairingEngine> Instance<E> {
     /// Get verification key by reference.
     pub fn verify_key_ref(&self) -> &VerifyingKey<E> {
         &self.prove_key.vk
@@ -54,7 +54,7 @@ impl<'a, E: PairingEngine> Instance<'a, E> {
     }
 }
 
-impl<'a, E, F, P> BatchArgument<'a, E>
+impl<E, F, P> BatchArgument<E>
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: RescueParameter + SWToTEConParam,
@@ -62,10 +62,10 @@ where
 {
     /// Setup the circuit and the proving key for a (mergeable) instance.
     pub fn setup_instance(
-        srs: &'a UniversalSrs<E>,
+        srs: &UniversalSrs<E>,
         mut circuit: PlonkCircuit<E::Fr>,
         circuit_type: MergeableCircuitType,
-    ) -> Result<Instance<'a, E>, PlonkError> {
+    ) -> Result<Instance<E>, PlonkError> {
         circuit.finalize_for_mergeable_circuit(circuit_type)?;
         let (prove_key, _) = PlonkKzgSnark::preprocess(srs, &circuit)?;
         Ok(Instance {
@@ -78,8 +78,8 @@ where
     /// Prove satisfiability of multiple instances in a batch.
     pub fn batch_prove<R, T>(
         prng: &mut R,
-        instances_type_a: &[Instance<'a, E>],
-        instances_type_b: &[Instance<'a, E>],
+        instances_type_a: &[Instance<E>],
+        instances_type_b: &[Instance<E>],
     ) -> Result<BatchProof<E>, PlonkError>
     where
         R: CryptoRng + RngCore,
@@ -175,7 +175,7 @@ where
     }
 }
 
-impl<'a, E> BatchArgument<'a, E>
+impl<E> BatchArgument<E>
 where
     E: PairingEngine,
 {

--- a/plonk/src/proof_system/mod.rs
+++ b/plonk/src/proof_system/mod.rs
@@ -5,9 +5,11 @@
 // along with the Jellyfish library. If not, see <https://mit-license.org/>.
 
 //! Interfaces for Plonk-based proof systems
-use crate::{circuit::Arithmetization, errors::PlonkError};
+use crate::circuit::Arithmetization;
 use ark_ec::PairingEngine;
 use ark_std::{
+    error::Error,
+    fmt::Debug,
     rand::{CryptoRng, RngCore},
     vec::Vec,
 };
@@ -19,8 +21,10 @@ pub(crate) mod verifier;
 use crate::transcript::PlonkTranscript;
 pub use snark::PlonkKzgSnark;
 
-/// An interface for SNARKs.
-pub trait Snark<E: PairingEngine> {
+// TODO: (alex) should we name it `PlonkishSNARK` instead? since we use
+// `PlonkTranscript` on prove and verify.
+/// An interface for SNARKs with universal setup.
+pub trait UniversalSNARK<E: PairingEngine> {
     /// The SNARK proof computed by the prover.
     type Proof: Clone;
 
@@ -32,18 +36,28 @@ pub trait Snark<E: PairingEngine> {
     /// specific circuit.
     type VerifyingKey: Clone;
 
-    // TODO: (alex) add back when `trait PolynomialCommitment` is implemented for
-    // KZG10, and the following can be compiled so that the Snark trait can be
-    // generic over prime field F.
-    // pub type UniversalSrs<F, PC> = <PC as PolynomialCommitment<F,
-    // DensePolynomial<F>>>::UniversalParams;
-    //
-    // /// Compute the proving/verifying keys from the circuit `circuit`.
-    // fn preprocess<C: Arithmetization<F>>(
-    //     &self,
-    //     srs: &UniversalSrs<F, PC>,
-    //     circuit: &C,
-    // ) -> Result<(Self::ProvingKey, Self::VerifyingKey), PlonkError>;
+    /// Universal Structured Reference String from `universal_setup`, used for
+    /// all subsequent circuit-specific preprocessing
+    type UniversalSRS: Clone + Debug;
+
+    /// SNARK related error
+    type Error: 'static + Error;
+
+    /// Generate the universal SRS for the argument system.
+    /// This setup is for trusted party to run, and mostly only used for
+    /// testing purpose. In practice, a MPC flavor of the setup will be carried
+    /// out to have higher assurance on the "toxic waste"/trapdoor being thrown
+    /// away to ensure soundness of the argument system.
+    fn universal_setup<R: RngCore + CryptoRng>(
+        max_degree: usize,
+        rng: &mut R,
+    ) -> Result<Self::UniversalSRS, Self::Error>;
+
+    /// Circuit-specific preprocessing to compute the proving/verifying keys.
+    fn preprocess<C: Arithmetization<E::Fr>>(
+        srs: &Self::UniversalSRS,
+        circuit: &C,
+    ) -> Result<(Self::ProvingKey, Self::VerifyingKey), Self::Error>;
 
     /// Compute a SNARK proof of a circuit `circuit`, using the corresponding
     /// proving key `prove_key`. The witness used to
@@ -55,11 +69,11 @@ pub trait Snark<E: PairingEngine> {
     /// resulting proof without any check on the data. It does not incur any
     /// additional cost in proof size or prove time.
     fn prove<C, R, T>(
-        prng: &mut R,
+        rng: &mut R,
         circuit: &C,
         prove_key: &Self::ProvingKey,
         extra_transcript_init_msg: Option<Vec<u8>>,
-    ) -> Result<Self::Proof, PlonkError>
+    ) -> Result<Self::Proof, Self::Error>
     where
         C: Arithmetization<E::Fr>,
         R: CryptoRng + RngCore,
@@ -74,5 +88,5 @@ pub trait Snark<E: PairingEngine> {
         public_input: &[E::Fr],
         proof: &Self::Proof,
         extra_transcript_init_msg: Option<Vec<u8>>,
-    ) -> Result<(), PlonkError>;
+    ) -> Result<(), Self::Error>;
 }

--- a/plonk/src/proof_system/prover.rs
+++ b/plonk/src/proof_system/prover.rs
@@ -23,7 +23,7 @@ use ark_poly::{
     Radix2EvaluationDomain, UVPolynomial,
 };
 use ark_poly_commit::{
-    kzg10::{Commitment, Randomness, KZG10},
+    kzg10::{Commitment, Powers, Randomness, KZG10},
     PCRandomness,
 };
 use ark_std::{
@@ -471,7 +471,9 @@ impl<E: PairingEngine> Prover<E> {
         ck: &CommitKey<E>,
         poly: &DensePolynomial<E::Fr>,
     ) -> Result<Commitment<E>, PlonkError> {
-        let (poly_comm, _) = KZG10::commit(ck, poly, None, None).map_err(PlonkError::PcsError)?;
+        let powers: Powers<'_, E> = ck.into();
+        let (poly_comm, _) =
+            KZG10::commit(&powers, poly, None, None).map_err(PlonkError::PcsError)?;
         Ok(poly_comm)
     }
 

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -436,7 +436,7 @@ where
     /// Input a circuit and the SRS, precompute the proving key and verification
     /// key.
     fn preprocess<C: Arithmetization<E::Fr>>(
-        srs: &UniversalSrs<E>,
+        srs: &Self::UniversalSRS,
         circuit: &C,
     ) -> Result<(Self::ProvingKey, Self::VerifyingKey), Self::Error> {
         // Make sure the SRS can support the circuit (with hiding degree of 2 for zk)
@@ -550,7 +550,7 @@ where
     /// `circuit` and `prove_key` has to be consistent (with the same evaluation
     /// domain etc.), otherwise return error.
     fn prove<C, R, T>(
-        prng: &mut R,
+        rng: &mut R,
         circuit: &C,
         prove_key: &Self::ProvingKey,
         extra_transcript_init_msg: Option<Vec<u8>>,
@@ -561,7 +561,7 @@ where
         T: PlonkTranscript<F>,
     {
         let (batch_proof, ..) = Self::batch_prove_internal::<_, _, T>(
-            prng,
+            rng,
             &[circuit],
             &[prove_key],
             extra_transcript_init_msg,

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -65,12 +65,12 @@ impl<E: PairingEngine> From<Powers<'_, E>> for CommitKey<E> {
     }
 }
 
-impl<'a, E: PairingEngine> From<&CommitKey<E>> for Powers<'a, E> {
-    fn from(ck: &CommitKey<E>) -> Self {
-        // We didn't use hiding variant of KZG, thus leave powers_of_gamma_g
-        // empty
+impl<'a, E: PairingEngine> From<&'a CommitKey<E>> for Powers<'a, E> {
+    fn from(ck: &'a CommitKey<E>) -> Self {
         Self {
-            powers_of_g: ark_std::borrow::Cow::Owned(ck.powers_of_g.clone()),
+            // Copy-on-write ensure reference passing as smart pointer for read-only access
+            powers_of_g: ark_std::borrow::Cow::Borrowed(&ck.powers_of_g),
+            // didn't use hiding variant of KZG, thus leave it empty
             powers_of_gamma_g: ark_std::borrow::Cow::Owned(Vec::new()),
         }
     }


### PR DESCRIPTION
## Description

Major changes include: 

- Remove `'a` lifetime from `CommitterKey` for kzg therefore most of other related structs by introducing conversion from `CommitterKey` to `ark_poly_commit::kzg10::Powers`
- Add back `universal_setup` and circuit-specific `preprocess` back to `trait Snark`
- Rename `trait Snark` to `trait UniversalSNARK`

closes: #78

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] ~Targeted PR against correct branch (main)~
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
