### PR TITLE
Bug fixed. `logic_or` should use `LogicOrValueGate`

### DIFF
--- a/relation/src/gadgets/logic.rs
+++ b/relation/src/gadgets/logic.rs
@@ -10,7 +10,7 @@ use ark_ff::PrimeField;
 
 use crate::{
     errors::CircuitError,
-    gates::{CondSelectGate, LogicOrGate, LogicOrValueGate},
+    gates::{CondSelectGate, LogicOrGate, LogicOrOutputGate},
     BoolVar, Circuit, PlonkCircuit, Variable,
 };
 
@@ -120,7 +120,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
 
         let c = self.create_boolean_variable_unchecked(c_val)?;
         let wire_vars = &[a.into(), b.into(), 0, 0, c.into()];
-        self.insert_gate(wire_vars, Box::new(LogicOrValueGate))?;
+        self.insert_gate(wire_vars, Box::new(LogicOrOutputGate))?;
 
         Ok(c)
     }

--- a/relation/src/gates/logic.rs
+++ b/relation/src/gates/logic.rs
@@ -34,9 +34,9 @@ where
 
 /// A gate for computing the logic OR value of 2 variables
 #[derive(Clone)]
-pub struct LogicOrValueGate;
+pub struct LogicOrOutputGate;
 
-impl<F> Gate<F> for LogicOrValueGate
+impl<F> Gate<F> for LogicOrOutputGate
 where
     F: Field,
 {


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #114 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] ~Updated relevant documentation in the code~
- [x] ~Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`~
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
