### PR TITLE
Restoring no_std compliance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Check Ignored Tests
         run: cargo test --no-run -- --ignored
 
+      - name: Check no_std compilation
+        run: cargo test --no-run --no-default-features
+
       - name: Test
         run: bash ./scripts/run_tests.sh
 

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -30,8 +30,8 @@ derivative = { version = "2", features = ["use_core"] }
 num-bigint = { version = "0.4", default-features = false}
 rand_chacha = { version = "0.3.1" }
 sha3 = "^0.10"
-espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.1.1" }
-
+espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", branch = "main" }
+hashbrown = "0.12.3"
 
 [dependencies.ark-poly-commit]
 git = "https://github.com/arkworks-rs/poly-commit/"

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -11,13 +11,13 @@ jf-utils = { path = "../utilities" }
 jf-rescue = { path = "../rescue" }
 
 ark-std = { version = "0.3.0", default-features = false }
-ark-serialize = { version = "0.3.0", default-features = false }
-ark-ff = { version = "0.3.0", default-features = false, features = ["asm", "parallel"] }
-ark-ec = { version = "0.3.0", default-features = false, features = ["parallel"] }
-ark-poly = { version = "0.3.0", default-features = false,  features = ["parallel"] }
-ark-bn254 = { version = "0.3.0", default-features = false, features = ["curve"] }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", features = ["curve"], rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-bls12-381 = { version = "0.3.0", default-features = false, features = ["curve"] }
+ark-serialize = "0.3.0"
+ark-ff = "0.3.0"
+ark-ec = "0.3.0"
+ark-poly = "0.3.0"
+ark-bn254 = "0.3.0"
+ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-bls12-381 = "0.3.0"
 ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
 
 merlin = { version = "3.0.0", default-features = false }
@@ -40,10 +40,10 @@ default-features = false
 
 [dev-dependencies]
 bincode = "1.0"
-ark-ed-on-bls12-381 = { version = "0.3.0", default-features = false }
+ark-ed-on-bls12-381 = "0.3.0"
 ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-ed-on-bls12-381-bandersnatch = { git = "https://github.com/arkworks-rs/curves", default-features = false, rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-ed-on-bn254 = { version = "0.3.0", default-features = false }
+ark-ed-on-bls12-381-bandersnatch = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-ed-on-bn254 = "0.3.0"
 hex = "^0.4.3"
 
 # Benchmarks
@@ -53,6 +53,7 @@ path = "benches/bench.rs"
 harness = false
 
 [features]
-std = []
-# exposing apis for testing purpose
-test_apis = []
+default = [ "ark-ff/asm" ] # no_std support
+std = [ "ark-std/std", "ark-serialize/std", "ark-ff/std", "ark-ec/std", "ark-poly/std"]
+test_apis = [] # exposing apis for testing purpose
+parallel = [ "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel" ]

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -12,7 +12,7 @@ jf-rescue = { path = "../rescue" }
 
 ark-std = { version = "0.3.0", default-features = false }
 ark-serialize = "0.3.0"
-ark-ff = "0.3.0"
+ark-ff = { version = "0.3.0", features = [ "asm" ] }
 ark-ec = "0.3.0"
 ark-poly = "0.3.0"
 ark-bn254 = "0.3.0"
@@ -21,7 +21,7 @@ ark-bls12-381 = "0.3.0"
 ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
 
 merlin = { version = "3.0.0", default-features = false }
-rayon = { version = "1.5.0", default-features = false }
+rayon = { version = "1.5.0", optional = true }
 itertools = { version = "0.10.1", default-features = false }
 downcast-rs = { version = "1.2.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -53,7 +53,7 @@ path = "benches/bench.rs"
 harness = false
 
 [features]
-default = [ "ark-ff/asm" ] # no_std support
+default = [ "parallel" ]
 std = [ "ark-std/std", "ark-serialize/std", "ark-ff/std", "ark-ec/std", "ark-poly/std"]
 test_apis = [] # exposing apis for testing purpose
-parallel = [ "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel" ]
+parallel = [ "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", "rayon" ]

--- a/plonk/benches/bench.rs
+++ b/plonk/benches/bench.rs
@@ -20,6 +20,7 @@ use jf_plonk::{
     transcript::StandardTranscript,
     PlonkType,
 };
+use std::time::Instant;
 
 const NUM_REPETITIONS: usize = 10;
 const NUM_GATES_LARGE: usize = 32768;
@@ -54,7 +55,7 @@ macro_rules! plonk_prove_bench {
 
         let (pk, _) = PlonkKzgSnark::<$bench_curve>::preprocess(&srs, &cs).unwrap();
 
-        let start = ark_std::time::Instant::now();
+        let start = Instant::now();
 
         for _ in 0..NUM_REPETITIONS {
             let _ = PlonkKzgSnark::<$bench_curve>::prove::<_, _, StandardTranscript>(
@@ -97,7 +98,7 @@ macro_rules! plonk_verify_bench {
             PlonkKzgSnark::<$bench_curve>::prove::<_, _, StandardTranscript>(rng, &cs, &pk, None)
                 .unwrap();
 
-        let start = ark_std::time::Instant::now();
+        let start = Instant::now();
 
         for _ in 0..NUM_REPETITIONS {
             let _ =
@@ -144,7 +145,7 @@ macro_rules! plonk_batch_verify_bench {
         let public_inputs_ref = vec![&pub_input[..]; $num_proofs];
         let proofs_ref = vec![&proof; $num_proofs];
 
-        let start = ark_std::time::Instant::now();
+        let start = Instant::now();
 
         for _ in 0..NUM_REPETITIONS {
             let _ = PlonkKzgSnark::<$bench_curve>::batch_verify::<StandardTranscript>(

--- a/plonk/src/circuit/basic.rs
+++ b/plonk/src/circuit/basic.rs
@@ -19,7 +19,7 @@ use ark_poly::{
 use ark_std::{
     boxed::Box,
     cmp::max,
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     format,
     string::ToString,
     vec,
@@ -321,7 +321,7 @@ impl<F: FftField> Circuit<F> for PlonkCircuit<F> {
                 self.check_range_gate(idx)?
             }
             // key-value map lookup gates
-            let mut key_val_table = HashSet::new();
+            let mut key_val_table = BTreeSet::new();
             key_val_table.insert((F::zero(), F::zero(), F::zero(), F::zero()));
             let q_lookup_vec = self.q_lookup();
             let q_dom_sep_vec = self.q_dom_sep();
@@ -1335,7 +1335,7 @@ where
             .into());
         }
         // only the first n-1 variables are for lookup
-        let mut lookup_map = HashMap::<F, usize>::new();
+        let mut lookup_map = BTreeMap::<F, usize>::new();
         let q_lookup_vec = self.q_lookup();
         let q_dom_sep_vec = self.q_dom_sep();
         for i in 0..(n - 1) {

--- a/plonk/src/circuit/basic.rs
+++ b/plonk/src/circuit/basic.rs
@@ -16,15 +16,8 @@ use ark_ff::{FftField, PrimeField};
 use ark_poly::{
     domain::Radix2EvaluationDomain, univariate::DensePolynomial, EvaluationDomain, UVPolynomial,
 };
-use ark_std::{
-    boxed::Box,
-    cmp::max,
-    collections::{BTreeMap, BTreeSet},
-    format,
-    string::ToString,
-    vec,
-    vec::Vec,
-};
+use ark_std::{boxed::Box, cmp::max, format, string::ToString, vec, vec::Vec};
+use hashbrown::{HashMap, HashSet};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -322,7 +315,7 @@ impl<F: FftField> Circuit<F> for PlonkCircuit<F> {
                 self.check_range_gate(idx)?
             }
             // key-value map lookup gates
-            let mut key_val_table = BTreeSet::new();
+            let mut key_val_table = HashSet::new();
             key_val_table.insert((F::zero(), F::zero(), F::zero(), F::zero()));
             let q_lookup_vec = self.q_lookup();
             let q_dom_sep_vec = self.q_dom_sep();
@@ -1383,7 +1376,7 @@ where
             .into());
         }
         // only the first n-1 variables are for lookup
-        let mut lookup_map = BTreeMap::<F, usize>::new();
+        let mut lookup_map = HashMap::<F, usize>::new();
         let q_lookup_vec = self.q_lookup();
         let q_dom_sep_vec = self.q_dom_sep();
         for i in 0..(n - 1) {

--- a/plonk/src/errors.rs
+++ b/plonk/src/errors.rs
@@ -46,9 +46,6 @@ pub enum PlonkError {
 
 impl ark_std::error::Error for PlonkError {}
 
-#[cfg(feature = "std")]
-impl std::error::Error for PlonkError {}
-
 impl From<ark_poly_commit::Error> for PlonkError {
     fn from(e: ark_poly_commit::Error) -> Self {
         Self::PcsError(e)

--- a/plonk/src/lib.rs
+++ b/plonk/src/lib.rs
@@ -21,6 +21,7 @@ extern crate derivative;
 pub mod circuit;
 pub mod constants;
 pub mod errors;
+pub(crate) mod par_utils;
 pub mod proof_system;
 pub mod transcript;
 

--- a/plonk/src/par_utils.rs
+++ b/plonk/src/par_utils.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Jellyfish library.
+// You should have received a copy of the MIT License
+// along with the Jellyfish library. If not, see <https://mit-license.org/>.
+
+//! Utilities for parallel code.
+
+/// this function helps with slice iterator creation that optionally use
+/// `par_iter()` when feature flag `parallel` is on.
+///
+/// # Usage
+/// let v = [1, 2, 3, 4, 5];
+/// let sum = parallelizable_slice_iter(&v).sum();
+///
+/// // the above code is a shorthand for (thus equivalent to)
+/// #[cfg(feature = "parallel")]
+/// let sum = v.par_iter().sum();
+/// #[cfg(not(feature = "parallel"))]
+/// let sum = v.iter().sum();
+#[cfg(feature = "parallel")]
+pub(crate) fn parallelizable_slice_iter<T: Sync>(data: &[T]) -> rayon::slice::Iter<T> {
+    use rayon::iter::IntoParallelIterator;
+    data.into_par_iter()
+}
+
+#[cfg(not(feature = "parallel"))]
+pub(crate) fn parallelizable_slice_iter<T>(data: &[T]) -> ark_std::slice::Iter<T> {
+    use ark_std::iter::IntoIterator;
+    data.iter()
+}

--- a/plonk/src/proof_system/prover.rs
+++ b/plonk/src/proof_system/prover.rs
@@ -32,6 +32,7 @@ use ark_std::{
     vec,
     vec::Vec,
 };
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 type CommitmentsAndPolys<E> = (
@@ -191,17 +192,37 @@ impl<E: PairingEngine> Prover<E> {
         online_oracles: &Oracles<E::Fr>,
         num_wire_types: usize,
     ) -> ProofEvaluations<E::Fr> {
-        let wires_evals: Vec<E::Fr> = online_oracles
-            .wire_polys
-            .par_iter()
-            .map(|poly| poly.evaluate(&challenges.zeta))
-            .collect();
-        let wire_sigma_evals: Vec<E::Fr> = pk
-            .sigmas
-            .par_iter()
-            .take(num_wire_types - 1)
-            .map(|poly| poly.evaluate(&challenges.zeta))
-            .collect();
+        let wires_evals: Vec<E::Fr>;
+        let wire_sigma_evals: Vec<E::Fr>;
+
+        #[cfg(feature = "parallel")]
+        {
+            wires_evals = online_oracles
+                .wire_polys
+                .par_iter()
+                .map(|poly| poly.evaluate(&challenges.zeta))
+                .collect();
+            wire_sigma_evals = pk
+                .sigmas
+                .par_iter()
+                .take(num_wire_types - 1)
+                .map(|poly| poly.evaluate(&challenges.zeta))
+                .collect();
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            wires_evals = online_oracles
+                .wire_polys
+                .iter()
+                .map(|poly| poly.evaluate(&challenges.zeta))
+                .collect();
+            wire_sigma_evals = pk
+                .sigmas
+                .iter()
+                .take(num_wire_types - 1)
+                .map(|poly| poly.evaluate(&challenges.zeta))
+                .collect();
+        }
         let perm_next_eval = online_oracles
             .prod_perm_poly
             .evaluate(&(challenges.zeta * self.domain.group_gen));
@@ -458,11 +479,23 @@ impl<E: PairingEngine> Prover<E> {
         ck: &CommitKey<E>,
         polys: &[DensePolynomial<E::Fr>],
     ) -> Result<Vec<Commitment<E>>, PlonkError> {
-        let poly_comms = polys
-            .par_iter()
-            .map(|poly| Self::commit_polynomial(ck, poly))
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(poly_comms)
+        #[cfg(feature = "parallel")]
+        {
+            let poly_comms = polys
+                .par_iter()
+                .map(|poly| Self::commit_polynomial(ck, poly))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(poly_comms)
+        }
+
+        #[cfg(not(feature = "parallel"))]
+        {
+            let poly_comms = polys
+                .iter()
+                .map(|poly| Self::commit_polynomial(ck, poly))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(poly_comms)
+        }
     }
 
     /// Commit a polynomial.
@@ -541,22 +574,48 @@ impl<E: PairingEngine> Prover<E> {
             let lookup_flag = pk.plookup_pk.is_some();
 
             // Compute coset evaluations.
-            let selectors_coset_fft: Vec<Vec<E::Fr>> = pk
-                .selectors
-                .par_iter()
-                .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
-                .collect();
-            let sigmas_coset_fft: Vec<Vec<E::Fr>> = pk
-                .sigmas
-                .par_iter()
-                .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
-                .collect();
+            let selectors_coset_fft: Vec<Vec<E::Fr>>;
+            let sigmas_coset_fft: Vec<Vec<E::Fr>>;
+            let wire_polys_coset_fft: Vec<Vec<E::Fr>>;
 
-            let wire_polys_coset_fft: Vec<Vec<E::Fr>> = oracles
-                .wire_polys
-                .par_iter()
-                .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
-                .collect();
+            #[cfg(feature = "parallel")]
+            {
+                selectors_coset_fft = pk
+                    .selectors
+                    .par_iter()
+                    .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
+                    .collect();
+                sigmas_coset_fft = pk
+                    .sigmas
+                    .par_iter()
+                    .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
+                    .collect();
+                wire_polys_coset_fft = oracles
+                    .wire_polys
+                    .par_iter()
+                    .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
+                    .collect();
+            }
+
+            #[cfg(not(feature = "parallel"))]
+            {
+                selectors_coset_fft = pk
+                    .selectors
+                    .iter()
+                    .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
+                    .collect();
+                sigmas_coset_fft = pk
+                    .sigmas
+                    .iter()
+                    .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
+                    .collect();
+                wire_polys_coset_fft = oracles
+                    .wire_polys
+                    .iter()
+                    .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
+                    .collect();
+            }
+
             // TODO: (binyi) we can also compute below in parallel with
             // `wire_polys_coset_fft`.
             let prod_perm_poly_coset_fft =
@@ -585,12 +644,25 @@ impl<E: PairingEngine> Prover<E> {
                 let key_table_coset_fft = self
                     .quot_domain
                     .coset_fft(pk.plookup_pk.as_ref().unwrap().key_table_poly.coeffs()); // safe unwrap
-                let h_coset_ffts: Vec<Vec<E::Fr>> = oracles
-                    .plookup_oracles
-                    .h_polys
-                    .par_iter()
-                    .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
-                    .collect();
+                let h_coset_ffts: Vec<Vec<E::Fr>>;
+                #[cfg(feature = "parallel")]
+                {
+                    h_coset_ffts = oracles
+                        .plookup_oracles
+                        .h_polys
+                        .par_iter()
+                        .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
+                        .collect();
+                }
+                #[cfg(not(feature = "parallel"))]
+                {
+                    h_coset_ffts = oracles
+                        .plookup_oracles
+                        .h_polys
+                        .iter()
+                        .map(|poly| self.quot_domain.coset_fft(poly.coeffs()))
+                        .collect();
+                }
                 let prod_lookup_poly_coset_fft = self
                     .quot_domain
                     .coset_fft(oracles.plookup_oracles.prod_lookup_poly.coeffs());
@@ -607,58 +679,70 @@ impl<E: PairingEngine> Prover<E> {
             };
 
             // Compute coset evaluations of the quotient polynomial.
-            let quot_poly_coset_evals: Vec<E::Fr> = (0..m)
-                .into_par_iter()
-                .map(|i| {
-                    let w: Vec<E::Fr> = (0..num_wire_types)
-                        .map(|j| wire_polys_coset_fft[j][i])
-                        .collect();
-                    let w_next: Vec<E::Fr> = (0..num_wire_types)
-                        .map(|j| wire_polys_coset_fft[j][(i + domain_size_ratio) % m])
-                        .collect();
+            let quot_poly_coset_evals: Vec<E::Fr>;
+            let quot_poly_coset_eval_fn = |i| {
+                let w: Vec<E::Fr> = (0..num_wire_types)
+                    .map(|j| wire_polys_coset_fft[j][i])
+                    .collect();
+                let w_next: Vec<E::Fr> = (0..num_wire_types)
+                    .map(|j| wire_polys_coset_fft[j][(i + domain_size_ratio) % m])
+                    .collect();
 
-                    let t_circ = Self::compute_quotient_circuit_contribution(
-                        i,
-                        &w,
-                        &pub_input_poly_coset_fft[i],
-                        &selectors_coset_fft,
-                    );
-                    let (t_perm_1, t_perm_2) = Self::compute_quotient_copy_constraint_contribution(
+                let t_circ = Self::compute_quotient_circuit_contribution(
+                    i,
+                    &w,
+                    &pub_input_poly_coset_fft[i],
+                    &selectors_coset_fft,
+                );
+                let (t_perm_1, t_perm_2) = Self::compute_quotient_copy_constraint_contribution(
+                    i,
+                    self.quot_domain.element(i) * E::Fr::multiplicative_generator(),
+                    pk,
+                    &w,
+                    &prod_perm_poly_coset_fft[i],
+                    &prod_perm_poly_coset_fft[(i + domain_size_ratio) % m],
+                    challenges,
+                    &sigmas_coset_fft,
+                );
+                let mut t1 = t_circ + t_perm_1;
+                let mut t2 = t_perm_2;
+
+                // add Plookup-related terms
+                if lookup_flag {
+                    let (t_lookup_1, t_lookup_2) = self.compute_quotient_plookup_contribution(
                         i,
                         self.quot_domain.element(i) * E::Fr::multiplicative_generator(),
                         pk,
                         &w,
-                        &prod_perm_poly_coset_fft[i],
-                        &prod_perm_poly_coset_fft[(i + domain_size_ratio) % m],
+                        &w_next,
+                        h_coset_ffts.as_ref().unwrap(),
+                        prod_lookup_poly_coset_fft.as_ref().unwrap(),
+                        range_table_coset_fft.as_ref().unwrap(),
+                        key_table_coset_fft.as_ref().unwrap(),
+                        selectors_coset_fft.last().unwrap(), /* TODO: add a method to extract
+                                                              * q_lookup_coset_fft */
+                        table_dom_sep_coset_fft.as_ref().unwrap(),
+                        q_dom_sep_coset_fft.as_ref().unwrap(),
                         challenges,
-                        &sigmas_coset_fft,
                     );
-                    let mut t1 = t_circ + t_perm_1;
-                    let mut t2 = t_perm_2;
+                    t1 += t_lookup_1;
+                    t2 += t_lookup_2;
+                }
+                t1 * z_h_inv[i % domain_size_ratio] + t2
+            };
 
-                    // add Plookup-related terms
-                    if lookup_flag {
-                        let (t_lookup_1, t_lookup_2) = self.compute_quotient_plookup_contribution(
-                            i,
-                            self.quot_domain.element(i) * E::Fr::multiplicative_generator(),
-                            pk,
-                            &w,
-                            &w_next,
-                            h_coset_ffts.as_ref().unwrap(),
-                            prod_lookup_poly_coset_fft.as_ref().unwrap(),
-                            range_table_coset_fft.as_ref().unwrap(),
-                            key_table_coset_fft.as_ref().unwrap(),
-                            selectors_coset_fft.last().unwrap(), // TODO: add a method to extract q_lookup_coset_fft
-                            table_dom_sep_coset_fft.as_ref().unwrap(),
-                            q_dom_sep_coset_fft.as_ref().unwrap(),
-                            challenges,
-                        );
-                        t1 += t_lookup_1;
-                        t2 += t_lookup_2;
-                    }
-                    t1 * z_h_inv[i % domain_size_ratio] + t2
-                })
-                .collect();
+            #[cfg(feature = "parallel")]
+            {
+                quot_poly_coset_evals = (0..m)
+                    .into_par_iter()
+                    .map(quot_poly_coset_eval_fn)
+                    .collect();
+            }
+            #[cfg(not(feature = "parallel"))]
+            {
+                quot_poly_coset_evals = (0..m).into_iter().map(quot_poly_coset_eval_fn).collect();
+            }
+
             for (a, b) in quot_poly_coset_evals_sum
                 .iter_mut()
                 .zip(quot_poly_coset_evals.iter())
@@ -919,20 +1003,31 @@ impl<E: PairingEngine> Prover<E> {
         let n = self.domain.size();
         // compute the splitting polynomials t'_i(X) s.t. t(X) =
         // \sum_{i=0}^{num_wire_types} X^{i*(n+2)} * t'_i(X)
-        let mut split_quot_polys: Vec<DensePolynomial<E::Fr>> = (0..num_wire_types)
-            .into_par_iter()
-            .map(|i| {
-                let end = if i < num_wire_types - 1 {
-                    (i + 1) * (n + 2)
-                } else {
-                    quot_poly.degree() + 1
-                };
-                // Degree-(n+1) polynomial has n + 2 coefficients.
-                DensePolynomial::<E::Fr>::from_coefficients_slice(
-                    &quot_poly.coeffs[i * (n + 2)..end],
-                )
-            })
-            .collect();
+        let mut split_quot_polys: Vec<DensePolynomial<E::Fr>>;
+        let split_quot_poly_fn = |i| {
+            let end = if i < num_wire_types - 1 {
+                (i + 1) * (n + 2)
+            } else {
+                quot_poly.degree() + 1
+            };
+            // Degree-(n+1) polynomial has n + 2 coefficients.
+            DensePolynomial::<E::Fr>::from_coefficients_slice(&quot_poly.coeffs[i * (n + 2)..end])
+        };
+
+        #[cfg(feature = "parallel")]
+        {
+            split_quot_polys = (0..num_wire_types)
+                .into_par_iter()
+                .map(split_quot_poly_fn)
+                .collect();
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            split_quot_polys = (0..num_wire_types)
+                .into_iter()
+                .map(split_quot_poly_fn)
+                .collect();
+        }
 
         // mask splitting polynomials t_i(X), for i in {0..num_wire_types}.
         // t_i(X) = t'_i(X) - b_last_i + b_now_i * X^(n+2)
@@ -1109,9 +1204,19 @@ impl<E: PairingEngine> Prover<E> {
 
     #[inline]
     fn mul_poly(poly: &DensePolynomial<E::Fr>, coeff: &E::Fr) -> DensePolynomial<E::Fr> {
-        DensePolynomial::<E::Fr>::from_coefficients_vec(
-            poly.coeffs.par_iter().map(|c| *coeff * c).collect(),
-        )
+        #[cfg(feature = "parallel")]
+        {
+            DensePolynomial::<E::Fr>::from_coefficients_vec(
+                poly.coeffs.par_iter().map(|c| *coeff * c).collect(),
+            )
+        }
+
+        #[cfg(not(feature = "parallel"))]
+        {
+            DensePolynomial::<E::Fr>::from_coefficients_vec(
+                poly.coeffs.iter().map(|c| *coeff * c).collect(),
+            )
+        }
     }
 }
 

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -18,6 +18,7 @@ use crate::{
     circuit::{customized::ecc::SWToTEConParam, Arithmetization},
     constants::{compute_coset_representatives, EXTRA_TRANSCRIPT_MSG_LABEL},
     errors::{PlonkError, SnarkError::ParameterError},
+    par_utils::parallelizable_slice_iter,
     proof_system::structs::UniversalSrs,
     transcript::*,
 };
@@ -122,43 +123,20 @@ where
             );
         }
 
-        let pcs_infos;
-        #[cfg(feature = "parallel")]
-        {
-            pcs_infos = verify_keys
-                .par_iter()
-                .zip(proofs.par_iter())
-                .zip(public_inputs.par_iter())
-                .zip(extra_transcript_init_msgs.par_iter())
-                .map(|(((&vk, &proof), &pub_input), extra_msg)| {
-                    let verifier = Verifier::new(vk.domain_size)?;
-                    verifier.prepare_pcs_info::<T>(
-                        &[vk],
-                        &[pub_input],
-                        &(*proof).clone().into(),
-                        extra_msg,
-                    )
-                })
-                .collect::<Result<Vec<_>, PlonkError>>()?;
-        }
-        #[cfg(not(feature = "parallel"))]
-        {
-            pcs_infos = verify_keys
-                .iter()
-                .zip(proofs.iter())
-                .zip(public_inputs.iter())
-                .zip(extra_transcript_init_msgs.iter())
-                .map(|(((&vk, &proof), &pub_input), extra_msg)| {
-                    let verifier = Verifier::new(vk.domain_size)?;
-                    verifier.prepare_pcs_info::<T>(
-                        &[vk],
-                        &[pub_input],
-                        &(*proof).clone().into(),
-                        extra_msg,
-                    )
-                })
-                .collect::<Result<Vec<_>, PlonkError>>()?;
-        }
+        let pcs_infos = parallelizable_slice_iter(verify_keys)
+            .zip(parallelizable_slice_iter(proofs))
+            .zip(parallelizable_slice_iter(public_inputs))
+            .zip(parallelizable_slice_iter(extra_transcript_init_msgs))
+            .map(|(((&vk, &proof), &pub_input), extra_msg)| {
+                let verifier = Verifier::new(vk.domain_size)?;
+                verifier.prepare_pcs_info::<T>(
+                    &[vk],
+                    &[pub_input],
+                    &(*proof).clone().into(),
+                    extra_msg,
+                )
+            })
+            .collect::<Result<Vec<_>, PlonkError>>()?;
 
         if !Verifier::batch_verify_opening_proofs::<T>(
             &verify_keys[0].open_key, // all open_key are the same
@@ -491,50 +469,22 @@ where
 
         // 2. Compute VerifyingKey
         let (commit_key, open_key) = trim(&srs.0, srs_size);
-        let selector_comms;
-        let sigma_comms;
-        #[cfg(feature = "parallel")]
-        {
-            selector_comms = selectors_polys
-                .par_iter()
-                .map(|poly| {
-                    let (comm, _) = KZG10::commit(&commit_key, poly, None, None)?;
-                    Ok(comm)
-                })
-                .collect::<Result<Vec<_>, PlonkError>>()?
-                .into_iter()
-                .collect();
-            sigma_comms = sigma_polys
-                .par_iter()
-                .map(|poly| {
-                    let (comm, _) = KZG10::commit(&commit_key, poly, None, None)?;
-                    Ok(comm)
-                })
-                .collect::<Result<Vec<_>, PlonkError>>()?
-                .into_iter()
-                .collect();
-        }
-        #[cfg(not(feature = "parallel"))]
-        {
-            selector_comms = selectors_polys
-                .iter()
-                .map(|poly| {
-                    let (comm, _) = KZG10::commit(&commit_key, poly, None, None)?;
-                    Ok(comm)
-                })
-                .collect::<Result<Vec<_>, PlonkError>>()?
-                .into_iter()
-                .collect();
-            sigma_comms = sigma_polys
-                .iter()
-                .map(|poly| {
-                    let (comm, _) = KZG10::commit(&commit_key, poly, None, None)?;
-                    Ok(comm)
-                })
-                .collect::<Result<Vec<_>, PlonkError>>()?
-                .into_iter()
-                .collect();
-        }
+        let selector_comms = parallelizable_slice_iter(&selectors_polys)
+            .map(|poly| {
+                let (comm, _) = KZG10::commit(&commit_key, poly, None, None)?;
+                Ok(comm)
+            })
+            .collect::<Result<Vec<_>, PlonkError>>()?
+            .into_iter()
+            .collect();
+        let sigma_comms = parallelizable_slice_iter(&sigma_polys)
+            .map(|poly| {
+                let (comm, _) = KZG10::commit(&commit_key, poly, None, None)?;
+                Ok(comm)
+            })
+            .collect::<Result<Vec<_>, PlonkError>>()?
+            .into_iter()
+            .collect();
 
         // Compute Plookup verifying key if support lookup.
         let plookup_vk = match circuit.support_lookup() {

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -9,6 +9,8 @@
 //! The functions and structs in this file should not be used for other
 //! purposes.
 
+#![allow(missing_docs)]
+
 use crate::{
     circuit::customized::ecc::SWToTEConParam,
     errors::PlonkError,
@@ -23,6 +25,7 @@ use ark_ff::Field;
 use ark_poly::Radix2EvaluationDomain;
 use ark_poly_commit::kzg10::Commitment;
 use ark_std::vec::Vec;
+use hashbrown::HashMap;
 use jf_rescue::RescueParameter;
 
 /// A wrapper of crate::proof_system::structs::Challenges
@@ -68,7 +71,7 @@ impl<F: Field> From<Challenges<F>> for structs::Challenges<F> {
 /// A wrapper of crate::proof_system::structs::ScalarsAndBases
 #[derive(Debug, Clone)]
 pub struct ScalarsAndBases<E: PairingEngine> {
-    pub base_scalar_map: Vec<(E::G1Affine, E::Fr)>,
+    pub base_scalar_map: HashMap<E::G1Affine, E::Fr>,
 }
 
 impl<E: PairingEngine> From<structs::ScalarsAndBases<E>> for ScalarsAndBases<E> {

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -22,7 +22,7 @@ use ark_ec::{short_weierstrass_jacobian::GroupAffine, PairingEngine, SWModelPara
 use ark_ff::Field;
 use ark_poly::Radix2EvaluationDomain;
 use ark_poly_commit::kzg10::Commitment;
-use ark_std::{collections::HashMap, vec::Vec};
+use ark_std::vec::Vec;
 use jf_rescue::RescueParameter;
 
 /// A wrapper of crate::proof_system::structs::Challenges
@@ -68,7 +68,7 @@ impl<F: Field> From<Challenges<F>> for structs::Challenges<F> {
 /// A wrapper of crate::proof_system::structs::ScalarsAndBases
 #[derive(Debug, Clone)]
 pub struct ScalarsAndBases<E: PairingEngine> {
-    pub base_scalar_map: HashMap<E::G1Affine, E::Fr>,
+    pub base_scalar_map: Vec<(E::G1Affine, E::Fr)>,
 }
 
 impl<E: PairingEngine> From<structs::ScalarsAndBases<E>> for ScalarsAndBases<E> {

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -29,7 +29,7 @@ jf-utils = { path = "../utilities" }
 rayon = { version = "1.5.0", default-features = false }
 zeroize = { version = "1.3", default-features = false }
 itertools = { version = "0.10.1", default-features = false, features = [ "use_alloc" ] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 generic-array = { version = "^0.14", default-features = false }
 crypto_box = { version = "0.7.1", default-features = false, features = [ "u64_backend", "alloc" ] }
 displaydoc = { version = "0.2.3", default-features = false }
@@ -40,7 +40,6 @@ digest = { version = "0.10.1", default-features = false }
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.1.1" }
 
 [dev-dependencies]
-rand_chacha = "^0.3"
 bincode = "1.0"
 quickcheck = "1.0.0"
 criterion = "0.3.1"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -26,7 +26,7 @@ jf-rescue = { path = "../rescue" }
 jf-utils = { path = "../utilities" }
 
 # others
-rayon = { version = "1.5.0", default-features = false }
+rayon = { version = "1.5.0", optional = true }
 zeroize = { version = "1.3", default-features = false }
 itertools = { version = "0.10.1", default-features = false, features = [ "use_alloc" ] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -55,5 +55,6 @@ name = "merkle_path"
 harness = false
 
 [features]
-default = [] # no_std support
+default = [ "parallel" ]
 std = []
+parallel = [ "jf-plonk/parallel", "rayon" ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -9,16 +9,16 @@ license = "MIT"
 [dependencies]
 
 # ark
-ark-ff = { version = "0.3.0", default-features = false }
+ark-ff = "0.3.0"
 ark-std = { version = "0.3.0", default-features = false }
-ark-ec = { version = "0.3.0", default-features = false }
-ark-serialize = { version = "0.3.0", default-features = false }
+ark-ec = "0.3.0"
+ark-serialize = "0.3.0"
 
 # ark curves
-ark-bls12-381 = { version = "0.3.0", default-features = false, features = ["curve"] }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = ["curve"], rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves", default-features = false, rev = "677b4ae751a274037880ede86e9b6f30f62635af"}
-ark-ed-on-bls12-381 = { version = "0.3.0", default-features = false }
+ark-bls12-381 = "0.3.0"
+ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af"}
+ark-ed-on-bls12-381 = "0.3.0"
 
 # jellyfish
 jf-plonk = { path = "../plonk" }
@@ -46,14 +46,15 @@ quickcheck = "1.0.0"
 criterion = "0.3.1"
 
 # ark curves
-ark-ed-on-bls12-381-bandersnatch = { git = "https://github.com/arkworks-rs/curves", default-features = false, rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-ed-on-bn254 = { version = "0.3.0", default-features = false }
-ark-bn254 = { version = "0.3.0", default-features = false, features = ["curve"] }
-ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves", default-features = false, rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-ed-on-bls12-381-bandersnatch = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-ed-on-bn254 = "0.3.0"
+ark-bn254 = "0.3.0"
+ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
 
 [[bench]]
 name = "merkle_path"
 harness = false
 
 [features]
+default = [] # no_std support
 std = []

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -37,7 +37,7 @@ derivative = { version = "2", features = ["use_core"] }
 rand_chacha = { version = "0.3.1", default-features = false }
 sha2 = { version = "0.10.1", default-features = false }
 digest = { version = "0.10.1", default-features = false }
-espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.1.1" }
+espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", branch = "main" }
 
 [dev-dependencies]
 bincode = "1.0"

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -29,7 +29,7 @@ use ark_std::{
     vec::Vec,
 };
 use core::{convert::TryFrom, fmt::Debug};
-use espresso_systems_common::jellyfish as tag;
+use espresso_systems_common::jellyfish::tag;
 use jf_rescue::{Permutation, RescueParameter};
 use jf_utils::tagged_blob;
 use serde::{Deserialize, Serialize};

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -19,7 +19,7 @@ use ark_std::{
     One, UniformRand,
 };
 use core::marker::PhantomData;
-use espresso_systems_common::jellyfish as tag;
+use espresso_systems_common::jellyfish::tag;
 use jf_utils::{multi_pairing, tagged_blob};
 
 /// BLS signature scheme.

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -23,7 +23,7 @@ use ark_std::{
     string::ToString,
     vec,
 };
-use espresso_systems_common::jellyfish as tag;
+use espresso_systems_common::jellyfish::tag;
 use jf_rescue::{Permutation, RescueParameter};
 use jf_utils::{fq_to_fr, fq_to_fr_with_mask, fr_to_fq, tagged_blob};
 use zeroize::Zeroize;

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -27,9 +27,8 @@ ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751
 jf-utils = { path = "../utilities" }
 
 # others
-rayon = { version = "1.5.0", default-features = false }
 zeroize = { version = "1.3", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 generic-array = { version = "^0.14", default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 derivative = { version = "2", features = ["use_core"] }
@@ -39,7 +38,6 @@ rand_chacha = "^0.3"
 bincode = "1.0"
 quickcheck = "1.0.0"
 criterion = "0.3.1"
-
 
 [features]
 default = [] # no_std support

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -9,19 +9,19 @@ license = "MIT"
 [dependencies]
 
 # ark
-ark-ff = { version = "0.3.0", default-features = false }
+ark-ff = "0.3.0"
 ark-std = { version = "0.3.0", default-features = false }
-ark-ec = { version = "0.3.0", default-features = false }
-ark-serialize = { version = "0.3.0", default-features = false }
+ark-ec = "0.3.0"
+ark-serialize = "0.3.0"
 
 # ark cruves
-ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves", default-features = false, rev = "677b4ae751a274037880ede86e9b6f30f62635af"}
-ark-ed-on-bls12-381 = { version = "0.3.0", default-features = false }
-ark-ed-on-bn254 = { version = "0.3.0", default-features = false }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = ["curve"], rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-bls12-381 = { version = "0.3.0", default-features = false, features = ["curve"] }
-ark-bn254 = { version = "0.3.0", default-features = false, features = ["curve"] }
-ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves", default-features = false, rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af"}
+ark-ed-on-bls12-381 = "0.3.0"
+ark-ed-on-bn254 = "0.3.0"
+ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-bls12-381 = "0.3.0"
+ark-bn254 = "0.3.0"
+ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
 
 # jellyfish
 jf-utils = { path = "../utilities" }
@@ -42,4 +42,5 @@ criterion = "0.3.1"
 
 
 [features]
+default = [] # no_std support
 std = []

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -40,5 +40,5 @@ quickcheck = "1.0.0"
 criterion = "0.3.1"
 
 [features]
-default = [] # no_std support
+default = []
 std = []

--- a/rescue/src/lib.rs
+++ b/rescue/src/lib.rs
@@ -5,6 +5,7 @@
 // along with the Jellyfish library. If not, see <https://mit-license.org/>.
 
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
 //! This module implements Rescue hash function over the following fields
 //! - bls12_377 base field
 //! - ed_on_bls12_377 base field

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -x
+
+cargo-nono check --no-default-features --package jf-utils-derive
+cargo-nono check --no-default-features --package jf-utils
+cargo-nono check --no-default-features --package jf-rescue
+cargo-nono check --no-default-features --package jf-primitives
+cargo-nono check --no-default-features --package jf-plonk

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -17,6 +17,7 @@ ark-serialize = { version = "0.3.0", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
 anyhow = { version = "^1.0", default-features = false }
+displaydoc = { version = "0.2.3", default-features = false }
 
 sha2 = { version = "0.10.1", default-features = false }
 digest = { version = "0.10.1", default-features = false }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -15,7 +15,7 @@ ark-ff = { version = "0.3.0", default-features = false }
 ark-ec = { version = "0.3.0", default-features = false }
 ark-serialize = { version = "0.3.0", default-features = false }
 
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 anyhow = { version = "^1.0", default-features = false }
 displaydoc = { version = "0.2.3", default-features = false }
 

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -11,7 +11,7 @@ jf-utils-derive = { path = "../utilities_derive" }
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.0" }
 
 ark-std = { version = "0.3.0", default-features = false }
-ark-ff = { version = "0.3.0", default-features = false }
+ark-ff = { version = "0.3.0", default-features = false, features = [ "asm" ] }
 ark-ec = { version = "0.3.0", default-features = false }
 ark-serialize = { version = "0.3.0", default-features = false }
 
@@ -34,6 +34,6 @@ ark-serialize = { version = "0.3.0", features = ["derive"] }
 serde_json = "1.0"
 
 [features]
-default = [ "ark-ff/asm" ] # no_std support
+default = [ "parallel" ]
 std = [ "ark-ff/std", "ark-std/std", "ark-ec/std", "ark-serialize/std" ]
 parallel = [ "ark-ff/parallel", "ark-std/parallel", "ark-ec/parallel" ]

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -11,27 +11,28 @@ jf-utils-derive = { path = "../utilities_derive" }
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.2.0" }
 
 ark-std = { version = "0.3.0", default-features = false }
-ark-ff = { version = "0.3.0", default-features = false, features = ["asm", "parallel"] }
-ark-ec = { version = "0.3.0", default-features = false, features = ["parallel"] }
+ark-ff = { version = "0.3.0", default-features = false }
+ark-ec = { version = "0.3.0", default-features = false }
 ark-serialize = { version = "0.3.0", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
 anyhow = { version = "^1.0", default-features = false }
-snafu = { version = "0.7", features = ["backtraces"] }
 
 sha2 = { version = "0.10.1", default-features = false }
 digest = { version = "0.10.1", default-features = false }
 
 [dev-dependencies]
-ark-ed-on-bn254 = { version = "0.3.0", default-features = false }
-ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves", default-features = false, rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-ed-on-bls12-381 = { version = "0.3.0", default-features = false }
-ark-ed-on-bls12-381-bandersnatch = { git = "https://github.com/arkworks-rs/curves", default-features = false, rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-bn254 = { version = "0.3.0", default-features = false, features = ["curve"] }
+ark-ed-on-bn254 = "0.3.0"
+ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-ed-on-bls12-381 = "0.3.0"
+ark-ed-on-bls12-381-bandersnatch = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
+ark-bn254 = "0.3.0"
 ark-bls12-377 =  { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }
-ark-bls12-381 = { version = "0.3.0", default-features = false, features = ["curve"] }
-ark-serialize = { version = "0.3.0", default-features = false, features = ["derive"] }
+ark-bls12-381 = "0.3.0"
+ark-serialize = { version = "0.3.0", features = ["derive"] }
 serde_json = "1.0"
 
 [features]
-std = []
+default = [ "ark-ff/asm" ] # no_std support
+std = [ "ark-ff/std", "ark-std/std", "ark-ec/std", "ark-serialize/std" ]
+parallel = [ "ark-ff/parallel", "ark-std/parallel", "ark-ec/parallel" ]

--- a/utilities/src/serialize.rs
+++ b/utilities/src/serialize.rs
@@ -9,7 +9,6 @@
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{marker::PhantomData, string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
-use snafu::Snafu;
 use tagged_base64::{TaggedBase64, Tb64Error};
 
 /// A helper for converting CanonicalSerde bytes to standard Serde bytes.
@@ -116,10 +115,9 @@ impl<T: Tagged + CanonicalSerialize + CanonicalDeserialize> From<&T> for TaggedB
     }
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug)]
 pub enum TaggedBlobError {
     Base64Error {
-        #[snafu(source(false))]
         source: Tb64Error,
     },
     DeserializationError {

--- a/utilities/src/serialize.rs
+++ b/utilities/src/serialize.rs
@@ -8,6 +8,7 @@
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{marker::PhantomData, string::String, vec::Vec};
+use displaydoc::Display;
 use serde::{Deserialize, Serialize};
 use tagged_base64::{TaggedBase64, Tb64Error};
 
@@ -115,11 +116,11 @@ impl<T: Tagged + CanonicalSerialize + CanonicalDeserialize> From<&T> for TaggedB
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum TaggedBlobError {
-    Base64Error {
-        source: Tb64Error,
-    },
+    /// TaggedBase64 parsing failure
+    Base64Error { source: Tb64Error },
+    /// CanonicalSerialize failure
     DeserializationError {
         source: ark_serialize::SerializationError,
     },


### PR DESCRIPTION
## Description

Major changes include: 
- adjust feature flag dep of arkworks so that by default we don't use any `std` components
- remove unnecessary feature flag declaration (or `default-features = false`) on arkworks
- use `hashbrown`'s HashSet, HashMap 
- put `rayon` accelerated code to `parallel` feature flag which is on by default

closes: #84 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] ~Targeted PR against correct branch (main)~
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~
- [x] ~Updated relevant documentation in the code~
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
