### PR TITLE
better deserialize_canonical_bytes macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Use [blst](https://github.com/supranational/blst) library for BLS signature/VRF (#89)
 - Introduce `struct BoolVar` whenever necessary and possible (#91)
 - Introduce comparison gates (#81)
+- More general input to `deserialize_canonical_bytes!()` (#108)
 
 ## v0.1.2
 

--- a/utilities/src/serialize.rs
+++ b/utilities/src/serialize.rs
@@ -27,20 +27,15 @@ impl<T: ark_serialize::CanonicalSerialize> From<T> for CanonicalBytes {
     }
 }
 
-// TODO: (alex) improve this code, currently very naive matcher expression
 #[macro_export]
 macro_rules! deserialize_canonical_bytes {
     ($t:ident) => {
-        impl From<CanonicalBytes> for $t {
-            fn from(bytes: CanonicalBytes) -> Self {
-                ark_serialize::CanonicalDeserialize::deserialize(bytes.0.as_slice())
-                    .expect("fail to deserialize canonical bytes")
-            }
-        }
+        deserialize_canonical_bytes!($t<>);
     };
 
-    ($t:ident < $lt:lifetime >) => {
-        impl<$lt> From<CanonicalBytes> for $t<$lt> {
+    // match MyStruct<'a, 'b, T: MyTrait, R: MyTrait2, ...> where any number of lifetime and generic parameters
+    ($t:ident < $( $lt:lifetime ),* $( $T:ident : $trait:ident ),* >) => {
+        impl<$($lt),* $( $T: $trait ),*> From<CanonicalBytes> for $t<$($lt),* $( $T ),*> {
             fn from(bytes: CanonicalBytes) -> Self {
                 ark_serialize::CanonicalDeserialize::deserialize(bytes.0.as_slice())
                     .expect("fail to deserialize canonical bytes")


### PR DESCRIPTION
## Description

Previously, our `deserialize_canonical_bytes!()` macro only accept `MyStruct` and `MyStruct<'a>`, now we can accept arbitrary number of lifetime and generic parameter such as `MyStruct<'a, 'b, C: Config, R: Rng, ...>`

Blocking: https://github.com/EspressoSystems/cap/pull/64

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [x] ~Wrote unit tests~
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
