### PR TITLE
Sponge API refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 - [#144](https://github.com/EspressoSystems/jellyfish/pull/144) (`jf-primitives`) Updated append-only merkle tree gadget with the latest MT API
 - [#119](https://github.com/EspressoSystems/jellyfish/pull/119) (all) Updated dependencies
   - Upgraded `criterion` from `0.3.1` to `0.4.0`
+- [#146](https://github.com/EspressoSystems/jellyfish/pull/146) (`jf-primitives`) Refactored Rescue sponge API:
+    - Remove all `.*sponge.*` methods from `Permutation`.
+    - Introduce `RescueCRHF` which takes over `sponge_with_padding` and `sponge_no_padding` from `Permutation`.
+    - Introduce `RescuePRF` which takes over `full_state_keyed_sponge_with_padding` and `full_state_keyed_sponge_no_padding` from `Permutation`.
 
 ### Fixed
 

--- a/plonk/src/transcript/rescue.rs
+++ b/plonk/src/transcript/rescue.rs
@@ -17,7 +17,7 @@ use ark_ec::{
 use ark_std::vec::Vec;
 use jf_primitives::{
     pcs::prelude::Commitment,
-    rescue::{Permutation as RescueHash, RescueParameter, STATE_SIZE},
+    rescue::{sponge::RescueCRHF, RescueParameter, STATE_SIZE},
 };
 use jf_relation::gadgets::ecc::{Point, SWToTEConParam};
 use jf_utils::{bytes_to_field_elements, field_switching, fq_to_fr_with_mask};
@@ -176,10 +176,8 @@ where
         // 2. challenge = state[0] in Fr
         // 3. transcript = Vec::new()
 
-        let hasher = RescueHash::default();
-
         let input = [self.state.as_ref(), self.transcript.as_ref()].concat();
-        let tmp = hasher.sponge_with_padding(&input, STATE_SIZE);
+        let tmp = RescueCRHF::sponge_with_padding(&input, STATE_SIZE);
         let challenge = fq_to_fr_with_mask::<F, E::Fr>(&tmp[0]);
         self.state.copy_from_slice(&tmp);
         self.transcript = Vec::new();

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -18,6 +18,7 @@ ark-ed-on-bn254 = "0.3.0"
 ark-ff = "0.3.0"
 ark-poly = "0.3.0"
 ark-serialize = "0.3.0"
+ark-sponge = "0.3.0"
 ark-std = { version = "0.3.0", default-features = false }
 blst = "0.3.10"
 crypto_box = "0.8.1"

--- a/primitives/src/circuit/commitment.rs
+++ b/primitives/src/circuit/commitment.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     circuit::rescue::RescueGadget,
-    rescue::{RescueParameter, RATE},
+    rescue::{RescueParameter, CRHF_RATE},
     utils::pad_with,
 };
 use ark_std::vec;
@@ -33,7 +33,7 @@ where
     fn commit(&mut self, input: &[Variable], blinding: Variable) -> Result<Variable, CircuitError> {
         let mut msg = vec![blinding];
         msg.extend_from_slice(input);
-        pad_with(&mut msg, RATE, self.zero());
+        pad_with(&mut msg, CRHF_RATE, self.zero());
         Ok(self.rescue_sponge_no_padding(&msg, 1)?[0])
     }
 }

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -652,7 +652,7 @@ mod tests {
 
     use super::{RescueGadget, RescueHelperGadget, RescueStateVar};
     use crate::rescue::{
-        sponge::{RescueCRH, RescuePRF},
+        sponge::{RescueCRHF, RescuePRF},
         Permutation, RescueMatrix, RescueParameter, RescueVector, PRP, RATE, STATE_SIZE,
     };
     use ark_ed_on_bls12_377::Fq as FqEd377;
@@ -972,7 +972,7 @@ mod tests {
             .map(|&x| circuit.create_variable(x).unwrap())
             .collect_vec();
 
-        let expected_sponge = RescueCRH::sponge_no_padding(&data, 1).unwrap()[0];
+        let expected_sponge = RescueCRHF::sponge_no_padding(&data, 1).unwrap()[0];
         let sponge_var = circuit
             .rescue_sponge_no_padding(data_vars.as_slice(), 1)
             .unwrap()[0];
@@ -1028,7 +1028,7 @@ mod tests {
             }
 
             // Check consistency between outputs
-            let expected_hash = RescueCRH::sponge_no_padding(&input_vec, output_len).unwrap();
+            let expected_hash = RescueCRHF::sponge_no_padding(&input_vec, output_len).unwrap();
 
             for (e, f) in out_var.iter().zip(expected_hash.iter()) {
                 assert_eq!(*f, circuit.witness(*e).unwrap());
@@ -1089,7 +1089,7 @@ mod tests {
                 }
 
                 // Check consistency between outputs
-                let expected_hash = RescueCRH::sponge_with_padding(&input_vec, output_len);
+                let expected_hash = RescueCRHF::sponge_with_padding(&input_vec, output_len);
 
                 for (&e, &f) in expected_hash.iter().zip(out_var.iter()) {
                     assert_eq!(e, circuit.witness(f).unwrap());

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -653,7 +653,7 @@ mod tests {
     use super::{RescueGadget, RescueHelperGadget, RescueStateVar};
     use crate::rescue::{
         sponge::{RescueCRHF, RescuePRF},
-        Permutation, RescueMatrix, RescueParameter, RescueVector, PRP, RATE, STATE_SIZE,
+        Permutation, RescueMatrix, RescueParameter, RescueVector, CRHF_RATE, PRP, STATE_SIZE,
     };
     use ark_ed_on_bls12_377::Fq as FqEd377;
     use ark_ed_on_bls12_381::Fq as FqEd381;
@@ -966,7 +966,7 @@ mod tests {
         let mut circuit = PlonkCircuit::new_turbo_plonk();
 
         let mut prng = ark_std::test_rng();
-        let data = (0..2 * RATE).map(|_| F::rand(&mut prng)).collect_vec();
+        let data = (0..2 * CRHF_RATE).map(|_| F::rand(&mut prng)).collect_vec();
         let data_vars = data
             .iter()
             .map(|&x| circuit.create_variable(x).unwrap())
@@ -987,7 +987,7 @@ mod tests {
         // If the data length is not a multiple of RATE==3 then an error is triggered
         let mut circuit = PlonkCircuit::<F>::new_turbo_plonk();
 
-        let size = 2 * RATE + 1; // Non multiple of RATE
+        let size = 2 * CRHF_RATE + 1; // Non multiple of RATE
         let data = (0..size).map(|_| F::rand(&mut prng)).collect_vec();
         let data_vars = data
             .iter()

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -652,6 +652,7 @@ mod tests {
 
     use super::{RescueGadget, RescueHelperGadget, RescueStateVar};
     use crate::rescue::{
+        sponge::{RescueSpongeCRHF, RescueSpongePRF},
         Permutation, RescueMatrix, RescueParameter, RescueVector, PRP, RATE, STATE_SIZE,
     };
     use ark_ed_on_bls12_377::Fq as FqEd377;
@@ -971,8 +972,7 @@ mod tests {
             .map(|&x| circuit.create_variable(x).unwrap())
             .collect_vec();
 
-        let rescue_perm = Permutation::default();
-        let expected_sponge = rescue_perm.sponge_no_padding(&data, 1).unwrap()[0];
+        let expected_sponge = RescueSpongeCRHF::sponge_no_padding(&data, 1).unwrap()[0];
         let sponge_var = circuit
             .rescue_sponge_no_padding(data_vars.as_slice(), 1)
             .unwrap()[0];
@@ -1022,17 +1022,14 @@ mod tests {
                 .rescue_sponge_no_padding(&input_var, output_len)
                 .unwrap();
 
-            let rescue_hash = Permutation::default();
-
             // Check consistency between inputs
             for i in 0..rate {
                 assert_eq!(input_vec[i], circuit.witness(input_var[i]).unwrap());
             }
 
             // Check consistency between outputs
-            let expected_hash = rescue_hash
-                .sponge_no_padding(&input_vec, output_len)
-                .unwrap();
+            let expected_hash =
+                RescueSpongeCRHF::sponge_no_padding(&input_vec, output_len).unwrap();
 
             for (e, f) in out_var.iter().zip(expected_hash.iter()) {
                 assert_eq!(*f, circuit.witness(*e).unwrap());
@@ -1087,15 +1084,13 @@ mod tests {
                     .rescue_sponge_with_padding(&input_var, output_len)
                     .unwrap();
 
-                let rescue_hash = Permutation::default();
-
                 // Check consistency between inputs
                 for i in 0..input_len {
                     assert_eq!(input_vec[i], circuit.witness(input_var[i]).unwrap());
                 }
 
                 // Check consistency between outputs
-                let expected_hash = rescue_hash.sponge_with_padding(&input_vec, output_len);
+                let expected_hash = RescueSpongeCRHF::sponge_with_padding(&input_vec, output_len);
 
                 for (&e, &f) in expected_hash.iter().zip(out_var.iter()) {
                     assert_eq!(e, circuit.witness(f).unwrap());
@@ -1131,10 +1126,8 @@ mod tests {
             .map(|&x| circuit.create_variable(x).unwrap())
             .collect_vec();
 
-        let perm = Permutation::default();
-        let expected_fsks_output = perm
-            .full_state_keyed_sponge_no_padding(&key, &data, 1)
-            .unwrap();
+        let expected_fsks_output =
+            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, &data, 1).unwrap();
 
         let fsks_var = circuit
             .rescue_full_state_keyed_sponge_no_padding(key_var, &data_vars)

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -652,7 +652,7 @@ mod tests {
 
     use super::{RescueGadget, RescueHelperGadget, RescueStateVar};
     use crate::rescue::{
-        sponge::{RescueSpongeCRHF, RescueSpongePRF},
+        sponge::{RescueCRH, RescuePRF},
         Permutation, RescueMatrix, RescueParameter, RescueVector, PRP, RATE, STATE_SIZE,
     };
     use ark_ed_on_bls12_377::Fq as FqEd377;
@@ -972,7 +972,7 @@ mod tests {
             .map(|&x| circuit.create_variable(x).unwrap())
             .collect_vec();
 
-        let expected_sponge = RescueSpongeCRHF::sponge_no_padding(&data, 1).unwrap()[0];
+        let expected_sponge = RescueCRH::sponge_no_padding(&data, 1).unwrap()[0];
         let sponge_var = circuit
             .rescue_sponge_no_padding(data_vars.as_slice(), 1)
             .unwrap()[0];
@@ -1028,8 +1028,7 @@ mod tests {
             }
 
             // Check consistency between outputs
-            let expected_hash =
-                RescueSpongeCRHF::sponge_no_padding(&input_vec, output_len).unwrap();
+            let expected_hash = RescueCRH::sponge_no_padding(&input_vec, output_len).unwrap();
 
             for (e, f) in out_var.iter().zip(expected_hash.iter()) {
                 assert_eq!(*f, circuit.witness(*e).unwrap());
@@ -1090,7 +1089,7 @@ mod tests {
                 }
 
                 // Check consistency between outputs
-                let expected_hash = RescueSpongeCRHF::sponge_with_padding(&input_vec, output_len);
+                let expected_hash = RescueCRH::sponge_with_padding(&input_vec, output_len);
 
                 for (&e, &f) in expected_hash.iter().zip(out_var.iter()) {
                     assert_eq!(e, circuit.witness(f).unwrap());
@@ -1127,7 +1126,7 @@ mod tests {
             .collect_vec();
 
         let expected_fsks_output =
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, &data, 1).unwrap();
+            RescuePRF::full_state_keyed_sponge_no_padding(&key, &data, 1).unwrap();
 
         let fsks_var = circuit
             .rescue_full_state_keyed_sponge_no_padding(key_var, &data_vars)

--- a/primitives/src/circuit/rescue/non_native.rs
+++ b/primitives/src/circuit/rescue/non_native.rs
@@ -736,6 +736,7 @@ mod tests {
 
     use super::{RescueNonNativeGadget, RescueNonNativeHelperGadget, RescueNonNativeStateVar};
     use crate::rescue::{
+        sponge::{RescueSpongeCRHF, RescueSpongePRF},
         Permutation, RescueMatrix, RescueParameter, RescueVector, PRP, RATE, STATE_SIZE,
     };
     use ark_bls12_377::Fq as Fq377;
@@ -1071,8 +1072,7 @@ mod tests {
             .collect();
 
         // sponge no padding with output length 1
-        let rescue_perm = Permutation::<T>::default();
-        let expected_sponge = rescue_perm.sponge_no_padding(&data_t, 1).unwrap()[0];
+        let expected_sponge = RescueSpongeCRHF::sponge_no_padding(&data_t, 1).unwrap()[0];
         let sponge_var = circuit
             .rescue_sponge_no_padding::<T>(data_vars.as_slice(), 1)
             .unwrap()[0];
@@ -1091,8 +1091,7 @@ mod tests {
 
         // general sponge no padding
         for output_len in 1..max_output_len {
-            let rescue_perm = Permutation::<T>::default();
-            let expected_sponge = rescue_perm.sponge_no_padding(&data_t, output_len).unwrap();
+            let expected_sponge = RescueSpongeCRHF::sponge_no_padding(&data_t, output_len).unwrap();
             let sponge_var = circuit
                 .rescue_sponge_no_padding::<T>(data_vars.as_slice(), output_len)
                 .unwrap();
@@ -1153,8 +1152,7 @@ mod tests {
                 .map(|x| FpElemVar::new_from_field_element(&mut circuit, x, m, None).unwrap())
                 .collect();
 
-            let rescue_perm = Permutation::<T>::default();
-            let expected_sponge = rescue_perm.sponge_with_padding(&data_t, 1);
+            let expected_sponge = RescueSpongeCRHF::sponge_with_padding(&data_t, 1);
 
             // sponge with padding
             let sponge_var = circuit
@@ -1175,8 +1173,7 @@ mod tests {
 
             // sponge full with padding
             for output_len in 1..max_output_len {
-                let rescue_perm = Permutation::<T>::default();
-                let expected_sponge = rescue_perm.sponge_with_padding(&data_t, output_len);
+                let expected_sponge = RescueSpongeCRHF::sponge_with_padding(&data_t, output_len);
 
                 let sponge_var = circuit
                     .rescue_sponge_with_padding::<T>(data_vars.as_slice(), output_len)
@@ -1271,10 +1268,8 @@ mod tests {
             })
             .collect();
 
-        let perm = Permutation::<T>::default();
-        let expected_fsks_output = perm
-            .full_state_keyed_sponge_no_padding(&key_t, &data_t, 1)
-            .unwrap();
+        let expected_fsks_output =
+            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key_t, &data_t, 1).unwrap();
 
         let fsks_var = circuit
             .rescue_full_state_keyed_sponge_no_padding::<T>(key_var, &data_vars)

--- a/primitives/src/circuit/rescue/non_native.rs
+++ b/primitives/src/circuit/rescue/non_native.rs
@@ -737,7 +737,7 @@ mod tests {
     use super::{RescueNonNativeGadget, RescueNonNativeHelperGadget, RescueNonNativeStateVar};
     use crate::rescue::{
         sponge::{RescueCRHF, RescuePRF},
-        Permutation, RescueMatrix, RescueParameter, RescueVector, PRP, RATE, STATE_SIZE,
+        Permutation, RescueMatrix, RescueParameter, RescueVector, CRHF_RATE, PRP, STATE_SIZE,
     };
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
@@ -1064,7 +1064,7 @@ mod tests {
         let mut prng = ark_std::test_rng();
 
         // setup the inputs
-        let data_t: Vec<T> = (0..2 * RATE).map(|_| T::rand(&mut prng)).collect_vec();
+        let data_t: Vec<T> = (0..2 * CRHF_RATE).map(|_| T::rand(&mut prng)).collect_vec();
         let data_f: Vec<F> = data_t.iter().map(|x| field_switching(x)).collect();
         let data_vars: Vec<FpElemVar<F>> = data_f
             .iter()
@@ -1110,7 +1110,7 @@ mod tests {
         // If the data length is not a multiple of RATE==3 then an error is triggered
         let mut circuit = PlonkCircuit::<F>::new_ultra_plonk(RANGE_BIT_LEN_FOR_TEST);
 
-        let size = 2 * RATE + 1; // Non multiple of RATE
+        let size = 2 * CRHF_RATE + 1; // Non multiple of RATE
         let data_t = (0..size).map(|_| T::rand(&mut prng)).collect_vec();
         let data_f: Vec<F> = data_t.iter().map(|x| field_switching(x)).collect();
         let data_vars: Vec<FpElemVar<F>> = data_f

--- a/primitives/src/circuit/rescue/non_native.rs
+++ b/primitives/src/circuit/rescue/non_native.rs
@@ -736,7 +736,7 @@ mod tests {
 
     use super::{RescueNonNativeGadget, RescueNonNativeHelperGadget, RescueNonNativeStateVar};
     use crate::rescue::{
-        sponge::{RescueSpongeCRHF, RescueSpongePRF},
+        sponge::{RescueCRH, RescuePRF},
         Permutation, RescueMatrix, RescueParameter, RescueVector, PRP, RATE, STATE_SIZE,
     };
     use ark_bls12_377::Fq as Fq377;
@@ -1072,7 +1072,7 @@ mod tests {
             .collect();
 
         // sponge no padding with output length 1
-        let expected_sponge = RescueSpongeCRHF::sponge_no_padding(&data_t, 1).unwrap()[0];
+        let expected_sponge = RescueCRH::sponge_no_padding(&data_t, 1).unwrap()[0];
         let sponge_var = circuit
             .rescue_sponge_no_padding::<T>(data_vars.as_slice(), 1)
             .unwrap()[0];
@@ -1091,7 +1091,7 @@ mod tests {
 
         // general sponge no padding
         for output_len in 1..max_output_len {
-            let expected_sponge = RescueSpongeCRHF::sponge_no_padding(&data_t, output_len).unwrap();
+            let expected_sponge = RescueCRH::sponge_no_padding(&data_t, output_len).unwrap();
             let sponge_var = circuit
                 .rescue_sponge_no_padding::<T>(data_vars.as_slice(), output_len)
                 .unwrap();
@@ -1152,7 +1152,7 @@ mod tests {
                 .map(|x| FpElemVar::new_from_field_element(&mut circuit, x, m, None).unwrap())
                 .collect();
 
-            let expected_sponge = RescueSpongeCRHF::sponge_with_padding(&data_t, 1);
+            let expected_sponge = RescueCRH::sponge_with_padding(&data_t, 1);
 
             // sponge with padding
             let sponge_var = circuit
@@ -1173,7 +1173,7 @@ mod tests {
 
             // sponge full with padding
             for output_len in 1..max_output_len {
-                let expected_sponge = RescueSpongeCRHF::sponge_with_padding(&data_t, output_len);
+                let expected_sponge = RescueCRH::sponge_with_padding(&data_t, output_len);
 
                 let sponge_var = circuit
                     .rescue_sponge_with_padding::<T>(data_vars.as_slice(), output_len)
@@ -1269,7 +1269,7 @@ mod tests {
             .collect();
 
         let expected_fsks_output =
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key_t, &data_t, 1).unwrap();
+            RescuePRF::full_state_keyed_sponge_no_padding(&key_t, &data_t, 1).unwrap();
 
         let fsks_var = circuit
             .rescue_full_state_keyed_sponge_no_padding::<T>(key_var, &data_vars)

--- a/primitives/src/circuit/rescue/non_native.rs
+++ b/primitives/src/circuit/rescue/non_native.rs
@@ -1217,8 +1217,6 @@ mod tests {
             .rescue_sponge_no_padding::<T>(&input_var, 1)
             .unwrap()[0];
 
-        let rescue_hash = Permutation::<T>::default();
-
         // Check consistency between inputs
         for i in 0..rate {
             assert_eq!(input_vec_f[i], input_var[i].witness(&circuit).unwrap());
@@ -1226,7 +1224,8 @@ mod tests {
 
         // Check consistency between outputs
         let expected_hash =
-            rescue_hash.hash_3_to_1(&[input_vec_t[0], input_vec_t[1], input_vec_t[2]]);
+            RescueCRHF::sponge_no_padding(&[input_vec_t[0], input_vec_t[1], input_vec_t[2]], 1)
+                .unwrap()[0];
         assert_eq!(
             field_switching::<T, F>(&expected_hash),
             out_var.witness(&circuit).unwrap()

--- a/primitives/src/circuit/rescue/non_native.rs
+++ b/primitives/src/circuit/rescue/non_native.rs
@@ -736,7 +736,7 @@ mod tests {
 
     use super::{RescueNonNativeGadget, RescueNonNativeHelperGadget, RescueNonNativeStateVar};
     use crate::rescue::{
-        sponge::{RescueCRH, RescuePRF},
+        sponge::{RescueCRHF, RescuePRF},
         Permutation, RescueMatrix, RescueParameter, RescueVector, PRP, RATE, STATE_SIZE,
     };
     use ark_bls12_377::Fq as Fq377;
@@ -1072,7 +1072,7 @@ mod tests {
             .collect();
 
         // sponge no padding with output length 1
-        let expected_sponge = RescueCRH::sponge_no_padding(&data_t, 1).unwrap()[0];
+        let expected_sponge = RescueCRHF::sponge_no_padding(&data_t, 1).unwrap()[0];
         let sponge_var = circuit
             .rescue_sponge_no_padding::<T>(data_vars.as_slice(), 1)
             .unwrap()[0];
@@ -1091,7 +1091,7 @@ mod tests {
 
         // general sponge no padding
         for output_len in 1..max_output_len {
-            let expected_sponge = RescueCRH::sponge_no_padding(&data_t, output_len).unwrap();
+            let expected_sponge = RescueCRHF::sponge_no_padding(&data_t, output_len).unwrap();
             let sponge_var = circuit
                 .rescue_sponge_no_padding::<T>(data_vars.as_slice(), output_len)
                 .unwrap();
@@ -1152,7 +1152,7 @@ mod tests {
                 .map(|x| FpElemVar::new_from_field_element(&mut circuit, x, m, None).unwrap())
                 .collect();
 
-            let expected_sponge = RescueCRH::sponge_with_padding(&data_t, 1);
+            let expected_sponge = RescueCRHF::sponge_with_padding(&data_t, 1);
 
             // sponge with padding
             let sponge_var = circuit
@@ -1173,7 +1173,7 @@ mod tests {
 
             // sponge full with padding
             for output_len in 1..max_output_len {
-                let expected_sponge = RescueCRH::sponge_with_padding(&data_t, output_len);
+                let expected_sponge = RescueCRHF::sponge_with_padding(&data_t, output_len);
 
                 let sponge_var = circuit
                     .rescue_sponge_with_padding::<T>(data_vars.as_slice(), output_len)

--- a/primitives/src/commitment.rs
+++ b/primitives/src/commitment.rs
@@ -10,7 +10,7 @@ use ark_std::marker::PhantomData;
 
 use crate::{
     errors::PrimitivesError,
-    rescue::{sponge::RescueSpongeCRHF, RescueParameter, RATE},
+    rescue::{sponge::RescueCRH, RescueParameter, RATE},
 };
 use ark_std::{format, string::String, vec};
 use jf_utils::pad_with_zeros;
@@ -47,7 +47,7 @@ impl<F: RescueParameter> Commitment<F> {
         msg.extend_from_slice(input);
         // Ok to pad with 0's since input length is fixed for the commitment instance
         pad_with_zeros(&mut msg, RATE);
-        let result_vec = RescueSpongeCRHF::sponge_no_padding(msg.as_slice(), 1)?;
+        let result_vec = RescueCRH::sponge_no_padding(msg.as_slice(), 1)?;
         Ok(result_vec[0])
     }
     /// Verifies `commitment` against `input` and `blind`.

--- a/primitives/src/commitment.rs
+++ b/primitives/src/commitment.rs
@@ -10,7 +10,7 @@ use ark_std::marker::PhantomData;
 
 use crate::{
     errors::PrimitivesError,
-    rescue::{sponge::RescueCRH, RescueParameter, RATE},
+    rescue::{sponge::RescueCRHF, RescueParameter, RATE},
 };
 use ark_std::{format, string::String, vec};
 use jf_utils::pad_with_zeros;
@@ -47,7 +47,7 @@ impl<F: RescueParameter> Commitment<F> {
         msg.extend_from_slice(input);
         // Ok to pad with 0's since input length is fixed for the commitment instance
         pad_with_zeros(&mut msg, RATE);
-        let result_vec = RescueCRH::sponge_no_padding(msg.as_slice(), 1)?;
+        let result_vec = RescueCRHF::sponge_no_padding(msg.as_slice(), 1)?;
         Ok(result_vec[0])
     }
     /// Verifies `commitment` against `input` and `blind`.

--- a/primitives/src/commitment.rs
+++ b/primitives/src/commitment.rs
@@ -6,9 +6,11 @@
 
 //! Implements a rescue hash based commitment scheme.
 
+use core::marker::PhantomData;
+
 use crate::{
     errors::PrimitivesError,
-    rescue::{Permutation, RescueParameter, RATE},
+    rescue::{sponge::RescueSpongeCRHF, RescueParameter, RATE},
 };
 use ark_std::{format, string::String, vec};
 use jf_utils::pad_with_zeros;
@@ -16,8 +18,8 @@ use jf_utils::pad_with_zeros;
 #[derive(Default)]
 /// Commitment instance for user defined input size (in scalar elements)
 pub struct Commitment<F: RescueParameter> {
-    hash: Permutation<F>,
     input_len: usize,
+    phantom_f: PhantomData<F>,
 }
 
 impl<F: RescueParameter> Commitment<F> {
@@ -25,8 +27,8 @@ impl<F: RescueParameter> Commitment<F> {
     pub fn new(input_len: usize) -> Commitment<F> {
         assert!(input_len > 0, "input_len must be positive");
         Commitment {
-            hash: Permutation::default(),
             input_len,
+            phantom_f: PhantomData,
         }
     }
     /// Commits to `input` slice using blinding `blind`. Return
@@ -45,7 +47,7 @@ impl<F: RescueParameter> Commitment<F> {
         msg.extend_from_slice(input);
         // Ok to pad with 0's since input length is fixed for the commitment instance
         pad_with_zeros(&mut msg, RATE);
-        let result_vec = self.hash.sponge_no_padding(msg.as_slice(), 1)?;
+        let result_vec = RescueSpongeCRHF::sponge_no_padding(msg.as_slice(), 1)?;
         Ok(result_vec[0])
     }
     /// Verifies `commitment` against `input` and `blind`.

--- a/primitives/src/commitment.rs
+++ b/primitives/src/commitment.rs
@@ -6,7 +6,7 @@
 
 //! Implements a rescue hash based commitment scheme.
 
-use core::marker::PhantomData;
+use ark_std::marker::PhantomData;
 
 use crate::{
     errors::PrimitivesError,

--- a/primitives/src/commitment.rs
+++ b/primitives/src/commitment.rs
@@ -10,7 +10,7 @@ use ark_std::marker::PhantomData;
 
 use crate::{
     errors::PrimitivesError,
-    rescue::{sponge::RescueCRHF, RescueParameter, RATE},
+    rescue::{sponge::RescueCRHF, RescueParameter, CRHF_RATE},
 };
 use ark_std::{format, string::String, vec};
 use jf_utils::pad_with_zeros;
@@ -46,7 +46,7 @@ impl<F: RescueParameter> Commitment<F> {
         let mut msg = vec![*blind];
         msg.extend_from_slice(input);
         // Ok to pad with 0's since input length is fixed for the commitment instance
-        pad_with_zeros(&mut msg, RATE);
+        pad_with_zeros(&mut msg, CRHF_RATE);
         let result_vec = RescueCRHF::sponge_no_padding(msg.as_slice(), 1)?;
         Ok(result_vec[0])
     }

--- a/primitives/src/merkle_tree/examples.rs
+++ b/primitives/src/merkle_tree/examples.rs
@@ -8,7 +8,7 @@
 //! E.g. Sparse merkle tree with BigUInt index.
 
 use super::{append_only::MerkleTree, prelude::RescueHash, DigestAlgorithm, Element, Index};
-use crate::rescue::{sponge::RescueSpongeCRHF, RescueParameter};
+use crate::rescue::{sponge::RescueCRH, RescueParameter};
 use ark_ff::Field;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use sha3::{Digest, Sha3_256};
@@ -21,12 +21,12 @@ pub struct Interval<F: Field>(pub F, pub F);
 
 impl<F: RescueParameter> DigestAlgorithm<Interval<F>, u64, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        RescueSpongeCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
+        RescueCRH::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &u64, elem: &Interval<F>) -> F {
         let data = [F::from(*pos), elem.0, elem.1];
-        RescueSpongeCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
+        RescueCRH::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 

--- a/primitives/src/merkle_tree/examples.rs
+++ b/primitives/src/merkle_tree/examples.rs
@@ -8,7 +8,7 @@
 //! E.g. Sparse merkle tree with BigUInt index.
 
 use super::{append_only::MerkleTree, prelude::RescueHash, DigestAlgorithm, Element, Index};
-use crate::rescue::{sponge::RescueCRH, RescueParameter};
+use crate::rescue::{sponge::RescueCRHF, RescueParameter};
 use ark_ff::Field;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use sha3::{Digest, Sha3_256};
@@ -21,12 +21,12 @@ pub struct Interval<F: Field>(pub F, pub F);
 
 impl<F: RescueParameter> DigestAlgorithm<Interval<F>, u64, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        RescueCRH::<F>::sponge_no_padding(data, 1).unwrap()[0]
+        RescueCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &u64, elem: &Interval<F>) -> F {
         let data = [F::from(*pos), elem.0, elem.1];
-        RescueCRH::<F>::sponge_no_padding(&data, 1).unwrap()[0]
+        RescueCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 

--- a/primitives/src/merkle_tree/examples.rs
+++ b/primitives/src/merkle_tree/examples.rs
@@ -8,7 +8,7 @@
 //! E.g. Sparse merkle tree with BigUInt index.
 
 use super::{append_only::MerkleTree, prelude::RescueHash, DigestAlgorithm, Element, Index};
-use crate::rescue::{Permutation, RescueParameter};
+use crate::rescue::{sponge::RescueSpongeCRHF, RescueParameter};
 use ark_ff::Field;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use sha3::{Digest, Sha3_256};
@@ -21,14 +21,12 @@ pub struct Interval<F: Field>(pub F, pub F);
 
 impl<F: RescueParameter> DigestAlgorithm<Interval<F>, u64, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        let perm = Permutation::default();
-        perm.sponge_no_padding(data, 1).unwrap()[0]
+        RescueSpongeCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &u64, elem: &Interval<F>) -> F {
         let data = [F::from(*pos), elem.0, elem.1];
-        let perm = Permutation::default();
-        perm.sponge_no_padding(&data, 1).unwrap()[0]
+        RescueSpongeCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 

--- a/primitives/src/merkle_tree/prelude.rs
+++ b/primitives/src/merkle_tree/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::{
     },
 };
 
-use crate::rescue::{sponge::RescueSpongeCRHF, RescueParameter};
+use crate::rescue::{sponge::RescueCRH, RescueParameter};
 use ark_std::marker::PhantomData;
 use num_bigint::BigUint;
 use typenum::U3;
@@ -28,12 +28,12 @@ pub struct RescueHash<F: RescueParameter> {
 
 impl<F: RescueParameter> DigestAlgorithm<F, u64, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        RescueSpongeCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
+        RescueCRH::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &u64, elem: &F) -> F {
         let data = [F::zero(), F::from(*pos), *elem];
-        RescueSpongeCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
+        RescueCRH::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 
@@ -42,12 +42,12 @@ pub type RescueMerkleTree<F> = MerkleTree<F, RescueHash<F>, u64, U3, F>;
 
 impl<F: RescueParameter> DigestAlgorithm<F, BigUint, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        RescueSpongeCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
+        RescueCRH::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &BigUint, elem: &F) -> F {
         let data = [F::zero(), F::from(pos.clone()), *elem];
-        RescueSpongeCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
+        RescueCRH::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 

--- a/primitives/src/merkle_tree/prelude.rs
+++ b/primitives/src/merkle_tree/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::{
     },
 };
 
-use crate::rescue::{Permutation, RescueParameter};
+use crate::rescue::{sponge::RescueSpongeCRHF, RescueParameter};
 use ark_std::marker::PhantomData;
 use num_bigint::BigUint;
 use typenum::U3;
@@ -28,14 +28,12 @@ pub struct RescueHash<F: RescueParameter> {
 
 impl<F: RescueParameter> DigestAlgorithm<F, u64, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        let perm = Permutation::default();
-        perm.sponge_no_padding(data, 1).unwrap()[0]
+        RescueSpongeCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &u64, elem: &F) -> F {
         let data = [F::zero(), F::from(*pos), *elem];
-        let perm = Permutation::default();
-        perm.sponge_no_padding(&data, 1).unwrap()[0]
+        RescueSpongeCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 
@@ -44,14 +42,12 @@ pub type RescueMerkleTree<F> = MerkleTree<F, RescueHash<F>, u64, U3, F>;
 
 impl<F: RescueParameter> DigestAlgorithm<F, BigUint, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        let perm = Permutation::default();
-        perm.sponge_no_padding(data, 1).unwrap()[0]
+        RescueSpongeCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &BigUint, elem: &F) -> F {
         let data = [F::zero(), F::from(pos.clone()), *elem];
-        let perm = Permutation::default();
-        perm.sponge_no_padding(&data, 1).unwrap()[0]
+        RescueSpongeCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 

--- a/primitives/src/merkle_tree/prelude.rs
+++ b/primitives/src/merkle_tree/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::{
     },
 };
 
-use crate::rescue::{sponge::RescueCRH, RescueParameter};
+use crate::rescue::{sponge::RescueCRHF, RescueParameter};
 use ark_std::marker::PhantomData;
 use num_bigint::BigUint;
 use typenum::U3;
@@ -28,12 +28,12 @@ pub struct RescueHash<F: RescueParameter> {
 
 impl<F: RescueParameter> DigestAlgorithm<F, u64, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        RescueCRH::<F>::sponge_no_padding(data, 1).unwrap()[0]
+        RescueCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &u64, elem: &F) -> F {
         let data = [F::zero(), F::from(*pos), *elem];
-        RescueCRH::<F>::sponge_no_padding(&data, 1).unwrap()[0]
+        RescueCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 
@@ -42,12 +42,12 @@ pub type RescueMerkleTree<F> = MerkleTree<F, RescueHash<F>, u64, U3, F>;
 
 impl<F: RescueParameter> DigestAlgorithm<F, BigUint, F> for RescueHash<F> {
     fn digest(data: &[F]) -> F {
-        RescueCRH::<F>::sponge_no_padding(data, 1).unwrap()[0]
+        RescueCRHF::<F>::sponge_no_padding(data, 1).unwrap()[0]
     }
 
     fn digest_leaf(pos: &BigUint, elem: &F) -> F {
         let data = [F::zero(), F::from(pos.clone()), *elem];
-        RescueCRH::<F>::sponge_no_padding(&data, 1).unwrap()[0]
+        RescueCRHF::<F>::sponge_no_padding(&data, 1).unwrap()[0]
     }
 }
 

--- a/primitives/src/prf.rs
+++ b/primitives/src/prf.rs
@@ -7,9 +7,11 @@
 //! This module implements a pseudo random function that is derived from
 //! the rescue hash function.
 
+use core::marker::PhantomData;
+
 use crate::{
     errors::PrimitivesError,
-    rescue::{Permutation, RescueParameter, STATE_SIZE},
+    rescue::{sponge::RescueSpongePRF, RescueParameter, STATE_SIZE},
 };
 use ark_ff::PrimeField;
 use ark_serialize::*;
@@ -24,7 +26,7 @@ pub struct PRF<F: RescueParameter> {
     pub input_len: usize,
     /// Length of the output.
     pub output_len: usize,
-    permutation: Permutation<F>,
+    phantom_f: PhantomData<F>,
 }
 
 #[derive(
@@ -61,7 +63,7 @@ impl<F: RescueParameter> PRF<F> {
         PRF {
             input_len,
             output_len,
-            permutation: Default::default(),
+            phantom_f: PhantomData,
         }
     }
 
@@ -84,8 +86,7 @@ impl<F: RescueParameter> PRF<F> {
         // Ok to pad with 0's since input length is fixed for the PRF instance
         let mut padded = input.to_owned();
         pad_with_zeros(&mut padded, STATE_SIZE);
-        self.permutation
-            .full_state_keyed_sponge_no_padding(&key.0, &padded, self.output_len)
+        RescueSpongePRF::full_state_keyed_sponge_no_padding(&key.0, &padded, self.output_len)
             .map_err(|_| {
                 PrimitivesError::InternalError("Bug in PRF: bad padding for input".to_string())
             })

--- a/primitives/src/prf.rs
+++ b/primitives/src/prf.rs
@@ -11,7 +11,7 @@ use ark_std::marker::PhantomData;
 
 use crate::{
     errors::PrimitivesError,
-    rescue::{sponge::RescueSpongePRF, RescueParameter, STATE_SIZE},
+    rescue::{sponge::RescuePRF, RescueParameter, STATE_SIZE},
 };
 use ark_ff::PrimeField;
 use ark_serialize::*;
@@ -86,10 +86,9 @@ impl<F: RescueParameter> PRF<F> {
         // Ok to pad with 0's since input length is fixed for the PRF instance
         let mut padded = input.to_owned();
         pad_with_zeros(&mut padded, STATE_SIZE);
-        RescueSpongePRF::full_state_keyed_sponge_no_padding(&key.0, &padded, self.output_len)
-            .map_err(|_| {
-                PrimitivesError::InternalError("Bug in PRF: bad padding for input".to_string())
-            })
+        RescuePRF::full_state_keyed_sponge_no_padding(&key.0, &padded, self.output_len).map_err(
+            |_| PrimitivesError::InternalError("Bug in PRF: bad padding for input".to_string()),
+        )
     }
 }
 

--- a/primitives/src/prf.rs
+++ b/primitives/src/prf.rs
@@ -7,7 +7,7 @@
 //! This module implements a pseudo random function that is derived from
 //! the rescue hash function.
 
-use core::marker::PhantomData;
+use ark_std::marker::PhantomData;
 
 use crate::{
     errors::PrimitivesError,

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -831,7 +831,6 @@ mod test_permutation {
 
     fn test_sponge_helper<F: RescueParameter>() {
         let rescue_prp = PRP::default();
-        // let rescue_permutation = Permutation::from(rescue_prp.clone());
         let mut prng = ark_std::test_rng();
         let e0 = F::rand(&mut prng);
         let e1 = F::rand(&mut prng);

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -699,7 +699,7 @@ mod test_prp {
 #[cfg(test)]
 mod test_permutation {
     use crate::rescue::{
-        sponge::{RescueSpongeCRHF, RescueSpongePRF},
+        sponge::{RescueCRH, RescuePRF},
         Permutation, RescueParameter, RescueVector, PRP,
     };
     use ark_bls12_377::Fq as Fq377;
@@ -841,7 +841,7 @@ mod test_permutation {
 
         let input = [e0, e1, e2, e3, e4, e5];
 
-        let output = RescueSpongeCRHF::<F>::sponge_no_padding(&input, 1).unwrap()[0];
+        let output = RescueCRH::<F>::sponge_no_padding(&input, 1).unwrap()[0];
 
         let zero = RescueVector::zero();
         let mut state = RescueVector {
@@ -868,7 +868,7 @@ mod test_permutation {
             Fr254::from_le_bytes_mod_order(&OUTPUT254[1]),
             Fr254::from_le_bytes_mod_order(&OUTPUT254[2]),
         ];
-        let real_output = RescueSpongeCRHF::sponge_no_padding(&input, 3).unwrap();
+        let real_output = RescueCRH::sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
     }
 
@@ -879,7 +879,7 @@ mod test_permutation {
             Fr377::from_le_bytes_mod_order(&OUTPUT377[1]),
             Fr377::from_le_bytes_mod_order(&OUTPUT377[2]),
         ];
-        let real_output = RescueSpongeCRHF::sponge_no_padding(&input, 3).unwrap();
+        let real_output = RescueCRH::sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
     }
 
@@ -890,7 +890,7 @@ mod test_permutation {
             Fr381::from_le_bytes_mod_order(&OUTPUT381[1]),
             Fr381::from_le_bytes_mod_order(&OUTPUT381[2]),
         ];
-        let real_output = RescueSpongeCRHF::sponge_no_padding(&input, 3).unwrap();
+        let real_output = RescueCRH::sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
     }
 
@@ -901,7 +901,7 @@ mod test_permutation {
             Fq377::from_le_bytes_mod_order(&OUTPUT761[1]),
             Fq377::from_le_bytes_mod_order(&OUTPUT761[2]),
         ];
-        let real_output = RescueSpongeCRHF::sponge_no_padding(&input, 3).unwrap();
+        let real_output = RescueCRH::sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
     }
 
@@ -915,28 +915,18 @@ mod test_permutation {
     fn test_fsks_no_padding_errors_helper<F: RescueParameter>() {
         let key = F::rand(&mut ark_std::test_rng());
         let input = vec![F::from(9u64); 4];
-        assert!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok()
-        );
+        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok());
         let input = vec![F::from(9u64); 12];
-        assert!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok()
-        );
+        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok());
 
         // test should panic because number of inputs is not multiple of 3
         let input = vec![F::from(9u64); 10];
-        assert!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_err()
-        );
+        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_err());
         let input = vec![F::from(9u64)];
-        assert!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_err()
-        );
+        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_err());
 
         let input = vec![];
-        assert!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok()
-        );
+        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok());
     }
 
     #[test]
@@ -948,91 +938,66 @@ mod test_permutation {
     }
     fn test_variable_output_sponge_and_fsks_helper<F: RescueParameter>() {
         let input = [F::zero(), F::one(), F::zero()];
-        assert_eq!(RescueSpongeCRHF::sponge_with_padding(&input, 0).len(), 0);
-        assert_eq!(RescueSpongeCRHF::sponge_with_padding(&input, 1).len(), 1);
-        assert_eq!(RescueSpongeCRHF::sponge_with_padding(&input, 2).len(), 2);
-        assert_eq!(RescueSpongeCRHF::sponge_with_padding(&input, 3).len(), 3);
-        assert_eq!(RescueSpongeCRHF::sponge_with_padding(&input, 10).len(), 10);
+        assert_eq!(RescueCRH::sponge_with_padding(&input, 0).len(), 0);
+        assert_eq!(RescueCRH::sponge_with_padding(&input, 1).len(), 1);
+        assert_eq!(RescueCRH::sponge_with_padding(&input, 2).len(), 2);
+        assert_eq!(RescueCRH::sponge_with_padding(&input, 3).len(), 3);
+        assert_eq!(RescueCRH::sponge_with_padding(&input, 10).len(), 10);
 
-        assert_eq!(
-            RescueSpongeCRHF::sponge_no_padding(&input, 0)
-                .unwrap()
-                .len(),
-            0
-        );
-        assert_eq!(
-            RescueSpongeCRHF::sponge_no_padding(&input, 1)
-                .unwrap()
-                .len(),
-            1
-        );
-        assert_eq!(
-            RescueSpongeCRHF::sponge_no_padding(&input, 2)
-                .unwrap()
-                .len(),
-            2
-        );
-        assert_eq!(
-            RescueSpongeCRHF::sponge_no_padding(&input, 3)
-                .unwrap()
-                .len(),
-            3
-        );
-        assert_eq!(
-            RescueSpongeCRHF::sponge_no_padding(&input, 10)
-                .unwrap()
-                .len(),
-            10
-        );
+        assert_eq!(RescueCRH::sponge_no_padding(&input, 0).unwrap().len(), 0);
+        assert_eq!(RescueCRH::sponge_no_padding(&input, 1).unwrap().len(), 1);
+        assert_eq!(RescueCRH::sponge_no_padding(&input, 2).unwrap().len(), 2);
+        assert_eq!(RescueCRH::sponge_no_padding(&input, 3).unwrap().len(), 3);
+        assert_eq!(RescueCRH::sponge_no_padding(&input, 10).unwrap().len(), 10);
 
         let key = F::rand(&mut ark_std::test_rng());
         let input = [F::zero(), F::one(), F::zero(), F::zero()];
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_with_padding(&key, &input, 0).len(),
+            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 0).len(),
             0
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_with_padding(&key, &input, 1).len(),
+            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 1).len(),
             1
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_with_padding(&key, &input, 2).len(),
+            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 2).len(),
             2
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_with_padding(&key, &input, 4).len(),
+            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 4).len(),
             4
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_with_padding(&key, &input, 10).len(),
+            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 10).len(),
             10
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, &input, 0)
+            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 0)
                 .unwrap()
                 .len(),
             0
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, &input, 1)
+            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 1)
                 .unwrap()
                 .len(),
             1
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, &input, 2)
+            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 2)
                 .unwrap()
                 .len(),
             2
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, &input, 4)
+            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 4)
                 .unwrap()
                 .len(),
             4
         );
         assert_eq!(
-            RescueSpongePRF::full_state_keyed_sponge_no_padding(&key, &input, 10)
+            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 10)
                 .unwrap()
                 .len(),
             10

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -699,7 +699,7 @@ mod test_prp {
 #[cfg(test)]
 mod test_permutation {
     use crate::rescue::{
-        sponge::{RescueCRH, RescuePRF},
+        sponge::{RescueCRHF, RescuePRF},
         Permutation, RescueParameter, RescueVector, PRP,
     };
     use ark_bls12_377::Fq as Fq377;
@@ -841,7 +841,7 @@ mod test_permutation {
 
         let input = [e0, e1, e2, e3, e4, e5];
 
-        let output = RescueCRH::<F>::sponge_no_padding(&input, 1).unwrap()[0];
+        let output = RescueCRHF::<F>::sponge_no_padding(&input, 1).unwrap()[0];
 
         let zero = RescueVector::zero();
         let mut state = RescueVector {
@@ -868,7 +868,7 @@ mod test_permutation {
             Fr254::from_le_bytes_mod_order(&OUTPUT254[1]),
             Fr254::from_le_bytes_mod_order(&OUTPUT254[2]),
         ];
-        let real_output = RescueCRH::sponge_no_padding(&input, 3).unwrap();
+        let real_output = RescueCRHF::sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
     }
 
@@ -879,7 +879,7 @@ mod test_permutation {
             Fr377::from_le_bytes_mod_order(&OUTPUT377[1]),
             Fr377::from_le_bytes_mod_order(&OUTPUT377[2]),
         ];
-        let real_output = RescueCRH::sponge_no_padding(&input, 3).unwrap();
+        let real_output = RescueCRHF::sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
     }
 
@@ -890,7 +890,7 @@ mod test_permutation {
             Fr381::from_le_bytes_mod_order(&OUTPUT381[1]),
             Fr381::from_le_bytes_mod_order(&OUTPUT381[2]),
         ];
-        let real_output = RescueCRH::sponge_no_padding(&input, 3).unwrap();
+        let real_output = RescueCRHF::sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
     }
 
@@ -901,7 +901,7 @@ mod test_permutation {
             Fq377::from_le_bytes_mod_order(&OUTPUT761[1]),
             Fq377::from_le_bytes_mod_order(&OUTPUT761[2]),
         ];
-        let real_output = RescueCRH::sponge_no_padding(&input, 3).unwrap();
+        let real_output = RescueCRHF::sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
     }
 
@@ -938,17 +938,17 @@ mod test_permutation {
     }
     fn test_variable_output_sponge_and_fsks_helper<F: RescueParameter>() {
         let input = [F::zero(), F::one(), F::zero()];
-        assert_eq!(RescueCRH::sponge_with_padding(&input, 0).len(), 0);
-        assert_eq!(RescueCRH::sponge_with_padding(&input, 1).len(), 1);
-        assert_eq!(RescueCRH::sponge_with_padding(&input, 2).len(), 2);
-        assert_eq!(RescueCRH::sponge_with_padding(&input, 3).len(), 3);
-        assert_eq!(RescueCRH::sponge_with_padding(&input, 10).len(), 10);
+        assert_eq!(RescueCRHF::sponge_with_padding(&input, 0).len(), 0);
+        assert_eq!(RescueCRHF::sponge_with_padding(&input, 1).len(), 1);
+        assert_eq!(RescueCRHF::sponge_with_padding(&input, 2).len(), 2);
+        assert_eq!(RescueCRHF::sponge_with_padding(&input, 3).len(), 3);
+        assert_eq!(RescueCRHF::sponge_with_padding(&input, 10).len(), 10);
 
-        assert_eq!(RescueCRH::sponge_no_padding(&input, 0).unwrap().len(), 0);
-        assert_eq!(RescueCRH::sponge_no_padding(&input, 1).unwrap().len(), 1);
-        assert_eq!(RescueCRH::sponge_no_padding(&input, 2).unwrap().len(), 2);
-        assert_eq!(RescueCRH::sponge_no_padding(&input, 3).unwrap().len(), 3);
-        assert_eq!(RescueCRH::sponge_no_padding(&input, 10).unwrap().len(), 10);
+        assert_eq!(RescueCRHF::sponge_no_padding(&input, 0).unwrap().len(), 0);
+        assert_eq!(RescueCRHF::sponge_no_padding(&input, 1).unwrap().len(), 1);
+        assert_eq!(RescueCRHF::sponge_no_padding(&input, 2).unwrap().len(), 2);
+        assert_eq!(RescueCRHF::sponge_no_padding(&input, 3).unwrap().len(), 3);
+        assert_eq!(RescueCRHF::sponge_no_padding(&input, 10).unwrap().len(), 10);
 
         let key = F::rand(&mut ark_std::test_rng());
         let input = [F::zero(), F::one(), F::zero(), F::zero()];

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -163,7 +163,7 @@ impl<F: PrimeField> RescueVector<F> {
         aux
     }
 
-    fn add_assign_elems(&mut self, elems: &[F], _expected_size: usize) {
+    fn add_assign_elems(&mut self, elems: &[F]) {
         self.vec
             .iter_mut()
             .zip(elems.iter())

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -29,8 +29,8 @@ use ark_std::{vec, vec::Vec};
 
 /// The state size of rescue hash.
 pub const STATE_SIZE: usize = 4;
-/// The rate of rescue hash.
-pub const RATE: usize = 3;
+/// The rate of the sponge used in RescueCRHF.
+pub const CRHF_RATE: usize = 3;
 
 /// The # of rounds of rescue hash.
 // In the paper, to derive ROUND:

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Jellyfish library.
+
+// You should have received a copy of the MIT License
+// along with the Jellyfish library. If not, see <https://mit-license.org/>.
+
 //! This file contains the APIs wrappers for ark-sponge
 
 use ark_ff::{BigInteger, PrimeField};

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -211,8 +211,7 @@ impl<T: RescueParameter + PrimeField, const CHUNK_SIZE: usize> CryptographicSpon
                 .map(|x| field_switching(x))
                 .collect::<Vec<F>>()
         } else {
-            // currently we do not support hashing into a non-native field
-            unimplemented!()
+            unimplemented!("currently we do not support hashing into a non-native field");
         }
     }
 

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -19,7 +19,7 @@ use super::{errors::RescueError, Permutation, RescueParameter, RescueVector, RAT
 #[derive(Clone, Default)]
 /// A rescue hash function consists of a permutation function and
 /// an internal state.
-pub struct RescueSponge<F: RescueParameter, const ABSORB_RATE: usize> {
+pub struct RescueSponge<F: RescueParameter, const CHUNK_SIZE: usize> {
     pub(crate) state: RescueVector<F>,
 }
 

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -137,7 +137,7 @@ impl<T: RescueParameter + PrimeField, const CHUNK_SIZE: usize> CryptographicSpon
             .chunks(CHUNK_SIZE)
             .into_iter()
             .for_each(|chunk| {
-                self.state.add_assign_elems(chunk, CHUNK_SIZE);
+                self.state.add_assign_elems(chunk);
                 self.state = permutation.eval(&self.state)
             });
     }

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -35,6 +35,10 @@ impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
     pub fn sponge_with_padding(input: &[F], num_outputs: usize) -> Vec<F> {
         // Pad input as follows: append a One, then pad with 0 until length is multiple
         // of RATE
+        assert_eq!(
+            CHUNK_SIZE, RATE,
+            "CHUNK_SIZE must be equal to RATE. Perhaps you meant to use a RescueSpongePRF instead?"
+        );
         let mut padded = input.to_vec();
         padded.push(F::one());
         pad_with_zeros(&mut padded, RATE);
@@ -46,6 +50,10 @@ impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
     /// for RATE 3 and CAPACITY 1. It allows input length multiple of the
     /// RATE and variable output length
     pub fn sponge_no_padding(input: &[F], num_output: usize) -> Result<Vec<F>, RescueError> {
+        assert_eq!(
+            CHUNK_SIZE, RATE,
+            "CHUNK_SIZE must be equal to RATE. Perhaps you meant to use a RescueSpongePRF instead?"
+        );
         if input.len() % RATE != 0 {
             return Err(RescueError::ParameterError(
                 "Rescue sponge Error : input to sponge hashing function is not multiple of RATE."
@@ -69,6 +77,9 @@ impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
         input: &[F],
         num_outputs: usize,
     ) -> Vec<F> {
+        assert_eq!(
+            CHUNK_SIZE, STATE_SIZE,
+            "CHUNK_SIZE must be equal to STATE_SIZE. Perhaps you meant to use a RescueSpongeCRHF instead?");
         let mut padded_input = input.to_vec();
         padded_input.push(F::one());
         pad_with_zeros(&mut padded_input, STATE_SIZE);
@@ -84,6 +95,9 @@ impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
         input: &[F],
         num_outputs: usize,
     ) -> Result<Vec<F>, RescueError> {
+        assert_eq!(
+            CHUNK_SIZE, STATE_SIZE,
+            "CHUNK_SIZE must be equal to STATE_SIZE. Perhaps you meant to use a RescueSpongeCRHF instead?");
         if input.len() % STATE_SIZE != 0 {
             return Err(RescueError::ParameterError(
                 "Rescue FSKS PRF Error: input to prf function is not multiple of STATE_SIZE."

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -34,15 +34,6 @@ pub struct RescuePRF<F: RescueParameter> {
 }
 
 impl<F: RescueParameter> RescueCRH<F> {
-    /// Create a new RescueCRH instance.
-    pub fn new(sponge_parameters: &Permutation<F>) -> Self {
-        Self {
-            sponge: RescueSponge::<F, RATE>::new(sponge_parameters),
-        }
-    }
-}
-
-impl<F: RescueParameter> RescueCRH<F> {
     /// Sponge hashing based on rescue permutation for Bls12_381 scalar field
     /// for RATE 3 and CAPACITY 1. It allows unrestricted variable length
     /// input and number of output elements

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -155,12 +155,12 @@ impl<T: RescueParameter + PrimeField, const CHUNK_SIZE: usize> CryptographicSpon
 
     /// Squeeze `num_bytes` bytes from the sponge.
     fn squeeze_bytes(&mut self, _num_bytes: usize) -> Vec<u8> {
-        unimplemented!()
+        unimplemented!("Currently we only support squeezing native field elements!")
     }
 
     /// Squeeze `num_bits` bits from the sponge.
     fn squeeze_bits(&mut self, _num_bits: usize) -> Vec<bool> {
-        unimplemented!()
+        unimplemented!("Currently we only support squeezing native field elements!")
     }
 
     /// Squeeze `sizes.len()` field elements from the sponge, where the `i`-th
@@ -183,7 +183,7 @@ impl<T: RescueParameter + PrimeField, const CHUNK_SIZE: usize> CryptographicSpon
                 .map(|x| field_switching(x))
                 .collect::<Vec<F>>()
         } else {
-            unimplemented!("currently we do not support hashing into a non-native field");
+            unimplemented!("Currently we only support squeezing native field elements!")
         }
     }
 
@@ -249,7 +249,7 @@ impl<T: RescueParameter, const CHUNK_SIZE: usize> FieldBasedCryptographicSponge<
         } else {
             // we do not currently want to output field elements other than T.
             // This will be fixed once `squeeze_bytes` interfaces is fixed.
-            unimplemented!()
+            unimplemented!("Currently we only support squeezing native field elements!")
         }
     }
 }

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -36,9 +36,9 @@ pub struct RescuePRF<F: RescueParameter> {
 }
 
 impl<F: RescueParameter> RescueCRHF<F> {
-    /// Sponge hashing based on rescue permutation for Bls12_381 scalar field
-    /// for RATE 3 and CAPACITY 1. It allows unrestricted variable length
-    /// input and number of output elements
+    /// Sponge hashing based on rescue permutation for RATE 3. It allows
+    /// unrestricted variable length input and returns a vector of
+    /// `num_outputs` elements.
     pub fn sponge_with_padding(input: &[F], num_outputs: usize) -> Vec<F> {
         // Pad input as follows: append a One, then pad with 0 until length is multiple
         // of RATE
@@ -49,9 +49,9 @@ impl<F: RescueParameter> RescueCRHF<F> {
             .expect("Bug in JF Primitives : bad padding of input for FSKS construction")
     }
 
-    /// Sponge hashing based on rescue permutation for Bls12_381 scalar field
-    /// for RATE 3 and CAPACITY 1. It allows input length multiple of the
-    /// RATE and variable output length
+    /// Sponge hashing based on rescue permutation for RATE 3 and CAPACITY 1. It
+    /// allows inputs with length that is a multiple of `CRHF_RATE` and
+    /// returns a vector of `num_outputs` elements.
     pub fn sponge_no_padding(input: &[F], num_output: usize) -> Result<Vec<F>, RescueError> {
         if input.len() % CRHF_RATE != 0 {
             return Err(RescueError::ParameterError(
@@ -71,8 +71,9 @@ impl<F: RescueParameter> RescueCRHF<F> {
 }
 
 impl<F: RescueParameter> RescuePRF<F> {
-    /// Pseudorandom function for Bls12_381 scalar field. It allows unrestricted
-    /// variable length input and number of output elements
+    /// Pseudorandom function based on rescue permutation for RATE 4. It allows
+    /// unrestricted variable length input and returns a vector of
+    /// `num_outputs` elements.
     pub fn full_state_keyed_sponge_with_padding(
         key: &F,
         input: &[F],
@@ -85,9 +86,9 @@ impl<F: RescueParameter> RescuePRF<F> {
             .expect("Bug in JF Primitives : bad padding of input for FSKS construction")
     }
 
-    /// Pseudorandom function for Bls12_381 scalar field. It allows unrestricted
-    /// variable length input and number of output elements. Return error if
-    /// input is not multiple of STATE_SIZE = 4
+    /// Pseudorandom function based on rescue permutation for RATE 4. It allows
+    /// inputs with length that is a multiple of `STATE_SIZE` and returns a
+    /// vector of `num_outputs` elements.
     pub fn full_state_keyed_sponge_no_padding(
         key: &F,
         input: &[F],
@@ -106,11 +107,13 @@ impl<F: RescueParameter> RescuePRF<F> {
             sponge: RescueSponge::from_state(state, &Permutation::default()),
         };
         r.sponge.absorb(&input);
+
+        // SQUEEZE PHASE
         Ok(r.sponge.squeeze_native_field_elements(num_outputs))
     }
 }
 
-impl<F: RescueParameter, const CHUNK_SIZE: usize> SpongeExt for RescueSponge<F, CHUNK_SIZE> {
+impl<F: RescueParameter, const RATE: usize> SpongeExt for RescueSponge<F, RATE> {
     type State = RescueVector<F>;
 
     fn from_state(state: Self::State, permutation: &Self::Parameters) -> Self {
@@ -213,7 +216,7 @@ impl<T: RescueParameter + PrimeField, const RATE: usize> CryptographicSponge
 }
 
 /// The interface for field-based cryptographic sponge.
-/// `CF` is the native field used by the cryptographic sponge implementation.
+/// `T` is the native field used by the cryptographic sponge implementation.
 impl<T: RescueParameter, const RATE: usize> FieldBasedCryptographicSponge<T>
     for RescueSponge<T, RATE>
 {

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -24,9 +24,9 @@ pub struct RescueSponge<F: RescueParameter, const CHUNK_SIZE: usize> {
 }
 
 /// CRHF
-pub type RescueSpongeCRHF<F> = RescueSponge<F, RATE>;
+pub type RescueCRH<F> = RescueSponge<F, RATE>;
 /// PRF
-pub type RescueSpongePRF<F> = RescueSponge<F, STATE_SIZE>;
+pub type RescuePRF<F> = RescueSponge<F, STATE_SIZE>;
 
 impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
     /// Sponge hashing based on rescue permutation for Bls12_381 scalar field
@@ -37,7 +37,7 @@ impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
         // of RATE
         assert_eq!(
             CHUNK_SIZE, RATE,
-            "CHUNK_SIZE must be equal to RATE. Perhaps you meant to use a RescueSpongePRF instead?"
+            "CHUNK_SIZE must be equal to RATE. Perhaps you meant to use a RescuePRF instead?"
         );
         let mut padded = input.to_vec();
         padded.push(F::one());
@@ -52,7 +52,7 @@ impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
     pub fn sponge_no_padding(input: &[F], num_output: usize) -> Result<Vec<F>, RescueError> {
         assert_eq!(
             CHUNK_SIZE, RATE,
-            "CHUNK_SIZE must be equal to RATE. Perhaps you meant to use a RescueSpongePRF instead?"
+            "CHUNK_SIZE must be equal to RATE. Perhaps you meant to use a RescuePRF instead?"
         );
         if input.len() % RATE != 0 {
             return Err(RescueError::ParameterError(
@@ -79,7 +79,8 @@ impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
     ) -> Vec<F> {
         assert_eq!(
             CHUNK_SIZE, STATE_SIZE,
-            "CHUNK_SIZE must be equal to STATE_SIZE. Perhaps you meant to use a RescueSpongeCRHF instead?");
+            "CHUNK_SIZE must be equal to STATE_SIZE. Perhaps you meant to use a RescueCRH instead?"
+        );
         let mut padded_input = input.to_vec();
         padded_input.push(F::one());
         pad_with_zeros(&mut padded_input, STATE_SIZE);
@@ -97,7 +98,8 @@ impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
     ) -> Result<Vec<F>, RescueError> {
         assert_eq!(
             CHUNK_SIZE, STATE_SIZE,
-            "CHUNK_SIZE must be equal to STATE_SIZE. Perhaps you meant to use a RescueSpongeCRHF instead?");
+            "CHUNK_SIZE must be equal to STATE_SIZE. Perhaps you meant to use a RescueCRH instead?"
+        );
         if input.len() % STATE_SIZE != 0 {
             return Err(RescueError::ParameterError(
                 "Rescue FSKS PRF Error: input to prf function is not multiple of STATE_SIZE."
@@ -331,8 +333,8 @@ mod test {
         assert_ne!(bytes1, bytes2);
 
         let sponge_param = Permutation::default();
-        let mut sponge1 = RescueSpongeCRHF::<F>::new(&sponge_param);
-        let mut sponge2 = RescueSpongeCRHF::<F>::new(&sponge_param);
+        let mut sponge1 = RescueCRH::<F>::new(&sponge_param);
+        let mut sponge2 = RescueCRH::<F>::new(&sponge_param);
 
         sponge1.absorb(&a);
         sponge2.absorb(&b);
@@ -393,7 +395,7 @@ mod test {
         let mut rng = test_rng();
         let sponge_param = Permutation::default();
         let elem = Fr::rand(&mut rng);
-        let mut sponge1 = RescueSpongeCRHF::<Fr>::new(&sponge_param);
+        let mut sponge1 = RescueCRH::<Fr>::new(&sponge_param);
         sponge1.absorb(&elem);
         let mut sponge2 = sponge1.clone();
 
@@ -407,11 +409,11 @@ mod test {
     #[test]
     fn test_macros() {
         let sponge_param = Permutation::default();
-        let mut sponge1 = RescueSpongeCRHF::<Fr>::new(&sponge_param);
+        let mut sponge1 = RescueCRH::<Fr>::new(&sponge_param);
         sponge1.absorb(&vec![1u8, 2, 3, 4, 5, 6]);
         sponge1.absorb(&Fr::from(114514u128));
 
-        let mut sponge2 = RescueSpongeCRHF::<Fr>::new(&sponge_param);
+        let mut sponge2 = RescueCRH::<Fr>::new(&sponge_param);
         absorb!(&mut sponge2, vec![1u8, 2, 3, 4, 5, 6], Fr::from(114514u128));
 
         let expected = sponge1.squeeze_native_field_elements(3);

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -1,0 +1,419 @@
+//! This file contains the APIs wrappers for ark-sponge
+
+use ark_ff::{BigInteger, PrimeField};
+use ark_sponge::{
+    Absorb, CryptographicSponge, FieldBasedCryptographicSponge, FieldElementSize, SpongeExt,
+};
+use ark_std::{string::ToString, vec, vec::Vec};
+use jf_utils::{field_switching, pad_with_zeros};
+use num_bigint::BigUint;
+
+use super::{errors::RescueError, Permutation, RescueParameter, RescueVector, RATE, STATE_SIZE};
+
+#[derive(Clone, Default)]
+/// A rescue hash function consists of a permutation function and
+/// an internal state.
+pub struct RescueSponge<F: RescueParameter, const ABSORB_RATE: usize> {
+    pub(crate) state: RescueVector<F>,
+}
+
+/// CRHF
+pub type RescueSpongeCRHF<F> = RescueSponge<F, 3>;
+/// PRF
+pub type RescueSpongePRF<F> = RescueSponge<F, 4>;
+
+impl<F: RescueParameter, const C: usize> RescueSponge<F, C> {
+    /// Sponge hashing based on rescue permutation for Bls12_381 scalar field
+    /// for RATE 3 and CAPACITY 1. It allows unrestricted variable length
+    /// input and number of output elements
+    pub fn sponge_with_padding(input: &[F], num_outputs: usize) -> Vec<F> {
+        // Pad input as follows: append a One, then pad with 0 until length is multiple
+        // of RATE
+        let mut padded = input.to_vec();
+        padded.push(F::one());
+        pad_with_zeros(&mut padded, RATE);
+        Self::sponge_no_padding(padded.as_slice(), num_outputs)
+            .expect("Bug in JF Primitives : bad padding of input for FSKS construction")
+    }
+
+    /// Sponge hashing based on rescue permutation for Bls12_381 scalar field
+    /// for RATE 3 and CAPACITY 1. It allows input length multiple of the
+    /// RATE and variable output length
+    pub fn sponge_no_padding(input: &[F], num_output: usize) -> Result<Vec<F>, RescueError> {
+        if input.len() % RATE != 0 {
+            return Err(RescueError::ParameterError(
+                "Rescue sponge Error : input to sponge hashing function is not multiple of RATE."
+                    .to_string(),
+            ));
+        }
+        // ABSORB PHASE
+        let mut r = Self::from_state(RescueVector::zero(), &Permutation::default());
+        r.absorb(&input);
+
+        // SQUEEZE PHASE
+        Ok(r.squeeze_native_field_elements(num_output))
+    }
+}
+
+impl<F: RescueParameter, const C: usize> RescueSponge<F, C> {
+    /// Pseudorandom function for Bls12_381 scalar field. It allows unrestricted
+    /// variable length input and number of output elements
+    pub fn full_state_keyed_sponge_with_padding(
+        key: &F,
+        input: &[F],
+        num_outputs: usize,
+    ) -> Vec<F> {
+        let mut padded_input = input.to_vec();
+        padded_input.push(F::one());
+        pad_with_zeros(&mut padded_input, STATE_SIZE);
+        Self::full_state_keyed_sponge_no_padding(key, padded_input.as_slice(), num_outputs)
+            .expect("Bug in JF Primitives : bad padding of input for FSKS construction")
+    }
+
+    /// Pseudorandom function for Bls12_381 scalar field. It allows unrestricted
+    /// variable length input and number of output elements. Return error if
+    /// input is not multiple of STATE_SIZE = 4
+    pub fn full_state_keyed_sponge_no_padding(
+        key: &F,
+        input: &[F],
+        num_outputs: usize,
+    ) -> Result<Vec<F>, RescueError> {
+        if input.len() % STATE_SIZE != 0 {
+            return Err(RescueError::ParameterError(
+                "Rescue FSKS PRF Error: input to prf function is not multiple of STATE_SIZE."
+                    .to_string(),
+            ));
+        }
+        // ABSORB PHASE
+        let mut state = RescueVector::zero();
+        state.vec[STATE_SIZE - 1] = *key;
+        let mut r = Self::from_state(state, &Permutation::default());
+        r.absorb(&input);
+        Ok(r.squeeze_native_field_elements(num_outputs))
+    }
+}
+
+impl<F: RescueParameter, const C: usize> SpongeExt for RescueSponge<F, C> {
+    type State = RescueVector<F>;
+
+    fn from_state(state: Self::State, _permutation: &Self::Parameters) -> Self {
+        Self { state }
+    }
+
+    fn into_state(self) -> Self::State {
+        self.state
+    }
+}
+
+impl<T: RescueParameter + PrimeField, const C: usize> CryptographicSponge for RescueSponge<T, C> {
+    /// Parameters used by the sponge.
+    type Parameters = Permutation<T>;
+
+    /// Initialize a new instance of the sponge.
+    fn new(_permutation: &Self::Parameters) -> Self {
+        Self {
+            state: RescueVector::default(),
+        }
+    }
+
+    /// Absorb an input into the sponge.
+    fn absorb(&mut self, input: &impl Absorb) {
+        let permutation = Permutation::default();
+
+        // let mut input_field_elements = input.to_sponge_field_elements_as_vec();
+        let input_field_elements = input.to_sponge_field_elements_as_vec();
+        // Pad input as follows: append a One, then pad with 0 until length is multiple
+        // of RATE
+        // input_field_elements.push(T::one());
+        // pad_with_zeros(&mut input_field_elements, RATE);
+
+        input_field_elements
+            .chunks_exact(C)
+            .into_iter()
+            .for_each(|chunk| {
+                let block = RescueVector::pad_smaller_chunk(chunk);
+                self.state.add_assign(&block);
+                self.state = permutation.eval(&self.state)
+            });
+    }
+
+    /// Squeeze `num_bytes` bytes from the sponge.
+    fn squeeze_bytes(&mut self, num_bytes: usize) -> Vec<u8> {
+        self.squeeze_bits(num_bytes)
+            .chunks(8)
+            .map(bools_to_u8)
+            .collect()
+    }
+
+    /// Squeeze `num_bits` bits from the sponge.
+    fn squeeze_bits(&mut self, num_bits: usize) -> Vec<bool> {
+        // we extract k number of field elements;
+        // each field elements will produce a maximum
+        // ```
+        // T::size_in_bits() - 129
+        // ```
+        // number of bits that is computational uniform.
+        #[cfg(debug_assertions)]
+        assert!(T::size_in_bits() > 129);
+
+        let permutation = Permutation::default();
+        let mut result = Vec::new();
+        let mut remaining = num_bits;
+
+        // we extract 3 elements with a hash call
+        let extracted_bits_per_elem = T::size_in_bits() - 129;
+        let mut elem_ctr = 0;
+        let mut extracted = self.state.vec;
+        self.state = permutation.eval(&self.state);
+
+        // modulus is 2^extracted_bits_per_elem
+        let modulus: BigUint = T::from(2u64).pow(&[extracted_bits_per_elem as u64]).into();
+
+        while remaining > extracted_bits_per_elem {
+            let e_int: BigUint = extracted[elem_ctr].into();
+            elem_ctr += 1;
+            if elem_ctr == 3 {
+                extracted = self.state.vec;
+                self.state = permutation.eval(&self.state);
+                elem_ctr = 0;
+            }
+
+            let extracted_bit = e_int % &modulus;
+            result.extend_from_slice(
+                &T::from(extracted_bit).into_repr().to_bits_le()[0..extracted_bits_per_elem],
+            );
+            remaining -= extracted_bits_per_elem;
+        }
+
+        let e_int: BigUint = extracted[elem_ctr].into();
+        let extracted_bit = e_int % &modulus;
+        result.extend_from_slice(&T::from(extracted_bit).into_repr().to_bits_le()[0..remaining]);
+
+        result
+    }
+
+    /// Squeeze `sizes.len()` field elements from the sponge, where the `i`-th
+    /// element of the output has size `sizes[i]`.
+    ///
+    /// If the implementation is field-based, to squeeze native field elements,
+    /// call `self.squeeze_native_field_elements` instead.
+    ///
+    /// TODO: Support general Field.
+    ///
+    /// Note that when `FieldElementSize` is `FULL`, the output is not strictly
+    /// uniform. Output space is uniform in \[0, 2^{F::MODULUS_BITS - 1}\]
+    fn squeeze_field_elements_with_sizes<F: PrimeField>(
+        &mut self,
+        sizes: &[FieldElementSize],
+    ) -> Vec<F> {
+        if T::size_in_bits() == F::size_in_bits() {
+            RescueSponge::<T, C>::squeeze_native_field_elements_with_sizes(self, sizes)
+                .iter()
+                .map(|x| field_switching(x))
+                .collect::<Vec<F>>()
+        } else {
+            // currently we do not support hashing into a non-native field
+            unimplemented!()
+        }
+    }
+
+    /// Squeeze `num_elements` nonnative field elements from the sponge.
+    ///
+    /// Because of rust limitation, for field-based implementation, using this
+    /// method to squeeze native field elements will have runtime casting
+    /// cost. For better efficiency, use `squeeze_native_field_elements`.
+    fn squeeze_field_elements<F: PrimeField>(&mut self, num_elements: usize) -> Vec<F> {
+        self.squeeze_field_elements_with_sizes::<F>(
+            vec![FieldElementSize::Full; num_elements].as_slice(),
+        )
+    }
+
+    /// Creates a new sponge with applied domain separation.
+    fn fork(&self, domain: &[u8]) -> Self {
+        let mut new_sponge = self.clone();
+
+        let mut input = Absorb::to_sponge_bytes_as_vec(&domain.len());
+        input.extend_from_slice(domain);
+        new_sponge.absorb(&input);
+
+        new_sponge
+    }
+}
+
+/// The interface for field-based cryptographic sponge.
+/// `CF` is the native field used by the cryptographic sponge implementation.
+impl<T: RescueParameter, const C: usize> FieldBasedCryptographicSponge<T> for RescueSponge<T, C> {
+    /// Squeeze `num_elements` field elements from the sponge.
+    fn squeeze_native_field_elements(&mut self, num_elements: usize) -> Vec<T> {
+        // SQUEEZE PHASE
+        let permutation = Permutation::default();
+        let mut result = vec![];
+        let mut remaining = num_elements;
+        // extract current rate before calling PRP again
+        loop {
+            let extract = remaining.min(RATE);
+            result.extend_from_slice(&self.state.vec[0..extract]);
+            remaining -= extract;
+            if remaining == 0 {
+                break;
+            }
+            self.state = permutation.eval(&self.state)
+        }
+        result
+    }
+
+    /// Squeeze `sizes.len()` field elements from the sponge, where the `i`-th
+    /// element of the output has size `sizes[i]`.
+    fn squeeze_native_field_elements_with_sizes(&mut self, sizes: &[FieldElementSize]) -> Vec<T> {
+        let mut all_full_sizes = true;
+        for size in sizes {
+            if *size != FieldElementSize::Full {
+                all_full_sizes = false;
+                break;
+            }
+        }
+
+        if all_full_sizes {
+            self.squeeze_native_field_elements(sizes.len())
+        } else {
+            // we do not currently want to output field elements other than T.
+            // This will be fixed once `squeeze_bytes` interfaces is fixed.
+            unimplemented!()
+        }
+    }
+}
+
+#[inline]
+fn bools_to_u8(input: &[bool]) -> u8 {
+    let mut res = 0;
+    for &e in input {
+        res <<= 1;
+        if e {
+            res += 1
+        }
+    }
+    res
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ark_bls12_381::Fr;
+    use ark_ff::{One, UniformRand};
+    use ark_sponge::{
+        absorb, collect_sponge_bytes, collect_sponge_field_elements, AbsorbWithLength,
+    };
+    use ark_std::test_rng;
+
+    fn assert_different_encodings<F: RescueParameter, A: Absorb>(a: &A, b: &A) {
+        let bytes1 = a.to_sponge_bytes_as_vec();
+        let bytes2 = b.to_sponge_bytes_as_vec();
+        assert_ne!(bytes1, bytes2);
+
+        let sponge_param = Permutation::default();
+        let mut sponge1 = RescueSpongeCRHF::<F>::new(&sponge_param);
+        let mut sponge2 = RescueSpongeCRHF::<F>::new(&sponge_param);
+
+        sponge1.absorb(&a);
+        sponge2.absorb(&b);
+
+        assert_ne!(
+            sponge1.squeeze_native_field_elements(3),
+            sponge2.squeeze_native_field_elements(3)
+        );
+    }
+
+    #[test]
+    fn single_field_element() {
+        let mut rng = test_rng();
+        let elem1 = Fr::rand(&mut rng);
+        let elem2 = elem1 + Fr::one();
+
+        assert_different_encodings::<Fr, _>(&elem1, &elem2)
+    }
+
+    #[test]
+    fn list_with_constant_size_element() {
+        let mut rng = test_rng();
+        let lst1: Vec<_> = (0..1024 * 8).map(|_| Fr::rand(&mut rng)).collect();
+        let mut lst2 = lst1.to_vec();
+        lst2[3] += Fr::one();
+
+        assert_different_encodings::<Fr, _>(&lst1, &lst2)
+    }
+
+    struct VariableSizeList(Vec<u8>);
+
+    impl Absorb for VariableSizeList {
+        fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
+            self.0.to_sponge_bytes_with_length(dest)
+        }
+
+        fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
+            self.0.to_sponge_field_elements_with_length(dest)
+        }
+    }
+
+    #[test]
+    fn list_with_nonconstant_size_element() {
+        let lst1 = vec![
+            VariableSizeList(vec![1u8, 2, 3, 4]),
+            VariableSizeList(vec![5, 6]),
+        ];
+        let lst2 = vec![
+            VariableSizeList(vec![1u8, 2]),
+            VariableSizeList(vec![3, 4, 5, 6]),
+        ];
+
+        assert_different_encodings::<Fr, _>(&lst1, &lst2);
+    }
+
+    #[test]
+    fn test_squeeze_cast_native() {
+        let mut rng = test_rng();
+        let sponge_param = Permutation::default();
+        let elem = Fr::rand(&mut rng);
+        let mut sponge1 = RescueSpongeCRHF::<Fr>::new(&sponge_param);
+        sponge1.absorb(&elem);
+        let mut sponge2 = sponge1.clone();
+
+        // those two should return same result
+        let squeezed1 = sponge1.squeeze_native_field_elements(5);
+        let squeezed2 = sponge2.squeeze_field_elements::<Fr>(5);
+
+        assert_eq!(squeezed1, squeezed2);
+    }
+
+    #[test]
+    fn test_macros() {
+        let sponge_param = Permutation::default();
+        let mut sponge1 = RescueSpongeCRHF::<Fr>::new(&sponge_param);
+        sponge1.absorb(&vec![1u8, 2, 3, 4, 5, 6]);
+        sponge1.absorb(&Fr::from(114514u128));
+
+        let mut sponge2 = RescueSpongeCRHF::<Fr>::new(&sponge_param);
+        absorb!(&mut sponge2, vec![1u8, 2, 3, 4, 5, 6], Fr::from(114514u128));
+
+        let expected = sponge1.squeeze_native_field_elements(3);
+        let actual = sponge2.squeeze_native_field_elements(3);
+
+        assert_eq!(actual, expected);
+
+        let mut expected = Vec::new();
+        vec![6u8, 5, 4, 3, 2, 1].to_sponge_bytes(&mut expected);
+        Fr::from(42u8).to_sponge_bytes(&mut expected);
+
+        let actual = collect_sponge_bytes!(vec![6u8, 5, 4, 3, 2, 1], Fr::from(42u8));
+
+        assert_eq!(actual, expected);
+
+        let mut expected: Vec<Fr> = Vec::new();
+        vec![6u8, 5, 4, 3, 2, 1].to_sponge_field_elements(&mut expected);
+        Fr::from(42u8).to_sponge_field_elements(&mut expected);
+
+        let actual: Vec<Fr> =
+            collect_sponge_field_elements!(vec![6u8, 5, 4, 3, 2, 1], Fr::from(42u8));
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -229,7 +229,7 @@ impl<T: RescueParameter, const CHUNK_SIZE: usize> FieldBasedCryptographicSponge<
         let mut remaining = num_elements;
         // extract current rate before calling PRP again
         loop {
-            let extract = remaining.min(RATE);
+            let extract = remaining.min(CHUNK_SIZE);
             result.extend_from_slice(&self.state.vec[0..extract]);
             remaining -= extract;
             if remaining == 0 {

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -24,7 +24,7 @@ struct RescueSponge<F: RescueParameter, const CHUNK_SIZE: usize> {
 }
 
 /// CRHF
-pub struct RescueCRH<F: RescueParameter> {
+pub struct RescueCRHF<F: RescueParameter> {
     sponge: RescueSponge<F, RATE>,
 }
 
@@ -33,7 +33,7 @@ pub struct RescuePRF<F: RescueParameter> {
     sponge: RescueSponge<F, STATE_SIZE>,
 }
 
-impl<F: RescueParameter> RescueCRH<F> {
+impl<F: RescueParameter> RescueCRHF<F> {
     /// Sponge hashing based on rescue permutation for Bls12_381 scalar field
     /// for RATE 3 and CAPACITY 1. It allows unrestricted variable length
     /// input and number of output elements

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -24,9 +24,9 @@ pub struct RescueSponge<F: RescueParameter, const CHUNK_SIZE: usize> {
 }
 
 /// CRHF
-pub type RescueSpongeCRHF<F> = RescueSponge<F, 3>;
+pub type RescueSpongeCRHF<F> = RescueSponge<F, RATE>;
 /// PRF
-pub type RescueSpongePRF<F> = RescueSponge<F, 4>;
+pub type RescueSpongePRF<F> = RescueSponge<F, STATE_SIZE>;
 
 impl<F: RescueParameter, const CHUNK_SIZE: usize> RescueSponge<F, CHUNK_SIZE> {
     /// Sponge hashing based on rescue permutation for Bls12_381 scalar field

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -11,7 +11,7 @@ use super::SignatureScheme;
 use crate::{
     constants::CS_ID_SCHNORR,
     errors::PrimitivesError,
-    rescue::{Permutation, RescueParameter},
+    rescue::{sponge::RescueSpongeCRHF, RescueParameter},
     utils::curve_cofactor,
 };
 use ark_ec::{
@@ -293,15 +293,14 @@ where
     /// Signature function
     #[allow(non_snake_case)]
     pub fn sign<B: AsRef<[u8]>>(&self, msg: &[F], csid: B) -> Signature<P> {
-        let hash = Permutation::default();
         // Do we want to remove the instance description?
         let instance_description = F::from_be_bytes_mod_order(csid.as_ref());
         let mut msg_input = vec![instance_description, fr_to_fq::<F, P>(&self.sk.0)];
         msg_input.extend(msg.iter());
 
-        let r = fq_to_fr::<F, P>(&hash.sponge_with_padding(&msg_input, 1)[0]);
+        let r = fq_to_fr::<F, P>(&RescueSpongeCRHF::sponge_with_padding(&msg_input, 1)[0]);
         let R = Group::mul(&GroupProjective::<P>::prime_subgroup_generator(), &r);
-        let c = self.vk.challenge(&hash, &R, msg, csid);
+        let c = self.vk.challenge(&R, msg, csid);
         let s = c * self.sk.0 + r;
 
         Signature { s, R }
@@ -366,8 +365,7 @@ where
         }
 
         // restrictive cofactorless verification
-        let hash = Permutation::<F>::default();
-        let c = self.challenge(&hash, &sig.R, msg, csid);
+        let c = self.challenge(&sig.R, msg, csid);
 
         let base = GroupProjective::<P>::prime_subgroup_generator();
         let x = Group::mul(&base, &sig.s);
@@ -393,7 +391,6 @@ where
     #[allow(non_snake_case)]
     fn challenge<B: AsRef<[u8]>>(
         &self,
-        hash: &Permutation<F>,
         R: &GroupProjective<P>,
         msg: &[F],
         csid: B,
@@ -413,7 +410,7 @@ where
             ]
         };
         challenge_input.extend(msg);
-        let challenge_fq = hash.sponge_with_padding(&challenge_input, 1)[0];
+        let challenge_fq = RescueSpongeCRHF::sponge_with_padding(&challenge_input, 1)[0];
 
         // this masking will drop the last byte, and the resulting
         // challenge will be 248 bits

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -11,7 +11,7 @@ use super::SignatureScheme;
 use crate::{
     constants::CS_ID_SCHNORR,
     errors::PrimitivesError,
-    rescue::{sponge::RescueCRH, RescueParameter},
+    rescue::{sponge::RescueCRHF, RescueParameter},
     utils::curve_cofactor,
 };
 use ark_ec::{
@@ -298,7 +298,7 @@ where
         let mut msg_input = vec![instance_description, fr_to_fq::<F, P>(&self.sk.0)];
         msg_input.extend(msg.iter());
 
-        let r = fq_to_fr::<F, P>(&RescueCRH::sponge_with_padding(&msg_input, 1)[0]);
+        let r = fq_to_fr::<F, P>(&RescueCRHF::sponge_with_padding(&msg_input, 1)[0]);
         let R = Group::mul(&GroupProjective::<P>::prime_subgroup_generator(), &r);
         let c = self.vk.challenge(&R, msg, csid);
         let s = c * self.sk.0 + r;
@@ -410,7 +410,7 @@ where
             ]
         };
         challenge_input.extend(msg);
-        let challenge_fq = RescueCRH::sponge_with_padding(&challenge_input, 1)[0];
+        let challenge_fq = RescueCRHF::sponge_with_padding(&challenge_input, 1)[0];
 
         // this masking will drop the last byte, and the resulting
         // challenge will be 248 bits

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -11,7 +11,7 @@ use super::SignatureScheme;
 use crate::{
     constants::CS_ID_SCHNORR,
     errors::PrimitivesError,
-    rescue::{sponge::RescueSpongeCRHF, RescueParameter},
+    rescue::{sponge::RescueCRH, RescueParameter},
     utils::curve_cofactor,
 };
 use ark_ec::{
@@ -298,7 +298,7 @@ where
         let mut msg_input = vec![instance_description, fr_to_fq::<F, P>(&self.sk.0)];
         msg_input.extend(msg.iter());
 
-        let r = fq_to_fr::<F, P>(&RescueSpongeCRHF::sponge_with_padding(&msg_input, 1)[0]);
+        let r = fq_to_fr::<F, P>(&RescueCRH::sponge_with_padding(&msg_input, 1)[0]);
         let R = Group::mul(&GroupProjective::<P>::prime_subgroup_generator(), &r);
         let c = self.vk.challenge(&R, msg, csid);
         let s = c * self.sk.0 + r;
@@ -410,7 +410,7 @@ where
             ]
         };
         challenge_input.extend(msg);
-        let challenge_fq = RescueSpongeCRHF::sponge_with_padding(&challenge_input, 1)[0];
+        let challenge_fq = RescueCRH::sponge_with_padding(&challenge_input, 1)[0];
 
         // this masking will drop the last byte, and the resulting
         // challenge will be 248 bits


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This is a WIP. 

The refactor defines new explicit types for CRHF and PRF which are sponges that internally use the Rescue `Permutation`, and as such is more aligned with the CAPE spec.

By following the sponge API we are able to re-use code shared between the above two functionalities.

It should then be then easier to make the circuits more generic by also defining and implementing a trait like [CryptographicSpongeVar](https://github.com/arkworks-rs/sponge/blob/master/src/constraints/mod.rs#L101), though we'd probably need to define our own due to a dependency on a R1CS `ConstraintSystem`.

closes: https://github.com/EspressoSystems/jellyfish/issues/15

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
