### PR TITLE
remove extra P: SWParam bound

### DIFF
--- a/plonk/src/circuit/customized/ecc/mod.rs
+++ b/plonk/src/circuit/customized/ecc/mod.rs
@@ -16,10 +16,11 @@ use ark_ec::{
     group::Group,
     short_weierstrass_jacobian::GroupAffine as SWGroupAffine,
     twisted_edwards_extended::{GroupAffine, GroupProjective},
-    AffineCurve, ModelParameters, ProjectiveCurve, SWModelParameters,
+    AffineCurve, ModelParameters, PairingEngine, ProjectiveCurve, SWModelParameters,
     TEModelParameters as Parameters,
 };
-use ark_ff::{PrimeField, Zero};
+use ark_ff::{Field, PrimeField, ToConstraintField, Zero};
+use ark_poly_commit::kzg10::Commitment;
 use ark_std::{borrow::ToOwned, boxed::Box, string::ToString, vec, vec::Vec};
 use core::marker::PhantomData;
 
@@ -49,6 +50,16 @@ where
         } else {
             Point(p.x, p.y)
         }
+    }
+}
+
+impl<E: PairingEngine> From<Commitment<E>> for Point<<E::Fq as Field>::BasePrimeField>
+where
+    <E as PairingEngine>::G1Affine: ToConstraintField<<E as PairingEngine>::Fq>,
+{
+    fn from(cm: Commitment<E>) -> Self {
+        let fe = <Commitment<E> as ToConstraintField<<E::Fq as Field>::BasePrimeField>>::to_field_elements(&cm).unwrap();
+        Point(fe[0], fe[1])
     }
 }
 

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -23,7 +23,7 @@ use crate::{
     transcript::*,
 };
 use ark_ec::{short_weierstrass_jacobian::GroupAffine, PairingEngine, SWModelParameters};
-use ark_ff::{Field, One};
+use ark_ff::{Field, One, ToConstraintField};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly_commit::{kzg10::KZG10, PCUniversalParams};
 use ark_std::{
@@ -41,11 +41,11 @@ use rayon::prelude::*;
 /// A Plonk instantiated with KZG PCS
 pub struct PlonkKzgSnark<E: PairingEngine>(PhantomData<E>);
 
-impl<E, F, P> PlonkKzgSnark<E>
+impl<E, F> PlonkKzgSnark<E>
 where
-    E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
+    E: PairingEngine<Fq = F>,
+    E::G1Affine: ToConstraintField<<E as PairingEngine>::Fq>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F>,
 {
     #[allow(clippy::new_without_default)]
     /// A new Plonk KZG SNARK

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -14,8 +14,8 @@ use crate::{
     proof_system::structs::{eval_merged_lookup_witness, eval_merged_table, OpenKey},
     transcript::*,
 };
-use ark_ec::{short_weierstrass_jacobian::GroupAffine, PairingEngine, SWModelParameters};
-use ark_ff::{Field, One, Zero};
+use ark_ec::PairingEngine;
+use ark_ff::{Field, One, ToConstraintField, Zero};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_poly_commit::kzg10::Commitment;
 use ark_std::{format, vec, vec::Vec};
@@ -49,11 +49,11 @@ pub(crate) struct Verifier<E: PairingEngine> {
     pub(crate) domain: Radix2EvaluationDomain<E::Fr>,
 }
 
-impl<E, F, P> Verifier<E>
+impl<E, F> Verifier<E>
 where
-    E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
+    E: PairingEngine<Fq = F>,
+    E::G1Affine: ToConstraintField<<E as PairingEngine>::Fq>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F>,
 {
     /// Construct a Plonk verifier that uses a domain with size `domain_size`.
     pub(crate) fn new(domain_size: usize) -> Result<Self, PlonkError> {
@@ -781,11 +781,10 @@ where
 }
 
 /// Private helper methods
-impl<E, F, P> Verifier<E>
+impl<E, F> Verifier<E>
 where
-    E: PairingEngine<Fq = F, G1Affine = GroupAffine<P>>,
+    E: PairingEngine<Fq = F>,
     F: RescueParameter + SWToTEConParam,
-    P: SWModelParameters<BaseField = F>,
 {
     /// Merge a polynomial commitment into the aggregated polynomial commitment
     /// (in the ScalarAndBases form), update the random combiner afterward.

--- a/plonk/src/transcript/solidity.rs
+++ b/plonk/src/transcript/solidity.rs
@@ -8,7 +8,7 @@
 use super::PlonkTranscript;
 use crate::{constants::KECCAK256_STATE_SIZE, errors::PlonkError};
 use ark_ec::PairingEngine;
-use ark_ff::PrimeField;
+use ark_ff::{Field, PrimeField};
 use ark_std::vec::Vec;
 use sha3::{Digest, Keccak256};
 
@@ -33,7 +33,7 @@ pub struct SolidityTranscript {
     state: [u8; KECCAK256_STATE_SIZE], // 64 bytes state size
 }
 
-impl<F> PlonkTranscript<F> for SolidityTranscript {
+impl<F: Field> PlonkTranscript<F> for SolidityTranscript {
     /// Create a new plonk transcript. `label` is omitted for efficiency.
     fn new(_label: &'static [u8]) -> Self {
         SolidityTranscript {

--- a/plonk/src/transcript/standard.rs
+++ b/plonk/src/transcript/standard.rs
@@ -8,14 +8,14 @@
 use super::PlonkTranscript;
 use crate::errors::PlonkError;
 use ark_ec::PairingEngine;
-use ark_ff::PrimeField;
+use ark_ff::{Field, PrimeField};
 use jf_utils::to_bytes;
 use merlin::Transcript;
 
 /// A wrapper of `merlin::Transcript`.
 pub struct StandardTranscript(Transcript);
 
-impl<F> PlonkTranscript<F> for StandardTranscript {
+impl<F: Field> PlonkTranscript<F> for StandardTranscript {
     /// create a new plonk transcript
     fn new(label: &'static [u8]) -> Self {
         Self(Transcript::new(label))


### PR DESCRIPTION
## Description

Major changes include:
- Remove unnecessary bound of `P: SWParam` on many APIs

The source of the "necessity" (afaiu) comes from conversion of `E::G1Affine` to `struct Point`, where previously since `G1Affine: AffineCurve` and there's no API from the `trait AffineCurve` to get `x, y`, thus we have to use `struct SWGroupAffine<P>` instead, and do `From<SWGroupAffine<P>> for Point<F>` instead, which is why you see so many API with `<E, F, P>` generic parameters.

I try to convert directly from `G1Affine` to `Point` by using `ToConstraintField` (see `plonk/src/circuit/customized/ecc/mod.rs`).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [x] ~Wrote unit tests~
- [x] ~Updated relevant documentation in the code~
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
