### PR TITLE
Introduce BoolVar struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Refactored `UniversalSNARK` trait (#80, #87)
 - Restore `no_std` compliance (#85, #87)
 - Use [blst](https://github.com/supranational/blst) library for BLS signature/VRF (#89)
+- Introduce `struct BoolVar` whenever necessary and possible (#91)
 
 ## v0.1.2
 

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://github.com/nixos/nixpkgs/archive/db8ab32efd3a4ad59044848d889480954e458f25.tar.gz",
-  "sha256": "1i7ayivjm3rx62qq263jjj55m0nzhn4b99wax25kw6a8zhhwcwjb"
+  "url": "https://github.com/nixos/nixpkgs/archive/6f38b43c8c84c800f93465b2241156419fd4fd52.tar.gz",
+  "sha256": "0xw3y3jx1bcnwsc0imacbp5m8f51b66s9h8kk8qnfbckwv67dhgd"
 }

--- a/nix/oxalica_rust_overlay.json
+++ b/nix/oxalica_rust_overlay.json
@@ -1,7 +1,7 @@
 {
     "owner": "oxalica",
     "repo": "rust-overlay",
-    "rev": "9d7c777625640b70a4d211f62711fa316bca7176",
-    "sha256": "025bw59nl12jqf4nrvbn0a8xn03aj9bz54nvf1rb25zl2l1nkrnd",
+    "rev": "53f8467a9ef7a49c8729b28660bb83d1a75da508",
+    "sha256": "aeno3vAJm5ReC2ZCOQoZHDoNsBsqM64HgSWgqhzF6yk=",
     "fetchSubmodules": true
 }

--- a/plonk/src/circuit/basic.rs
+++ b/plonk/src/circuit/basic.rs
@@ -269,7 +269,10 @@ impl<F: FftField> PlonkCircuit<F> {
     /// You should absolutely sure about what you are doing.
     /// You should normally only use this API if you already enforce `v` to be a
     /// boolean value using other constraints.
-    pub(crate) fn create_bool_variable_unchecked(&mut self, a: F) -> Result<BoolVar, PlonkError> {
+    pub(crate) fn create_boolean_variable_unchecked(
+        &mut self,
+        a: F,
+    ) -> Result<BoolVar, PlonkError> {
         let var = self.create_variable(a)?;
         Ok(BoolVar::new_unchecked(var))
     }

--- a/plonk/src/circuit/basic.rs
+++ b/plonk/src/circuit/basic.rs
@@ -715,23 +715,6 @@ impl<F: FftField> PlonkCircuit<F> {
         Ok(())
     }
 
-    // Check whether the variable `var` is a boolean value
-    // this is used to return error to invalid parameter early in the circuit
-    // building development lifecycle, it should NOT be used as a circuit constraint
-    // for which you should use bool_gate() instead
-    #[inline]
-    pub(crate) fn check_bool(&self, var: Variable) -> Result<(), PlonkError> {
-        let val = self.witness(var)?;
-        if val != F::zero() && val != F::one() {
-            Err(ParameterError(
-                "Expecting a boolean value, something is wrong with your circuit logic".to_string(),
-            )
-            .into())
-        } else {
-            Ok(())
-        }
-    }
-
     // Return the variable that maps to a wire `(i, j)` where i is the wire type and
     // j is the gate index. If gate `j` is a padded dummy gate, return zero
     // variable.

--- a/plonk/src/circuit/basic.rs
+++ b/plonk/src/circuit/basic.rs
@@ -5,7 +5,7 @@
 // along with the Jellyfish library. If not, see <https://mit-license.org/>.
 
 //! Basic instantiations of Plonk-based constraint systems
-use super::{Arithmetization, Circuit, GateId, Variable, WireId};
+use super::{Arithmetization, BoolVar, Circuit, GateId, Variable, WireId};
 use crate::{
     circuit::{gates::*, SortedLookupVecAndPolys},
     constants::{compute_coset_representatives, GATE_WIDTH, N_MUL_SELECTORS},
@@ -263,6 +263,15 @@ impl<F: FftField> PlonkCircuit<F> {
     /// The range size of UltraPlonk range gates.
     pub fn range_size(&self) -> Result<usize, PlonkError> {
         Ok(1 << self.range_bit_len()?)
+    }
+
+    /// creating a `BoolVar` without checking if `v` is a boolean value!
+    /// You should absolutely sure about what you are doing.
+    /// You should normally only use this API if you already enforce `v` to be a
+    /// boolean value using other constraints.
+    pub(crate) fn create_bool_variable_unchecked(&mut self, a: F) -> Result<BoolVar, PlonkError> {
+        let var = self.create_variable(a)?;
+        Ok(BoolVar::new_unchecked(var))
     }
 }
 

--- a/plonk/src/circuit/customized/ecc/glv.rs
+++ b/plonk/src/circuit/customized/ecc/glv.rs
@@ -459,7 +459,7 @@ where
 
     let k1_var = circuit.create_variable(int_to_fq!(k1_int))?;
     let k2_var = circuit.create_variable(int_to_fq!(k2_int))?;
-    let k2_sign_var = circuit.create_bool_variable(is_k2_positive)?;
+    let k2_sign_var = circuit.create_boolean_variable(is_k2_positive)?;
 
     let t_var = circuit.create_variable(int_to_fq!(t_int))?;
 

--- a/plonk/src/circuit/customized/ecc/glv.rs
+++ b/plonk/src/circuit/customized/ecc/glv.rs
@@ -514,7 +514,8 @@ where
     };
 
     //  (f.3) either f.1 or f.2 is satisfied
-    let sat = circuit.conditional_select(k2_sign_var, k2_is_neg_sat, k2_is_pos_sat)?;
+    let sat =
+        circuit.conditional_select(k2_sign_var, k2_is_neg_sat.into(), k2_is_pos_sat.into())?;
     circuit.enforce_true(sat)?;
 
     //  (g) tmp2 + lambda_2 * k2_sign * k2 + s2  = t * t_sign * r2
@@ -544,7 +545,8 @@ where
     };
 
     //  (g.3) either g.1 or g.2 is satisfied
-    let sat = circuit.conditional_select(k2_sign_var, k2_is_neg_sat, k2_is_pos_sat)?;
+    let sat =
+        circuit.conditional_select(k2_sign_var, k2_is_neg_sat.into(), k2_is_pos_sat.into())?;
     circuit.enforce_true(sat)?;
 
     // extract the output

--- a/plonk/src/circuit/customized/ecc/mod.rs
+++ b/plonk/src/circuit/customized/ecc/mod.rs
@@ -9,7 +9,7 @@
 
 use super::gates::*;
 use crate::{
-    circuit::{gates::Gate, Circuit, PlonkCircuit, Variable},
+    circuit::{gates::Gate, BoolVar, Circuit, PlonkCircuit, Variable},
     errors::{CircuitError, PlonkError},
 };
 use ark_ec::{
@@ -180,19 +180,20 @@ where
     /// variables, that would ultimately failed to build a correct circuit.
     fn quaternary_point_select<P: Parameters<BaseField = F> + Clone>(
         &mut self,
-        b0: Variable,
-        b1: Variable,
+        b0: BoolVar,
+        b1: BoolVar,
         point1: &Point<F>,
         point2: &Point<F>,
         point3: &Point<F>,
     ) -> Result<PointVariable, PlonkError> {
-        self.check_var_bound(b0)?;
-        self.check_var_bound(b1)?;
-        self.check_bool(b0)?;
-        self.check_bool(b1)?;
+        self.check_var_bound(b0.into())?;
+        self.check_var_bound(b1.into())?;
 
         let selected_point = {
-            let selected = match (self.witness(b0)? == F::one(), self.witness(b1)? == F::one()) {
+            let selected = match (
+                self.witness(b0.into())? == F::one(),
+                self.witness(b1.into())? == F::one(),
+            ) {
                 (false, false) => Point::from(GroupAffine::<P>::zero()),
                 (true, false) => point1.to_owned(),
                 (false, true) => point2.to_owned(),
@@ -201,7 +202,7 @@ where
             // create new point with the same (x, y) coordinates
             self.create_point_variable(selected)?
         };
-        let wire_vars_x = [b0, b1, 0, 0, selected_point.0];
+        let wire_vars_x = [b0.into(), b1.into(), 0, 0, selected_point.0];
         self.insert_gate(
             &wire_vars_x,
             Box::new(QuaternaryPointSelectXGate {
@@ -210,7 +211,7 @@ where
                 x3: point3.0,
             }),
         )?;
-        let wire_vars_y = [b0, b1, 0, 0, selected_point.1];
+        let wire_vars_y = [b0.into(), b1.into(), 0, 0, selected_point.1];
         self.insert_gate(
             &wire_vars_y,
             Box::new(QuaternaryPointSelectYGate {
@@ -229,14 +230,13 @@ where
     /// Return error if invalid input parameters are provided.
     fn binary_point_vars_select(
         &mut self,
-        b: Variable,
+        b: BoolVar,
         point0: &PointVariable,
         point1: &PointVariable,
     ) -> Result<PointVariable, PlonkError> {
-        self.check_var_bound(b)?;
+        self.check_var_bound(b.into())?;
         self.check_point_var_bound(point0)?;
         self.check_point_var_bound(point1)?;
-        self.check_bool(b)?;
 
         let selected_x = self.conditional_select(b, point0.0, point1.0)?;
         let selected_y = self.conditional_select(b, point0.1, point1.1)?;
@@ -497,12 +497,11 @@ where
     /// Currently only supports GroupAffine::<P>.
     pub fn variable_base_binary_scalar_mul<P: Parameters<BaseField = F> + Clone>(
         &mut self,
-        scalar_bits_le: &[Variable],
+        scalar_bits_le: &[BoolVar],
         base: &PointVariable,
     ) -> Result<PointVariable, PlonkError> {
         for &bit in scalar_bits_le {
-            self.check_var_bound(bit)?;
-            self.check_bool(bit)?;
+            self.check_var_bound(bit.into())?;
         }
         self.check_point_var_bound(base)?;
 
@@ -852,10 +851,12 @@ mod test {
         let p3 = GroupAffine::<P>::rand(&mut rng);
 
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
+        let false_var = circuit.create_bool_variable(false)?;
+        let true_var = circuit.create_bool_variable(true)?;
 
         let select_p0 = circuit.quaternary_point_select::<P>(
-            circuit.zero(),
-            circuit.zero(),
+            false_var,
+            false_var,
             &Point::from(p1),
             &Point::from(p2),
             &Point::from(p3),
@@ -865,24 +866,24 @@ mod test {
             Point(circuit.witness(select_p0.0)?, circuit.witness(select_p0.1)?)
         );
         let select_p1 = circuit.quaternary_point_select::<P>(
-            circuit.one(),
-            circuit.zero(),
+            true_var,
+            false_var,
             &Point::from(p1),
             &Point::from(p2),
             &Point::from(p3),
         )?;
         assert_eq!(Point::from(p1), circuit.point_witness(&select_p1)?);
         let select_p2 = circuit.quaternary_point_select::<P>(
-            circuit.zero(),
-            circuit.one(),
+            false_var,
+            true_var,
             &Point::from(p1),
             &Point::from(p2),
             &Point::from(p3),
         )?;
         assert_eq!(Point::from(p2), circuit.point_witness(&select_p2)?);
         let select_p3 = circuit.quaternary_point_select::<P>(
-            circuit.one(),
-            circuit.one(),
+            true_var,
+            true_var,
             &Point::from(p1),
             &Point::from(p2),
             &Point::from(p3),
@@ -891,55 +892,24 @@ mod test {
 
         assert!(circuit.check_circuit_satisfiability(&[]).is_ok());
 
-        // non binary b0, b1 should fail
-        let two = circuit.create_variable(F::from(2u32))?;
-        assert!(circuit
-            .quaternary_point_select::<P>(
-                two,
-                1,
-                &Point::from(p1),
-                &Point::from(p2),
-                &Point::from(p3)
-            )
-            .is_err());
-        assert!(circuit
-            .quaternary_point_select::<P>(
-                0,
-                two,
-                &Point::from(p1),
-                &Point::from(p2),
-                &Point::from(p3)
-            )
-            .is_err());
-
         *circuit.witness_mut(select_p3.0) = p2.x;
         *circuit.witness_mut(select_p3.1) = p2.y;
         assert!(circuit.check_circuit_satisfiability(&[]).is_err());
-        // Check variable out of bound error.
-        assert!(circuit
-            .quaternary_point_select::<P>(
-                0,
-                circuit.num_vars(),
-                &Point::from(p1),
-                &Point::from(p2),
-                &Point::from(p3)
-            )
-            .is_err());
 
-        let circuit_1 = build_quaternary_select_gate::<F, P>(F::zero(), F::zero())?;
-        let circuit_2 = build_quaternary_select_gate::<F, P>(F::one(), F::one())?;
+        let circuit_1 = build_quaternary_select_gate::<F, P>(false, false)?;
+        let circuit_2 = build_quaternary_select_gate::<F, P>(true, true)?;
         customized::test::test_variable_independence_for_circuit(circuit_1, circuit_2)?;
         Ok(())
     }
 
-    fn build_quaternary_select_gate<F, P>(b0: F, b1: F) -> Result<PlonkCircuit<F>, PlonkError>
+    fn build_quaternary_select_gate<F, P>(b0: bool, b1: bool) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: PrimeField,
         P: Parameters<BaseField = F> + Clone,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let b0_var = circuit.create_variable(b0)?;
-        let b1_var = circuit.create_variable(b1)?;
+        let b0_var = circuit.create_bool_variable(b0)?;
+        let b1_var = circuit.create_bool_variable(b1)?;
 
         let mut rng = ark_std::test_rng();
         let p1 = GroupAffine::<P>::rand(&mut rng);
@@ -1198,43 +1168,30 @@ mod test {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let p0_var = circuit.create_point_variable(Point::from(p0))?;
         let p1_var = circuit.create_point_variable(Point::from(p1))?;
-        let select_p0 = circuit.binary_point_vars_select(circuit.zero(), &p0_var, &p1_var)?;
+        let true_var = circuit.create_bool_variable(true)?;
+        let false_var = circuit.create_bool_variable(false)?;
+
+        let select_p0 = circuit.binary_point_vars_select(false_var, &p0_var, &p1_var)?;
         assert_eq!(circuit.point_witness(&select_p0)?, Point::from(p0));
-        let select_p1 = circuit.binary_point_vars_select(circuit.one(), &p0_var, &p1_var)?;
+        let select_p1 = circuit.binary_point_vars_select(true_var, &p0_var, &p1_var)?;
         assert_eq!(circuit.point_witness(&select_p1)?, Point::from(p1));
         assert!(circuit.check_circuit_satisfiability(&[]).is_ok());
 
-        // non boolean selection variable should fail
-        let two = circuit.create_variable(F::from(2u32))?;
-        assert!(circuit
-            .binary_point_vars_select(two, &p0_var, &p1_var)
-            .is_err());
         // wrong witness should fail
         *circuit.witness_mut(p1_var.0) = F::rand(&mut rng);
         assert!(circuit.check_circuit_satisfiability(&[]).is_err());
-        // Check variable out of bound error.
         assert!(circuit
             .binary_point_vars_select(
-                circuit.zero(),
-                &PointVariable(circuit.num_vars(), p0_var.1),
-                &p1_var
-            )
-            .is_err());
-        assert!(circuit
-            .binary_point_vars_select(
-                circuit.zero(),
+                false_var,
                 &p0_var,
                 &PointVariable(p1_var.0, circuit.num_vars()),
             )
             .is_err());
 
-        let circuit_1 = build_binary_point_vars_select_circuit::<F, P>(
-            F::one(),
-            Point::from(p0),
-            Point::from(p1),
-        )?;
+        let circuit_1 =
+            build_binary_point_vars_select_circuit::<F, P>(true, Point::from(p0), Point::from(p1))?;
         let circuit_2 = build_binary_point_vars_select_circuit::<F, P>(
-            F::zero(),
+            false,
             Point::from(p1),
             Point::from(p2),
         )?;
@@ -1244,7 +1201,7 @@ mod test {
     }
 
     fn build_binary_point_vars_select_circuit<F, P>(
-        b: F,
+        b: bool,
         p0: Point<F>,
         p1: Point<F>,
     ) -> Result<PlonkCircuit<F>, PlonkError>
@@ -1253,7 +1210,7 @@ mod test {
         P: Parameters<BaseField = F> + Clone,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let b_var = circuit.create_variable(b)?;
+        let b_var = circuit.create_bool_variable(b)?;
         let p0_var = circuit.create_point_variable(p0)?;
         let p1_var = circuit.create_point_variable(p1)?;
         circuit.binary_point_vars_select(b_var, &p0_var, &p1_var)?;
@@ -1313,45 +1270,6 @@ mod test {
             Point::from(GroupAffine::<P>::rand(&mut rng)),
         )?;
         customized::test::test_variable_independence_for_circuit(circuit_1, circuit_2)?;
-
-        Ok(())
-    }
-
-    // Given `test_variable_base_scalar_mul`, we don't need to further test
-    // `variable_base_binary_scalar_mul`'s good paths.
-    #[test]
-    fn test_variable_base_binary_scalar_mul_errors() -> Result<(), PlonkError> {
-        test_variable_base_binary_scalar_mul_errors_helper::<FqEd354, Param254>()?;
-        test_variable_base_binary_scalar_mul_errors_helper::<FqEd377, Param377>()?;
-        test_variable_base_binary_scalar_mul_errors_helper::<FqEd381, Param381>()?;
-        test_variable_base_binary_scalar_mul_errors_helper::<FqEd381b, Param381b>()?;
-        test_variable_base_binary_scalar_mul_errors_helper::<Fq377, Param761>()
-    }
-    fn test_variable_base_binary_scalar_mul_errors_helper<F, P>() -> Result<(), PlonkError>
-    where
-        F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
-    {
-        let mut rng = ark_std::test_rng();
-        let mut circuit = PlonkCircuit::<F>::new_turbo_plonk();
-        let non_bit_var = circuit.create_variable(F::from(2u8))?;
-        let base = GroupAffine::<P>::rand(&mut rng);
-        let base_var = circuit.create_point_variable(Point::from(base))?;
-        // Binary scalar variables out of bound
-        assert!(circuit
-            .variable_base_binary_scalar_mul::<P>(&[circuit.one(), circuit.num_vars()], &base_var)
-            .is_err());
-        // Base point out of bound
-        assert!(circuit
-            .variable_base_binary_scalar_mul::<P>(
-                &[circuit.zero(), circuit.one()],
-                &PointVariable(circuit.num_vars(), circuit.num_vars())
-            )
-            .is_err());
-        // Non-binary scalar variables
-        assert!(circuit
-            .variable_base_binary_scalar_mul::<P>(&[circuit.one(), non_bit_var], &base_var)
-            .is_err());
 
         Ok(())
     }

--- a/plonk/src/circuit/customized/ecc/mod.rs
+++ b/plonk/src/circuit/customized/ecc/mod.rs
@@ -268,13 +268,7 @@ where
         self.check_point_var_bound(point1)?;
         let x_eq = self.check_equal(point0.0, point1.0)?;
         let y_eq = self.check_equal(point0.1, point1.1)?;
-
-        let res = self.create_bool_variable_unchecked(
-            self.witness(x_eq.into())? * self.witness(y_eq.into())?,
-        )?;
-        self.mul_gate(x_eq.into(), y_eq.into(), res.into())?;
-
-        Ok(res)
+        self.logic_and(x_eq, y_eq)
     }
 }
 
@@ -330,9 +324,9 @@ where
 
         let b = {
             if self.point_witness(point_var)? == Point::from(GroupAffine::<P>::zero()) {
-                self.create_bool_variable(true)?
+                self.create_boolean_variable(true)?
             } else {
-                self.create_bool_variable(false)?
+                self.create_boolean_variable(false)?
             }
         };
 
@@ -914,8 +908,8 @@ mod test {
         P: Parameters<BaseField = F> + Clone,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let b0_var = circuit.create_bool_variable(b0)?;
-        let b1_var = circuit.create_bool_variable(b1)?;
+        let b0_var = circuit.create_boolean_variable(b0)?;
+        let b1_var = circuit.create_boolean_variable(b1)?;
 
         let mut rng = ark_std::test_rng();
         let p1 = GroupAffine::<P>::rand(&mut rng);
@@ -1216,7 +1210,7 @@ mod test {
         P: Parameters<BaseField = F> + Clone,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let b_var = circuit.create_bool_variable(b)?;
+        let b_var = circuit.create_boolean_variable(b)?;
         let p0_var = circuit.create_point_variable(p0)?;
         let p1_var = circuit.create_point_variable(p1)?;
         circuit.binary_point_vars_select(b_var, &p0_var, &p1_var)?;

--- a/plonk/src/circuit/customized/ecc/mod.rs
+++ b/plonk/src/circuit/customized/ecc/mod.rs
@@ -857,8 +857,8 @@ mod test {
         let p3 = GroupAffine::<P>::rand(&mut rng);
 
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let false_var = circuit.create_bool_variable(false)?;
-        let true_var = circuit.create_bool_variable(true)?;
+        let false_var = circuit.false_var();
+        let true_var = circuit.true_var();
 
         let select_p0 = circuit.quaternary_point_select::<P>(
             false_var,
@@ -1174,8 +1174,8 @@ mod test {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let p0_var = circuit.create_point_variable(Point::from(p0))?;
         let p1_var = circuit.create_point_variable(Point::from(p1))?;
-        let true_var = circuit.create_bool_variable(true)?;
-        let false_var = circuit.create_bool_variable(false)?;
+        let true_var = circuit.true_var();
+        let false_var = circuit.false_var();
 
         let select_p0 = circuit.binary_point_vars_select(false_var, &p0_var, &p1_var)?;
         assert_eq!(circuit.point_witness(&select_p0)?, Point::from(p0));

--- a/plonk/src/circuit/customized/ecc/msm.rs
+++ b/plonk/src/circuit/customized/ecc/msm.rs
@@ -335,7 +335,7 @@ where
 
     // create circuit
     let range_size = F::from((1 << c) as u32);
-    circuit.decompose_vars_gate(decomposed_scalar_vars.clone(), scalar_var, range_size)?;
+    circuit.decomposition_gate(decomposed_scalar_vars.clone(), scalar_var, range_size)?;
 
     Ok(decomposed_scalar_vars)
 }

--- a/plonk/src/circuit/customized/mod.rs
+++ b/plonk/src/circuit/customized/mod.rs
@@ -834,8 +834,8 @@ pub(crate) mod test {
 
     fn test_logic_or_helper<F: PrimeField>() -> Result<(), PlonkError> {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let false_var = circuit.create_bool_variable(false)?;
-        let true_var = circuit.create_bool_variable(true)?;
+        let false_var = circuit.false_var();
+        let true_var = circuit.true_var();
         // Good path
         circuit.logic_or_gate(false_var, true_var)?;
         circuit.logic_or_gate(true_var, false_var)?;
@@ -1204,8 +1204,9 @@ pub(crate) mod test {
 
     fn test_conditional_select_helper<F: PrimeField>() -> Result<(), PlonkError> {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let bit_true = circuit.create_bool_variable(true)?;
-        let bit_false = circuit.create_bool_variable(false)?;
+        let bit_true = circuit.true_var();
+        let bit_false = circuit.false_var();
+
         let x_0 = circuit.create_variable(F::from(23u32))?;
         let x_1 = circuit.create_variable(F::from(24u32))?;
         let select_true = circuit.conditional_select(bit_true, x_0, x_1)?;

--- a/plonk/src/circuit/customized/mod.rs
+++ b/plonk/src/circuit/customized/mod.rs
@@ -348,7 +348,7 @@ where
                 })?,
             )
         };
-        let y = self.create_bool_variable_unchecked(y)?;
+        let y = self.create_boolean_variable_unchecked(y)?;
         let a_inv = self.create_variable(a_inv)?;
 
         // constraint 1: 1 - a * a^(-1) = y, i.e., a * a^(-1) + 1 * y = 1
@@ -381,8 +381,8 @@ where
     /// the index of the variable. Return error if the input variables are
     /// invalid.
     pub fn logic_and(&mut self, a: BoolVar, b: BoolVar) -> Result<BoolVar, PlonkError> {
-        let c =
-            self.create_bool_variable_unchecked(self.witness(a.into())? * self.witness(b.into())?)?;
+        let c = self
+            .create_boolean_variable_unchecked(self.witness(a.into())? * self.witness(b.into())?)?;
         self.mul_gate(a.into(), b.into(), c.into())?;
         Ok(c)
     }
@@ -414,7 +414,7 @@ where
         let b_val = self.witness(b.into())?;
         let c_val = a_val + b_val - a_val * b_val;
 
-        let c = self.create_bool_variable_unchecked(c_val)?;
+        let c = self.create_boolean_variable_unchecked(c_val)?;
         let wire_vars = &[a.into(), b.into(), 0, 0, c.into()];
         self.insert_gate(wire_vars, Box::new(LogicOrValueGate))?;
 
@@ -709,7 +709,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
             .iter()
             .take(bit_len) // since little-endian, truncate would remove MSBs
             .map(|&b| {
-                self.create_bool_variable(b)
+                self.create_boolean_variable(b)
             })
             .collect::<Result<Vec<_>, PlonkError>>()?;
 
@@ -857,8 +857,8 @@ pub(crate) mod test {
         b: bool,
     ) -> Result<PlonkCircuit<F>, PlonkError> {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let a = circuit.create_bool_variable(a)?;
-        let b = circuit.create_bool_variable(b)?;
+        let a = circuit.create_boolean_variable(a)?;
+        let b = circuit.create_boolean_variable(b)?;
         circuit.logic_or_gate(a, b)?;
         circuit.finalize_for_arithmetization()?;
         Ok(circuit)
@@ -906,8 +906,8 @@ pub(crate) mod test {
         b: bool,
     ) -> Result<PlonkCircuit<F>, PlonkError> {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let a = circuit.create_bool_variable(a)?;
-        let b = circuit.create_bool_variable(b)?;
+        let a = circuit.create_boolean_variable(a)?;
+        let b = circuit.create_boolean_variable(b)?;
         circuit.logic_and(a, b)?;
         circuit.finalize_for_arithmetization()?;
         Ok(circuit)
@@ -1239,7 +1239,7 @@ pub(crate) mod test {
         x_1: F,
     ) -> Result<PlonkCircuit<F>, PlonkError> {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
-        let bit_var = circuit.create_bool_variable(bit)?;
+        let bit_var = circuit.create_boolean_variable(bit)?;
         let x_0_var = circuit.create_variable(x_0)?;
         let x_1_var = circuit.create_variable(x_1)?;
         circuit.conditional_select(bit_var, x_0_var, x_1_var)?;
@@ -1452,7 +1452,7 @@ pub(crate) mod test {
         circuit.lc(&wire_in.try_into().unwrap(), &coeffs)?;
 
         // conditional select gate
-        let bit_true = circuit.create_bool_variable(true)?;
+        let bit_true = circuit.create_boolean_variable(true)?;
         let x_0 = circuit.create_variable(F::from(23u32))?;
         let x_1 = circuit.create_variable(F::from(24u32))?;
         circuit.conditional_select(bit_true, x_0, x_1)?;

--- a/plonk/src/circuit/customized/ultraplonk/range.rs
+++ b/plonk/src/circuit/customized/ultraplonk/range.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
         }
 
         // add linear combination gates
-        self.decompose_vars_gate(reprs_le_vars, a, F::from(range_size as u64))?;
+        self.decomposition_gate(reprs_le_vars, a, F::from(range_size as u64))?;
 
         Ok(())
     }

--- a/plonk/src/circuit/mod.rs
+++ b/plonk/src/circuit/mod.rs
@@ -32,7 +32,7 @@ impl BoolVar {
     /// Create a `BoolVar` without any check. Be careful!
     /// This is an internal API, shouldn't be used unless you know what you are
     /// doing. Normally you should only construct `BoolVar` through
-    /// `Circuit::create_bool_variable()`.
+    /// `Circuit::create_boolean_variable()`.
     pub(crate) fn new_unchecked(inner: usize) -> Self {
         Self(inner)
     }
@@ -76,7 +76,7 @@ pub trait Circuit<F: Field> {
     fn create_variable(&mut self, val: F) -> Result<Variable, PlonkError>;
 
     /// Add a bool variable to the circuit; return the index of the variable.
-    fn create_bool_variable(&mut self, val: bool) -> Result<BoolVar, PlonkError> {
+    fn create_boolean_variable(&mut self, val: bool) -> Result<BoolVar, PlonkError> {
         let val_scalar = if val { F::one() } else { F::zero() };
         let var = self.create_variable(val_scalar)?;
         self.bool_gate(var)?;

--- a/plonk/src/circuit/mod.rs
+++ b/plonk/src/circuit/mod.rs
@@ -18,6 +18,16 @@ pub use basic::PlonkCircuit;
 
 /// An index to one of the witness values.
 pub type Variable = usize;
+/// An index to a witness value of boolean type.
+#[derive(Debug, Clone, Copy)]
+pub struct BoolVar(usize);
+
+impl From<BoolVar> for Variable {
+    fn from(bv: BoolVar) -> Self {
+        bv.0
+    }
+}
+
 /// An index to a gate in circuit.
 pub type GateId = usize;
 /// An index to the type of gate wires.
@@ -56,11 +66,12 @@ pub trait Circuit<F: Field> {
     fn create_variable(&mut self, val: F) -> Result<Variable, PlonkError>;
 
     /// Add a bool variable to the circuit; return the index of the variable.
-    fn create_bool_variable(&mut self, val: bool) -> Result<Variable, PlonkError> {
+    fn create_bool_variable(&mut self, val: bool) -> Result<BoolVar, PlonkError> {
         let val_scalar = if val { F::one() } else { F::zero() };
         let var = self.create_variable(val_scalar)?;
+        // FIXME: (alex) should I enforce this in `BoolVar::create()` instead?
         self.bool_gate(var)?;
-        Ok(var)
+        Ok(BoolVar(var))
     }
 
     /// Add a public input variable; return the index of the variable.

--- a/plonk/src/circuit/mod.rs
+++ b/plonk/src/circuit/mod.rs
@@ -28,6 +28,16 @@ impl From<BoolVar> for Variable {
     }
 }
 
+impl BoolVar {
+    /// Create a `BoolVar` without any check. Be careful!
+    /// This is an internal API, shouldn't be used unless you know what you are
+    /// doing. Normally you should only construct `BoolVar` through
+    /// `Circuit::create_bool_variable()`.
+    pub(crate) fn new_unchecked(inner: usize) -> Self {
+        Self(inner)
+    }
+}
+
 /// An index to a gate in circuit.
 pub type GateId = usize;
 /// An index to the type of gate wires.
@@ -69,7 +79,6 @@ pub trait Circuit<F: Field> {
     fn create_bool_variable(&mut self, val: bool) -> Result<BoolVar, PlonkError> {
         let val_scalar = if val { F::one() } else { F::zero() };
         let var = self.create_variable(val_scalar)?;
-        // FIXME: (alex) should I enforce this in `BoolVar::create()` instead?
         self.bool_gate(var)?;
         Ok(BoolVar(var))
     }
@@ -85,6 +94,16 @@ pub trait Circuit<F: Field> {
 
     /// Return a default variable with value one.
     fn one(&self) -> Variable;
+
+    /// Return a default variable with value `false` (namely zero).
+    fn false_var(&self) -> BoolVar {
+        BoolVar::new_unchecked(self.zero())
+    }
+
+    /// Return a default variable with value `true` (namely one).
+    fn true_var(&self) -> BoolVar {
+        BoolVar::new_unchecked(self.one())
+    }
 
     /// Return the witness value of variable `idx`.
     /// Return error if the input variable is invalid.

--- a/primitives/src/circuit/merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree.rs
@@ -248,8 +248,8 @@ where
                 Ok(MerkleNodeVars {
                     sibling1: self.create_variable(node.sibling1.0)?,
                     sibling2: self.create_variable(node.sibling2.0)?,
-                    is_left_child: self.create_bool_variable(node.is_left_child)?,
-                    is_right_child: self.create_bool_variable(node.is_right_child)?,
+                    is_left_child: self.create_boolean_variable(node.is_left_child)?,
+                    is_right_child: self.create_boolean_variable(node.is_right_child)?,
                 })
             })
             .collect::<Result<Vec<MerkleNodeVars>, PlonkError>>()?;
@@ -355,8 +355,8 @@ mod test {
     ) {
         let zero = F::zero();
 
-        let node_is_left = circuit.create_bool_variable(is_left).unwrap();
-        let node_is_right = circuit.create_bool_variable(is_right).unwrap();
+        let node_is_left = circuit.create_boolean_variable(is_left).unwrap();
+        let node_is_right = circuit.create_boolean_variable(is_right).unwrap();
 
         let node = input_vars[0];
         let sib1 = input_vars[1];

--- a/primitives/src/circuit/merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree.rs
@@ -13,7 +13,7 @@ use ark_ec::TEModelParameters as Parameters;
 use ark_ff::PrimeField;
 use ark_std::{vec, vec::Vec};
 use jf_plonk::{
-    circuit::{customized::rescue::RescueGadget, Circuit, PlonkCircuit, Variable},
+    circuit::{customized::rescue::RescueGadget, BoolVar, Circuit, PlonkCircuit, Variable},
     errors::PlonkError,
 };
 use jf_rescue::RescueParameter;
@@ -22,16 +22,16 @@ use jf_rescue::RescueParameter;
 struct MerkleNodeBooleanEncoding<F: PrimeField> {
     sibling1: NodeValue<F>,
     sibling2: NodeValue<F>,
-    is_left_child: u8,
-    is_right_child: u8,
+    is_left_child: bool,
+    is_right_child: bool,
 }
 
 impl<F: PrimeField> MerkleNodeBooleanEncoding<F> {
     fn new(
         sibling1: NodeValue<F>,
         sibling2: NodeValue<F>,
-        is_left_child: u8,
-        is_right_child: u8,
+        is_left_child: bool,
+        is_right_child: bool,
     ) -> Self {
         MerkleNodeBooleanEncoding {
             sibling1,
@@ -60,13 +60,13 @@ impl<F: PrimeField> From<&MerklePath<F>> for MerklePathBooleanEncoding<F> {
         for node in path.nodes.iter() {
             let circuit_node = match node.pos {
                 NodePos::Left => {
-                    MerkleNodeBooleanEncoding::new(node.sibling1, node.sibling2, 1_u8, 0_u8)
+                    MerkleNodeBooleanEncoding::new(node.sibling1, node.sibling2, true, false)
                 },
                 NodePos::Middle => {
-                    MerkleNodeBooleanEncoding::new(node.sibling1, node.sibling2, 0_u8, 0_u8)
+                    MerkleNodeBooleanEncoding::new(node.sibling1, node.sibling2, false, false)
                 },
                 NodePos::Right => {
-                    MerkleNodeBooleanEncoding::new(node.sibling1, node.sibling2, 0_u8, 1_u8)
+                    MerkleNodeBooleanEncoding::new(node.sibling1, node.sibling2, false, true)
                 },
             };
             nodes.push(circuit_node);
@@ -81,8 +81,8 @@ impl<F: PrimeField> From<&MerklePath<F>> for MerklePathBooleanEncoding<F> {
 pub struct MerkleNodeVars {
     pub sibling1: Variable,
     pub sibling2: Variable,
-    pub is_left_child: Variable,
-    pub is_right_child: Variable,
+    pub is_left_child: BoolVar,
+    pub is_right_child: BoolVar,
 }
 
 #[derive(Debug)]
@@ -134,8 +134,8 @@ trait MerkleTreeHelperGadget<F: PrimeField> {
         node: Variable,
         sib1: Variable,
         sib2: Variable,
-        node_is_left: Variable,
-        node_is_right: Variable,
+        node_is_left: BoolVar,
+        node_is_right: BoolVar,
     ) -> Result<[Variable; 3], PlonkError>;
 
     /// Ensure that the position of each node of the path is correctly encoded
@@ -221,8 +221,8 @@ where
         node: Variable,
         sib1: Variable,
         sib2: Variable,
-        node_is_left: Variable,
-        node_is_right: Variable,
+        node_is_left: BoolVar,
+        node_is_right: BoolVar,
     ) -> Result<[Variable; 3], PlonkError> {
         let one = F::one();
         let left_node = self.conditional_select(node_is_left, sib1, node)?;
@@ -248,8 +248,8 @@ where
                 Ok(MerkleNodeVars {
                     sibling1: self.create_variable(node.sibling1.0)?,
                     sibling2: self.create_variable(node.sibling2.0)?,
-                    is_left_child: self.create_variable(F::from(node.is_left_child as u32))?,
-                    is_right_child: self.create_variable(F::from(node.is_right_child as u32))?,
+                    is_left_child: self.create_bool_variable(node.is_left_child)?,
+                    is_right_child: self.create_bool_variable(node.is_right_child)?,
                 })
             })
             .collect::<Result<Vec<MerkleNodeVars>, PlonkError>>()?;
@@ -257,11 +257,10 @@ where
         // `is_left_child`, `is_right_child` and `is_left_child+is_right_child` are
         // boolean
         for node in nodes.iter() {
-            self.bool_gate(node.is_left_child)?;
-            self.bool_gate(node.is_right_child)?;
             // Boolean constrain `is_left_child + is_right_child` because a node
             // can either be the left or the right child of its parent
-            let left_plus_right = self.add(node.is_left_child, node.is_right_child)?;
+            let left_plus_right =
+                self.add(node.is_left_child.into(), node.is_right_child.into())?;
             self.bool_gate(left_plus_right)?;
         }
 
@@ -307,7 +306,7 @@ mod test {
     use jf_plonk::circuit::{Circuit, PlonkCircuit, Variable};
     use jf_rescue::RescueParameter;
 
-    fn check_merkle_path<F: PrimeField>(is_left_child: u8, is_right_child: u8, accept: bool) {
+    fn check_merkle_path<F: PrimeField>(is_left_child: bool, is_right_child: bool, accept: bool) {
         let mut circuit = PlonkCircuit::<F>::new_turbo_plonk();
         let zero = F::zero();
         let one = F::one();
@@ -338,18 +337,13 @@ mod test {
         // Happy path:
         // `is_left_child`,`is_right_child` and `is_left_child + is_right_child` are
         // boolean
-        check_merkle_path::<F>(1, 0, true);
-        check_merkle_path::<F>(0, 1, true);
-        check_merkle_path::<F>(0, 0, true);
-
-        // Circuit cannot be satisfied when `is_left_child` (or `is_right_child`) is not
-        // boolean
-        check_merkle_path::<F>(2, 0, false);
-        check_merkle_path::<F>(0, 2, false);
+        check_merkle_path::<F>(true, false, true);
+        check_merkle_path::<F>(false, true, true);
+        check_merkle_path::<F>(false, false, true);
 
         // Circuit cannot be satisfied when `is_left_child + is_right_child` is not
         // boolean
-        check_merkle_path::<F>(1, 1, false);
+        check_merkle_path::<F>(true, true, false);
     }
 
     fn check_permute<F: PrimeField>(
@@ -360,17 +354,9 @@ mod test {
         expected_output_vars: &[Variable],
     ) {
         let zero = F::zero();
-        let one = F::one();
 
-        let node_is_left = match is_left {
-            false => circuit.create_variable(zero).unwrap(),
-            true => circuit.create_variable(one).unwrap(),
-        };
-
-        let node_is_right = match is_right {
-            false => circuit.create_variable(zero).unwrap(),
-            true => circuit.create_variable(one).unwrap(),
-        };
+        let node_is_left = circuit.create_bool_variable(is_left).unwrap();
+        let node_is_right = circuit.create_bool_variable(is_right).unwrap();
 
         let node = input_vars[0];
         let sib1 = input_vars[1];

--- a/primitives/src/circuit/signature/schnorr.rs
+++ b/primitives/src/circuit/signature/schnorr.rs
@@ -20,7 +20,7 @@ use jf_plonk::{
             ecc::{Point, PointVariable},
             rescue::RescueGadget,
         },
-        Circuit, PlonkCircuit, Variable,
+        BoolVar, Circuit, PlonkCircuit, Variable,
     },
     errors::PlonkError,
 };
@@ -159,7 +159,7 @@ where
         vk: &VerKeyVar,
         sig_point: &PointVariable,
         msg: &[Variable],
-    ) -> Result<Vec<Variable>, PlonkError>;
+    ) -> Result<Vec<BoolVar>, PlonkError>;
 }
 
 impl<F, P> SignatureHelperGadget<F, P> for PlonkCircuit<F>
@@ -172,7 +172,7 @@ where
         vk: &VerKeyVar,
         sig_point: &PointVariable,
         msg: &[Variable],
-    ) -> Result<Vec<Variable>, PlonkError> {
+    ) -> Result<Vec<BoolVar>, PlonkError> {
         let instance_description = F::from_be_bytes_mod_order(CS_ID_SCHNORR.as_ref());
         // TODO: create `inst_desc_var` and the constant gate *only once* during the
         // entire circuit construction.

--- a/primitives/src/circuit/signature/schnorr.rs
+++ b/primitives/src/circuit/signature/schnorr.rs
@@ -70,7 +70,7 @@ where
         vk: &VerKeyVar,
         msg: &[Variable],
         sig: &SignatureVar,
-    ) -> Result<Variable, PlonkError>;
+    ) -> Result<BoolVar, PlonkError>;
 
     /// Create a signature variable from a signature `sig`.
     fn create_signature_variable(&mut self, sig: &Signature<P>)
@@ -111,7 +111,7 @@ where
         vk: &VerKeyVar,
         msg: &[Variable],
         sig: &SignatureVar,
-    ) -> Result<Variable, PlonkError> {
+    ) -> Result<BoolVar, PlonkError> {
         let (p1, p2) = <Self as SignatureGadget<F, P>>::verify_sig_core(self, vk, msg, sig)?;
         self.check_equal_point(&p1, &p2)
     }
@@ -316,6 +316,6 @@ mod tests {
             &msg_var,
             &sig_var,
         )?;
-        Ok((circuit, bit))
+        Ok((circuit, bit.into()))
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,22 +1,20 @@
 let
   basePkgs = import ./nix/nixpkgs.nix { };
 
-  rust_overlay = with basePkgs; import (fetchFromGitHub
-    (lib.importJSON ./nix/oxalica_rust_overlay.json));
+  rust_overlay = with basePkgs;
+    import (fetchFromGitHub (lib.importJSON ./nix/oxalica_rust_overlay.json));
 
   pkgs = import ./nix/nixpkgs.nix { overlays = [ rust_overlay ]; };
 
-  nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal.override {
-    extensions = [ "rustfmt" ];
-  });
+  nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith
+    (toolchain: toolchain.minimal.override { extensions = [ "rustfmt" ]; });
 
-  stableToolchain = pkgs.rust-bin.stable."1.56.1".minimal.override {
+  stableToolchain = pkgs.rust-bin.stable.latest.minimal.override {
     extensions = [ "clippy" "llvm-tools-preview" "rust-src" ];
   };
 
   pre-commit-check = pkgs.callPackage ./nix/pre-commit.nix { };
-in
-with pkgs;
+in with pkgs;
 
 mkShell {
   buildInputs = [
@@ -28,9 +26,7 @@ mkShell {
     stableToolchain
     nightlyToolchain
 
-  ] ++ lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
   shellHook = ''
     export RUST_BACKTRACE=full


### PR DESCRIPTION
## Description

Introducing `struct BoolVar` whose creation automatically enforces a `bool_gate()`, distinguishing from normal `Variable` to avoid repeated checks and make API clearer.

closes: #91 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
