### PR TITLE
Fixing some trait bound

### DIFF
--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -32,6 +32,7 @@ rand_chacha = { version = "0.3.1" }
 sha3 = "^0.10"
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", branch = "main" }
 hashbrown = "0.12.3"
+dyn-clone = "^1.0"
 
 [dependencies.ark-poly-commit]
 git = "https://github.com/arkworks-rs/poly-commit/"

--- a/plonk/examples/proof_of_exp.rs
+++ b/plonk/examples/proof_of_exp.rs
@@ -94,7 +94,7 @@ fn proof_of_exponent_circuit<EmbedCurve, PairingCurve>(
     X: TEAffine<EmbedCurve>,
 ) -> Result<PlonkCircuit<EmbedCurve::BaseField>, PlonkError>
 where
-    EmbedCurve: TEModelParameters + Clone,
+    EmbedCurve: TEModelParameters,
     <EmbedCurve as ModelParameters>::BaseField: PrimeField,
     PairingCurve: PairingEngine,
 {

--- a/plonk/src/circuit/basic.rs
+++ b/plonk/src/circuit/basic.rs
@@ -17,15 +17,9 @@ use ark_ff::{BigInteger, FftField, PrimeField};
 use ark_poly::{
     domain::Radix2EvaluationDomain, univariate::DensePolynomial, EvaluationDomain, UVPolynomial,
 };
-use ark_std::{
-    boxed::Box,
-    cmp::max,
-    collections::{HashMap, HashSet},
-    format,
-    string::ToString,
-    vec,
-    vec::Vec,
-};
+use ark_std::{boxed::Box, cmp::max, format, string::ToString, vec, vec::Vec};
+use hashbrown::{HashMap, HashSet};
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 /// The wire type identifier for range gates.

--- a/plonk/src/circuit/customized/ecc/conversion.rs
+++ b/plonk/src/circuit/customized/ecc/conversion.rs
@@ -22,7 +22,7 @@ use ark_ff::{BigInteger256, BigInteger384, BigInteger768, PrimeField};
 impl<F, P> From<&SWAffine<P>> for Point<F>
 where
     F: PrimeField + SWToTEConParam,
-    P: SWParam<BaseField = F> + Clone,
+    P: SWParam<BaseField = F>,
 {
     fn from(p: &SWAffine<P>) -> Self {
         // this function is only correct for BLS12-377

--- a/plonk/src/circuit/customized/ecc/glv.rs
+++ b/plonk/src/circuit/customized/ecc/glv.rs
@@ -85,7 +85,7 @@ where
 {
     /// Perform GLV multiplication in circuit (which costs a few less
     /// constraints).
-    pub fn glv_mul<P: TEModelParameters<BaseField = F> + Clone>(
+    pub fn glv_mul<P: TEModelParameters<BaseField = F>>(
         &mut self,
         scalar: Variable,
         base: &PointVariable,
@@ -111,7 +111,7 @@ fn multi_scalar_mul_circuit<F, P>(
 ) -> Result<PointVariable, PlonkError>
 where
     F: PrimeField,
-    P: TEModelParameters<BaseField = F> + Clone,
+    P: TEModelParameters<BaseField = F>,
 {
     let endo_base_neg = circuit.inverse_point(endo_base)?;
     let endo_base =
@@ -129,7 +129,7 @@ where
 fn endomorphism<F, P>(base: &Point<F>) -> Point<F>
 where
     F: PrimeField,
-    P: TEModelParameters<BaseField = F> + Clone,
+    P: TEModelParameters<BaseField = F>,
 {
     let x = base.get_x();
     let y = base.get_y();
@@ -154,7 +154,7 @@ fn endomorphism_circuit<F, P>(
 ) -> Result<PointVariable, PlonkError>
 where
     F: PrimeField,
-    P: TEModelParameters<BaseField = F> + Clone,
+    P: TEModelParameters<BaseField = F>,
 {
     let base = circuit.point_witness(point_var)?;
     let endo_point = endomorphism::<_, P>(&base);
@@ -269,7 +269,7 @@ fn scalar_decomposition_gate<F, P, S>(
 ) -> Result<(Variable, Variable, BoolVar), PlonkError>
 where
     F: PrimeField,
-    P: TEModelParameters<BaseField = F, ScalarField = S> + Clone,
+    P: TEModelParameters<BaseField = F, ScalarField = S>,
     S: PrimeField,
 {
     // the order of scalar field
@@ -588,7 +588,7 @@ mod tests {
     fn test_glv_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
 

--- a/plonk/src/circuit/customized/ecc/mod.rs
+++ b/plonk/src/circuit/customized/ecc/mod.rs
@@ -36,7 +36,7 @@ pub struct Point<F: PrimeField>(F, F);
 impl<F, P> From<GroupAffine<P>> for Point<F>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn from(p: GroupAffine<P>) -> Self {
         if p.is_zero() {
@@ -87,7 +87,7 @@ impl<F: PrimeField> Point<F> {
 impl<F, P> From<GroupProjective<P>> for Point<F>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn from(p: GroupProjective<P>) -> Self {
         let affine_repr = p.into_affine();
@@ -98,7 +98,7 @@ where
 impl<F, P> From<Point<F>> for GroupAffine<P>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn from(p: Point<F>) -> Self {
         Self::new(p.0, p.1)
@@ -108,7 +108,7 @@ where
 impl<F, P> From<Point<F>> for GroupProjective<P>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn from(p: Point<F>) -> Self {
         let affine_point: GroupAffine<P> = p.into();
@@ -178,7 +178,7 @@ where
     /// parameters.
     /// A bad PointVariable would be returned if (b0, b1) are not boolean
     /// variables, that would ultimately failed to build a correct circuit.
-    fn quaternary_point_select<P: Parameters<BaseField = F> + Clone>(
+    fn quaternary_point_select<P: Parameters<BaseField = F>>(
         &mut self,
         b0: BoolVar,
         b1: BoolVar,
@@ -318,7 +318,7 @@ where
     /// Return error if input variables are invalid
     pub fn is_neutral_point<P>(&mut self, point_var: &PointVariable) -> Result<BoolVar, PlonkError>
     where
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         self.check_point_var_bound(point_var)?;
 
@@ -339,7 +339,7 @@ where
     /// scalar field
     ///
     /// Returns error if input variables are invalid
-    pub fn on_curve_gate<P: Parameters<BaseField = F> + Clone>(
+    pub fn on_curve_gate<P: Parameters<BaseField = F>>(
         &mut self,
         point_var: &PointVariable,
     ) -> Result<(), PlonkError> {
@@ -361,7 +361,7 @@ where
     /// Currently only supports GroupAffine::<P> addition.
     ///
     /// Returns error if the input variables are invalid.
-    fn ecc_add_gate<P: Parameters<BaseField = F> + Clone>(
+    fn ecc_add_gate<P: Parameters<BaseField = F>>(
         &mut self,
         point_a: &PointVariable,
         point_b: &PointVariable,
@@ -397,7 +397,7 @@ where
     /// Currently only supports GroupAffine::<P> addition.
     ///
     /// Returns error if inputs are invalid
-    pub fn ecc_add<P: Parameters<BaseField = F> + Clone>(
+    pub fn ecc_add<P: Parameters<BaseField = F>>(
         &mut self,
         point_a: &PointVariable,
         point_b: &PointVariable,
@@ -420,7 +420,7 @@ where
 
     /// Obtain the fixed-based scalar multiplication result of `scalar` * `Base`
     /// Currently only supports GroupAffine::<P> scalar multiplication.
-    pub fn fixed_base_scalar_mul<P: Parameters<BaseField = F> + Clone>(
+    pub fn fixed_base_scalar_mul<P: Parameters<BaseField = F>>(
         &mut self,
         scalar: Variable,
         base: &GroupAffine<P>,
@@ -469,7 +469,7 @@ where
     /// multiplication. both `scalar` and `base` are variables.
     /// Currently only supports GroupAffine::<P>.
     /// If the parameter is bandersnatch, we will use GLV multiplication.
-    pub fn variable_base_scalar_mul<P: Parameters<BaseField = F> + Clone>(
+    pub fn variable_base_scalar_mul<P: Parameters<BaseField = F>>(
         &mut self,
         scalar: Variable,
         base: &PointVariable,
@@ -495,7 +495,7 @@ where
     /// multiplication. Both `scalar_bits_le` and `base` are variables,
     /// where `scalar_bits_le` is the little-endian form of the scalar.
     /// Currently only supports GroupAffine::<P>.
-    pub fn variable_base_binary_scalar_mul<P: Parameters<BaseField = F> + Clone>(
+    pub fn variable_base_binary_scalar_mul<P: Parameters<BaseField = F>>(
         &mut self,
         scalar_bits_le: &[BoolVar],
         base: &PointVariable,
@@ -628,7 +628,7 @@ mod test {
     fn test_is_neutral_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField + ?Sized,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let p1 = circuit.create_point_variable(Point(F::zero(), F::one()))?;
@@ -656,7 +656,7 @@ mod test {
     fn build_is_neutral_circuit<F, P>(point: Point<F>) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let p = circuit.create_point_variable(point)?;
@@ -759,7 +759,7 @@ mod test {
     fn build_on_curve_gate_circuit<F, P>(point: Point<F>) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let p = circuit.create_point_variable(point)?;
@@ -780,7 +780,7 @@ mod test {
     fn test_curve_point_addition_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let p1 = GroupAffine::<P>::rand(&mut rng);
@@ -821,7 +821,7 @@ mod test {
     ) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let p1_var = circuit.create_point_variable(p1)?;
@@ -843,7 +843,7 @@ mod test {
     fn test_quaternary_point_select_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let p1 = GroupAffine::<P>::rand(&mut rng);
@@ -905,7 +905,7 @@ mod test {
     fn build_quaternary_select_gate<F, P>(b0: bool, b1: bool) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let b0_var = circuit.create_boolean_variable(b0)?;
@@ -938,7 +938,7 @@ mod test {
     fn test_point_equal_gate_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let p = GroupAffine::<P>::rand(&mut rng);
@@ -988,7 +988,7 @@ mod test {
     fn test_is_equal_point_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let p1 = GroupAffine::<P>::rand(&mut rng);
@@ -1048,12 +1048,12 @@ mod test {
     fn test_compute_fixed_bases_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         fn check_base_list<F, P>(bases: &[GroupAffine<P>])
         where
             F: PrimeField,
-            P: Parameters<BaseField = F> + Clone,
+            P: Parameters<BaseField = F>,
         {
             bases
                 .windows(2)
@@ -1104,7 +1104,7 @@ mod test {
     fn test_fixed_based_scalar_mul_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
@@ -1136,7 +1136,7 @@ mod test {
     fn build_fixed_based_scalar_mul_circuit<F, P>(scalar: F) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
@@ -1158,7 +1158,7 @@ mod test {
     fn test_binary_point_vars_select_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let p0 = GroupAffine::<P>::rand(&mut rng);
@@ -1207,7 +1207,7 @@ mod test {
     ) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let b_var = circuit.create_boolean_variable(b)?;
@@ -1229,7 +1229,7 @@ mod test {
     fn test_variable_base_scalar_mul_helper<F, P>() -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
@@ -1280,7 +1280,7 @@ mod test {
     ) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit: PlonkCircuit<F> = PlonkCircuit::new_turbo_plonk();
         let scalar_var = circuit.create_variable(scalar)?;

--- a/plonk/src/circuit/customized/ecc/msm.rs
+++ b/plonk/src/circuit/customized/ecc/msm.rs
@@ -23,7 +23,7 @@ use jf_utils::fq_to_fr;
 pub trait MultiScalarMultiplicationCircuit<F, P>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     /// Compute the multi-scalar-multiplications.
     /// Use pippenger when the circuit supports lookup;
@@ -48,7 +48,7 @@ where
 impl<F, P> MultiScalarMultiplicationCircuit<F, P> for PlonkCircuit<F>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn msm(
         &mut self,
@@ -133,7 +133,7 @@ fn msm_naive<F, P>(
 ) -> Result<PointVariable, PlonkError>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     circuit.check_vars_bound(scalars)?;
     for base in bases.iter() {
@@ -197,7 +197,7 @@ fn msm_pippenger<F, P>(
 ) -> Result<PointVariable, PlonkError>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     // ================================================
     // check inputs
@@ -350,7 +350,7 @@ fn compute_scalar_mul_value<F, P>(
 ) -> Result<Point<F>, PlonkError>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     let curve_point: GroupProjective<P> = circuit.point_witness(base_var)?.into();
     let scalar = fq_to_fr::<F, P>(&circuit.witness(scalar_var)?);
@@ -411,7 +411,7 @@ mod tests {
     ) -> Result<(), PlonkError>
     where
         F: PrimeField,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
 

--- a/plonk/src/circuit/customized/gates.rs
+++ b/plonk/src/circuit/customized/gates.rs
@@ -23,7 +23,8 @@ fn edwards_coeff_d<P: Parameters>() -> P::BaseField {
 }
 
 /// A gate for checking a point conforming the twisted Edwards curve equation
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Clone(bound = "P: Parameters"))]
 pub struct EdwardsCurveEquationGate<P: Parameters> {
     pub(crate) _phantom: PhantomData<P>,
 }
@@ -31,7 +32,7 @@ pub struct EdwardsCurveEquationGate<P: Parameters> {
 impl<F, P> Gate<F> for EdwardsCurveEquationGate<P>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn name(&self) -> &'static str {
         "Curve Equation Gate"
@@ -51,7 +52,8 @@ where
 }
 
 /// A gate for point addition on x-coordinate between two Curve Points
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Clone(bound = "P: Parameters"))]
 pub struct CurvePointXAdditionGate<P: Parameters> {
     pub(crate) _phantom: PhantomData<P>,
 }
@@ -59,7 +61,7 @@ pub struct CurvePointXAdditionGate<P: Parameters> {
 impl<F, P> Gate<F> for CurvePointXAdditionGate<P>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn name(&self) -> &'static str {
         "Point Addition X-coordinate Gate"
@@ -77,7 +79,8 @@ where
 }
 
 /// A gate for point addition on y-coordinate between two Curve Points
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Clone(bound = "P: Parameters"))]
 pub struct CurvePointYAdditionGate<P: Parameters> {
     pub(crate) _phantom: PhantomData<P>,
 }
@@ -85,7 +88,7 @@ pub struct CurvePointYAdditionGate<P: Parameters> {
 impl<F, P> Gate<F> for CurvePointYAdditionGate<P>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn name(&self) -> &'static str {
         "Point Addition Y-coordinate Gate"

--- a/plonk/src/circuit/customized/transcript/mod.rs
+++ b/plonk/src/circuit/customized/transcript/mod.rs
@@ -296,7 +296,7 @@ mod tests {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
     {
         let mut circuit = PlonkCircuit::<F>::new_ultra_plonk(RANGE_BIT_LEN_FOR_TEST);
 

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/gadgets.rs
@@ -483,8 +483,8 @@ mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone + TEModelParameters,
-        Q: TEParam<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F> + TEModelParameters,
+        Q: TEParam<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         // 1. Simulate universal setup

--- a/plonk/src/circuit/customized/ultraplonk/plonk_verifier/mod.rs
+++ b/plonk/src/circuit/customized/ultraplonk/plonk_verifier/mod.rs
@@ -62,7 +62,7 @@ impl<E: PairingEngine> VerifyingKeyVar<E> {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: PrimeField + SWToTEConParam,
-        P: SWParam<BaseField = F> + Clone,
+        P: SWParam<BaseField = F>,
     {
         let sigma_comms = verify_key
             .sigma_comms
@@ -106,7 +106,7 @@ impl<E: PairingEngine> VerifyingKeyVar<E> {
     ) -> Result<Self, PlonkError>
     where
         F: PrimeField,
-        P: TEParam<BaseField = F> + Clone,
+        P: TEParam<BaseField = F>,
     {
         if self.is_merged || other.is_merged {
             return Err(ParameterError("cannot merge a merged key again".to_string()).into());
@@ -161,7 +161,7 @@ impl<E: PairingEngine> VerifyingKeyVar<E> {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWParam<BaseField = F> + Clone + TEParam,
+        P: SWParam<BaseField = F> + TEParam,
     {
         if merged_vks.is_empty() {
             return Err(ParameterError("empty merged verification keys".to_string()).into());
@@ -293,7 +293,7 @@ where
     ) -> Result<Vec<VerifyingKeyVar<E>>, PlonkError>
     where
         E: PairingEngine,
-        P: TEParam<BaseField = F> + Clone,
+        P: TEParam<BaseField = F>,
     {
         if vk_type_a_vars.len() != vk_type_b_vars.len() {
             return Err(ParameterError(format!(
@@ -342,8 +342,8 @@ mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: PrimeField + RescueParameter + SWToTEConParam,
-        P: SWParam<BaseField = F> + Clone,
-        Q: TEParam<BaseField = F> + Clone,
+        P: SWParam<BaseField = F>,
+        Q: TEParam<BaseField = F>,
     {
         // Simulate universal setup
         let rng = &mut test_rng();
@@ -434,7 +434,7 @@ mod test {
     ) where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: PrimeField + SWToTEConParam,
-        P: SWParam<BaseField = F> + Clone,
+        P: SWParam<BaseField = F>,
     {
         for (comm_var, comm) in vk_var.sigma_comms.iter().zip(vk.sigma_comms.iter()) {
             let expected_comm = Point::from(&comm.0);
@@ -456,8 +456,8 @@ mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone + TEModelParameters,
-        Q: TEParam<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F> + TEModelParameters,
+        Q: TEParam<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         let rng = &mut test_rng();
@@ -695,7 +695,7 @@ mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone + TEModelParameters,
+        P: SWModelParameters<BaseField = F> + TEModelParameters,
     {
         let mut circuit = PlonkCircuit::<E::Fq>::new_ultra_plonk(RANGE_BIT_LEN_FOR_TEST);
 
@@ -751,8 +751,8 @@ mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone + TEModelParameters,
-        Q: TEParam<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F> + TEModelParameters,
+        Q: TEParam<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         let rng = &mut test_rng();

--- a/plonk/src/circuit/gates.rs
+++ b/plonk/src/circuit/gates.rs
@@ -9,11 +9,12 @@ use ark_ff::Field;
 use ark_std::boxed::Box;
 use core::fmt;
 use downcast_rs::Downcast;
+use dyn_clone::DynClone;
 
 use crate::constants::{GATE_WIDTH, N_MUL_SELECTORS};
 
 /// Describes a gate with getter for all selectors configuration
-pub trait Gate<F: Field>: Downcast + GateClone<F> {
+pub trait Gate<F: Field>: Downcast + DynClone {
     /// Get the name of a gate.
     fn name(&self) -> &'static str;
     /// Selectors for linear combination.
@@ -59,24 +60,9 @@ pub trait Gate<F: Field>: Downcast + GateClone<F> {
 }
 impl_downcast!(Gate<F> where F: Field);
 
-/// Clone a Gate.
-pub trait GateClone<F: Field> {
-    /// Clone a Gate.
-    fn clone_box(&self) -> Box<dyn Gate<F>>;
-}
-
-impl<T, F: Field> GateClone<F> for T
-where
-    T: 'static + Gate<F> + Clone,
-{
-    fn clone_box(&self) -> Box<dyn Gate<F>> {
-        Box::new(self.clone())
-    }
-}
-
 impl<F: Field> Clone for Box<dyn Gate<F>> {
     fn clone(&self) -> Box<dyn Gate<F>> {
-        self.clone_box()
+        dyn_clone::clone_box(&**self)
     }
 }
 

--- a/plonk/src/proof_system/batch_arg.rs
+++ b/plonk/src/proof_system/batch_arg.rs
@@ -58,7 +58,7 @@ impl<E, F, P> BatchArgument<E>
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F> + Clone,
+    P: SWModelParameters<BaseField = F>,
 {
     /// Setup the circuit and the proving key for a (mergeable) instance.
     pub fn setup_instance(
@@ -245,7 +245,7 @@ pub fn build_batch_proof_and_vks_for_test<E, F, P, R, T>(
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F> + Clone,
+    P: SWModelParameters<BaseField = F>,
     R: CryptoRng + RngCore,
     T: PlonkTranscript<F>,
 {
@@ -296,7 +296,7 @@ mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         // 1. Simulate universal setup

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -45,7 +45,7 @@ impl<E, F, P> PlonkKzgSnark<E>
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F> + Clone,
+    P: SWModelParameters<BaseField = F>,
 {
     #[allow(clippy::new_without_default)]
     /// A new Plonk KZG SNARK
@@ -418,7 +418,7 @@ impl<E, F, P> UniversalSNARK<E> for PlonkKzgSnark<E>
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F> + Clone,
+    P: SWModelParameters<BaseField = F>,
 {
     type Proof = Proof<E>;
     type ProvingKey = ProvingKey<E>;
@@ -720,7 +720,7 @@ pub mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
     {
         let rng = &mut ark_std::test_rng();
         let circuit = gen_circuit_for_test(5, 6, plonk_type)?;
@@ -862,7 +862,7 @@ pub mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         // 1. Simulate universal setup
@@ -1082,7 +1082,7 @@ pub mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         // 1. Simulate universal setup
@@ -1177,7 +1177,7 @@ pub mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         // 1. Simulate universal setup
@@ -1439,7 +1439,7 @@ pub mod test {
     where
         E: PairingEngine<G1Affine = GroupAffine<P>>,
         E::Fq: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = E::Fq, ScalarField = E::Fr> + Clone,
+        P: SWModelParameters<BaseField = E::Fq, ScalarField = E::Fr>,
     {
         let rng = &mut ark_std::test_rng();
         let circuit = gen_circuit_for_test(3, 4, PlonkType::TurboPlonk)?;
@@ -1484,7 +1484,7 @@ pub mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         let rng = &mut ark_std::test_rng();
@@ -1547,7 +1547,7 @@ pub mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
         T: PlonkTranscript<F>,
     {
         // 1. Simulate universal setup
@@ -1645,7 +1645,7 @@ pub mod test {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
         R: CryptoRng + RngCore,
         T: PlonkTranscript<F>,
     {

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -110,7 +110,7 @@ pub struct Proof<E: PairingEngine> {
 impl<E, P> TryFrom<Vec<E::Fq>> for Proof<E>
 where
     E: PairingEngine<G1Affine = GroupAffine<P>>,
-    P: SWModelParameters<BaseField = E::Fq, ScalarField = E::Fr> + Clone,
+    P: SWModelParameters<BaseField = E::Fq, ScalarField = E::Fr>,
 {
     type Error = SnarkError;
 
@@ -205,7 +205,7 @@ where
 impl<E, P> From<Proof<E>> for Vec<E::Fq>
 where
     E: PairingEngine<G1Affine = GroupAffine<P>>,
-    P: SWModelParameters<BaseField = E::Fq, ScalarField = E::Fr> + Clone,
+    P: SWModelParameters<BaseField = E::Fq, ScalarField = E::Fr>,
 {
     fn from(proof: Proof<E>) -> Self {
         if proof.plookup_proof.is_some() {
@@ -379,7 +379,7 @@ impl<E: PairingEngine> BatchProof<E> {
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
         F: RescueParameter + SWToTEConParam,
-        P: SWModelParameters<BaseField = F> + Clone,
+        P: SWModelParameters<BaseField = F>,
     {
         let mut wires_poly_comms_vec = Vec::new();
         for e in self.wires_poly_comms_vec.iter() {
@@ -711,8 +711,8 @@ impl<E, F, P1, P2> From<VerifyingKey<E>> for Vec<E::Fq>
 where
     E: PairingEngine<G1Affine = GroupAffine<P1>, G2Affine = GroupAffine<P2>, Fqe = Fp2<F>>,
     F: Fp2Parameters<Fp = E::Fq>,
-    P1: SWModelParameters<BaseField = E::Fq, ScalarField = E::Fr> + Clone,
-    P2: SWModelParameters<BaseField = E::Fqe, ScalarField = E::Fr> + Clone,
+    P1: SWModelParameters<BaseField = E::Fq, ScalarField = E::Fr>,
+    P2: SWModelParameters<BaseField = E::Fqe, ScalarField = E::Fr>,
 {
     fn from(vk: VerifyingKey<E>) -> Self {
         if vk.plookup_vk.is_some() {
@@ -746,7 +746,7 @@ impl<E, F, P> VerifyingKey<E>
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: SWToTEConParam,
-    P: SWModelParameters<BaseField = F> + Clone,
+    P: SWModelParameters<BaseField = F>,
 {
     /// Convert the group elements to a list of scalars that represent the
     /// Twisted Edwards coordinates.

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -53,7 +53,7 @@ impl<E, F, P> Verifier<E>
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F> + Clone,
+    P: SWModelParameters<BaseField = F>,
 {
     /// Construct a Plonk verifier that uses a domain with size `domain_size`.
     pub(crate) fn new(domain_size: usize) -> Result<Self, PlonkError> {
@@ -785,7 +785,7 @@ impl<E, F, P> Verifier<E>
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F> + Clone,
+    P: SWModelParameters<BaseField = F>,
 {
     /// Merge a polynomial commitment into the aggregated polynomial commitment
     /// (in the ScalarAndBases form), update the random combiner afterward.

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -171,7 +171,7 @@ impl<E, F, P> Verifier<E>
 where
     E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F> + Clone,
+    P: SWModelParameters<BaseField = F>,
 {
     /// Construct a Plonk verifier that uses a domain with size `domain_size`.
     pub fn new(domain_size: usize) -> Result<Self, PlonkError> {

--- a/plonk/src/transcript/mod.rs
+++ b/plonk/src/transcript/mod.rs
@@ -48,7 +48,7 @@ pub trait PlonkTranscript<F> {
     ) -> Result<(), PlonkError>
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
-        P: SWParam<BaseField = F> + Clone,
+        P: SWParam<BaseField = F>,
     {
         <Self as PlonkTranscript<F>>::append_message(
             self,
@@ -111,7 +111,7 @@ pub trait PlonkTranscript<F> {
     ) -> Result<(), PlonkError>
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
-        P: SWParam<BaseField = F> + Clone,
+        P: SWParam<BaseField = F>,
     {
         for comm in comms.iter() {
             self.append_commitment(label, comm)?;
@@ -127,7 +127,7 @@ pub trait PlonkTranscript<F> {
     ) -> Result<(), PlonkError>
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
-        P: SWParam<BaseField = F> + Clone,
+        P: SWParam<BaseField = F>,
     {
         <Self as PlonkTranscript<F>>::append_message(self, label, &to_bytes!(comm)?)
     }

--- a/plonk/src/transcript/rescue.rs
+++ b/plonk/src/transcript/rescue.rs
@@ -59,7 +59,7 @@ where
     ) -> Result<(), PlonkError>
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
-        P: SWParam<BaseField = F> + Clone,
+        P: SWParam<BaseField = F>,
     {
         // to enable a more efficient verifier circuit, we remove
         // the following messages (c.f. merlin transcript)
@@ -109,7 +109,7 @@ where
     ) -> Result<(), PlonkError>
     where
         E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
-        P: SWParam<BaseField = F> + Clone,
+        P: SWParam<BaseField = F>,
     {
         // convert the SW form commitments into TE form
         let te_point: Point<F> = (&comm.0).into();

--- a/primitives/src/circuit/elgamal.rs
+++ b/primitives/src/circuit/elgamal.rs
@@ -167,7 +167,7 @@ where
 pub trait ElGamalEncryptionGadget<F, P>
 where
     F: PrimeField,
-    P: TEModelParameters<BaseField = F> + Clone,
+    P: TEModelParameters<BaseField = F>,
 {
     /// Compute the gadget that check a correct Elgamal encryption
     /// * `pk_vars` - variables corresponding to the encryption public key
@@ -197,7 +197,7 @@ where
 impl<F, P> ElGamalEncryptionGadget<F, P> for PlonkCircuit<F>
 where
     F: RescueParameter,
-    P: TEModelParameters<BaseField = F> + Clone,
+    P: TEModelParameters<BaseField = F>,
 {
     fn elgamal_encrypt(
         &mut self,
@@ -279,7 +279,7 @@ mod tests {
     fn apply_counter_mode_stream_no_padding_helper<F, P>()
     where
         F: RescueParameter,
-        P: TEModelParameters<BaseField = F> + Clone,
+        P: TEModelParameters<BaseField = F>,
     {
         let mut circuit = PlonkCircuit::<F>::new_turbo_plonk();
         let mut prng = ark_std::test_rng();
@@ -342,7 +342,7 @@ mod tests {
     fn test_elgamal_hybrid_encrypt_circuit_helper<F, P>()
     where
         F: RescueParameter,
-        P: TEModelParameters<BaseField = F> + Clone,
+        P: TEModelParameters<BaseField = F>,
     {
         let mut circuit = PlonkCircuit::<F>::new_turbo_plonk();
 
@@ -422,7 +422,7 @@ mod tests {
     fn test_create_ciphertext_variable_helper<F, P>()
     where
         F: RescueParameter,
-        P: TEModelParameters<BaseField = F> + Clone,
+        P: TEModelParameters<BaseField = F>,
     {
         // Prepare ciphertext
         let rng = &mut ark_std::test_rng();

--- a/primitives/src/circuit/merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree.rs
@@ -111,7 +111,7 @@ impl AccMemberWitnessVar {
     ) -> Result<Self, PlonkError>
     where
         F: RescueParameter,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         Ok(Self {
             uid: circuit.create_variable(F::from(acc_member_witness.uid as u64))?,

--- a/primitives/src/circuit/signature/schnorr.rs
+++ b/primitives/src/circuit/signature/schnorr.rs
@@ -47,7 +47,7 @@ pub struct SignatureVar {
 pub trait SignatureGadget<F, P>
 where
     F: RescueParameter,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     /// Signature verification circuit
     /// * `vk` - signature verification key variable.
@@ -92,7 +92,7 @@ where
 impl<F, P> SignatureGadget<F, P> for PlonkCircuit<F>
 where
     F: RescueParameter,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn verify_signature(
         &mut self,
@@ -151,7 +151,7 @@ where
 trait SignatureHelperGadget<F, P>
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     // Return signature hash challenge in little-endian binary form.
     fn challenge_bits(
@@ -165,7 +165,7 @@ where
 impl<F, P> SignatureHelperGadget<F, P> for PlonkCircuit<F>
 where
     F: RescueParameter,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn challenge_bits(
         &mut self,
@@ -217,7 +217,7 @@ mod tests {
     fn test_dsa_circuit_helper<F, P>() -> Result<(), PlonkError>
     where
         F: RescueParameter,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut rng = ark_std::test_rng();
         let keypair = KeyPair::<P>::generate(&mut rng);
@@ -281,7 +281,7 @@ mod tests {
     ) -> Result<PlonkCircuit<F>, PlonkError>
     where
         F: RescueParameter,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit = PlonkCircuit::<F>::new_turbo_plonk();
         let vk_var = circuit.create_signature_vk_variable(vk)?;
@@ -301,7 +301,7 @@ mod tests {
     ) -> Result<(PlonkCircuit<F>, Variable), PlonkError>
     where
         F: RescueParameter,
-        P: Parameters<BaseField = F> + Clone,
+        P: Parameters<BaseField = F>,
     {
         let mut circuit = PlonkCircuit::new_turbo_plonk();
         let vk_var = circuit.create_signature_vk_variable(vk)?;

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -36,7 +36,7 @@ pub struct SchnorrSignatureScheme<P> {
 impl<F, P> SignatureScheme for SchnorrSignatureScheme<P>
 where
     F: RescueParameter,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     const CS_ID: &'static str = CS_ID_SCHNORR;
 
@@ -122,15 +122,18 @@ impl<F: PrimeField> SignKey<F> {
 /// Signature public verification key
 // derive zeroize here so that keypair can be zeroized
 #[tagged_blob(tag::SCHNORRVERKEY)]
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize, Derivative)]
-#[derivative(Debug(bound = "P: Parameters"))]
-#[derivative(Default(bound = "P: Parameters"))]
-#[derivative(Eq(bound = "P: Parameters"))]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Derivative)]
+#[derivative(
+    Debug(bound = "P: Parameters"),
+    Default(bound = "P: Parameters"),
+    Eq(bound = "P: Parameters"),
+    Clone(bound = "P: Parameters")
+)]
 pub struct VerKey<P>(pub(crate) GroupProjective<P>)
 where
-    P: Parameters + Clone;
+    P: Parameters;
 
-impl<P: Parameters + Clone> VerKey<P> {
+impl<P: Parameters> VerKey<P> {
     /// Return a randomized verification key.
     pub fn randomize_with<F>(&self, randomizer: &F) -> Self
     where
@@ -149,7 +152,7 @@ impl<P: Parameters + Clone> VerKey<P> {
 
 impl<P> Hash for VerKey<P>
 where
-    P: Parameters + Clone,
+    P: Parameters,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         Hash::hash(&self.0.into_affine(), state)
@@ -158,7 +161,7 @@ where
 
 impl<P> PartialEq for VerKey<P>
 where
-    P: Parameters + Clone,
+    P: Parameters,
 {
     fn eq(&self, other: &Self) -> bool {
         self.0.into_affine().eq(&other.0.into_affine())
@@ -167,14 +170,14 @@ where
 
 impl<P> From<GroupAffine<P>> for VerKey<P>
 where
-    P: Parameters + Clone,
+    P: Parameters,
 {
     fn from(point: GroupAffine<P>) -> Self {
         VerKey(point.into_projective())
     }
 }
 
-impl<P: Parameters + Clone> VerKey<P> {
+impl<P: Parameters> VerKey<P> {
     /// Convert the verification key into the affine form.
     pub fn to_affine(&self) -> GroupAffine<P> {
         self.0.into_affine()
@@ -188,11 +191,16 @@ impl<P: Parameters + Clone> VerKey<P> {
 /// Signature secret key pair used to sign messages
 // make sure sk can be zeroized
 #[tagged_blob(tag::SIGNKEYPAIR)]
-#[derive(Clone, Default, CanonicalSerialize, CanonicalDeserialize, PartialEq, Derivative)]
-#[derivative(Debug(bound = "P: Parameters"))]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Derivative)]
+#[derivative(
+    Debug(bound = "P: Parameters"),
+    Default(bound = "P: Parameters"),
+    Clone(bound = "P: Parameters"),
+    PartialEq(bound = "P: Parameters")
+)]
 pub struct KeyPair<P>
 where
-    P: Parameters + Clone,
+    P: Parameters,
 {
     sk: SignKey<P::ScalarField>,
     vk: VerKey<P>,
@@ -204,13 +212,17 @@ where
 
 /// The signature of Schnorr signature scheme
 #[tagged_blob(tag::SIG)]
-#[derive(Clone, Eq, CanonicalSerialize, CanonicalDeserialize, Derivative)]
-#[derivative(Debug(bound = "P: Parameters"))]
-#[derivative(Default(bound = "P: Parameters"))]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Derivative)]
+#[derivative(
+    Debug(bound = "P: Parameters"),
+    Default(bound = "P: Parameters"),
+    Eq(bound = "P: Parameters"),
+    Clone(bound = "P: Parameters")
+)]
 #[allow(non_snake_case)]
 pub struct Signature<P>
 where
-    P: Parameters + Clone,
+    P: Parameters,
 {
     pub(crate) s: P::ScalarField,
     pub(crate) R: GroupProjective<P>,
@@ -218,7 +230,7 @@ where
 
 impl<P> Hash for Signature<P>
 where
-    P: Parameters + Clone,
+    P: Parameters,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         Hash::hash(&self.s, state);
@@ -228,7 +240,7 @@ where
 
 impl<P> PartialEq for Signature<P>
 where
-    P: Parameters + Clone,
+    P: Parameters,
 {
     fn eq(&self, other: &Self) -> bool {
         self.s == other.s && self.R.into_affine() == other.R.into_affine()
@@ -241,7 +253,7 @@ where
 impl<F, P> KeyPair<P>
 where
     F: RescueParameter,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     /// Key-pair generation algorithm
     pub fn generate<R: Rng>(prng: &mut R) -> KeyPair<P> {
@@ -309,7 +321,7 @@ impl<F: PrimeField> SignKey<F> {
 
 impl<P, F> From<&SignKey<F>> for VerKey<P>
 where
-    P: Parameters<ScalarField = F> + Clone,
+    P: Parameters<ScalarField = F>,
     F: PrimeField,
 {
     fn from(sk: &SignKey<F>) -> Self {
@@ -323,7 +335,7 @@ where
 impl<F, P> VerKey<P>
 where
     F: RescueParameter,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     /// Get the internal of verifying key, namely a curve Point
     pub fn internal(&self) -> &GroupProjective<P> {
@@ -368,7 +380,7 @@ where
 impl<F, P> VerKey<P>
 where
     F: RescueParameter,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     // TODO: this function should be generic w.r.t. hash functions
     // Fixme after the hash-api PR is merged.

--- a/primitives/src/utils.rs
+++ b/primitives/src/utils.rs
@@ -13,7 +13,7 @@ use jf_plonk::circuit::Variable;
 impl<F, P> From<&schnorr::VerKey<P>> for (F, F)
 where
     F: PrimeField,
-    P: Parameters<BaseField = F> + Clone,
+    P: Parameters<BaseField = F>,
 {
     fn from(vk: &schnorr::VerKey<P>) -> Self {
         let point = vk.0.into_affine();
@@ -23,7 +23,7 @@ where
 
 impl<P> From<&elgamal::EncKey<P>> for (P::BaseField, P::BaseField)
 where
-    P: Parameters + Clone,
+    P: Parameters,
 {
     fn from(pk: &elgamal::EncKey<P>) -> Self {
         let point = pk.key.into_affine();

--- a/utilities/src/conversion.rs
+++ b/utilities/src/conversion.rs
@@ -15,7 +15,7 @@ use sha2::{Digest, Sha512};
 pub fn fr_to_fq<F, P>(scalar: &P::ScalarField) -> F
 where
     F: PrimeField,
-    P: ModelParameters<BaseField = F> + Clone,
+    P: ModelParameters<BaseField = F>,
 {
     // sanity checks:
     // ensure | jubjub scalar field | <= | BLS Scalar field |
@@ -36,7 +36,7 @@ where
 pub fn fq_to_fr<F, P>(base: &F) -> P::ScalarField
 where
     F: PrimeField,
-    P: ModelParameters<BaseField = F> + Clone,
+    P: ModelParameters<BaseField = F>,
 {
     P::ScalarField::from_le_bytes_mod_order(&base.into_repr().to_bytes_le())
 }


### PR DESCRIPTION
## Description

Major changes include:
- A missing modification for #87 in 6ee2ac08bdf910bf05bcd141a6e903b8b3e57131
- Remove unnecessary `Clone` on some trait bound: `P: Parameters + Clone` -> `P: Parameters`, whose source is our `trait Gate`, and trick I use is by relying on object-safe [`dyn_clone`](https://github.com/dtolnay/dyn-clone)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [x] ~Wrote unit tests~
- [x] ~Updated relevant documentation in the code~
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` (@zhenfeizhang I don't think we need to add this to changelog, WDYT?)
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
