### PR TITLE
`SignatureScheme` trait bounds

### DIFF
--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -20,7 +20,7 @@ derivative = { version = "2", features = ["use_core"] }
 displaydoc = { version = "0.2.3", default-features = false }
 downcast-rs = { version = "1.2.0", default-features = false }
 dyn-clone = "^1.0"
-espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", branch = "main" }
+espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.0" }
 hashbrown = "0.12.3"
 itertools = { version = "0.10.1", default-features = false }
 jf-primitives = { path = "../primitives", default-features = false }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,7 +24,7 @@ crypto_box = "0.8.1"
 derivative = { version = "2", features = ["use_core"] }
 digest = { version = "0.10.1", default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
-espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", branch = "main" }
+espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.0" }
 generic-array = { version = "^0.14", default-features = false }
 itertools = { version = "0.10.1", default-features = false, features = [ "use_alloc" ] }
 jf-relation = { path = "../relation", default-features = false }

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -11,3 +11,10 @@ pub const CS_ID_SCHNORR: &str = "SCHNORR_WITH_RESCUE_HASH_v01";
 
 /// ciphersuite identifier for BLS signature
 pub const CS_ID_BLS_SIG_NAIVE: &str = "BLS_SIG_WITH_NAIVE_HtG_v01";
+
+/// Size in bytes of a secret key in our BLS signature scheme.
+pub const BLS_SIG_KEY_SIZE: usize = 32;
+/// Size in bytes of a signature in our BLS signature scheme.
+pub const BLS_SIG_SIGNATURE_SIZE: usize = 96;
+/// Size in bytes of a verification key in our BLS signature scheme.
+pub const BLS_SIG_VERKEY_SIZE: usize = 192;

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -27,14 +27,6 @@ use zeroize::Zeroize;
 #[derive(Clone, Debug, Zeroize)]
 pub struct BLSSignKey(SecretKey);
 
-impl core::ops::Deref for BLSSignKey {
-    type Target = SecretKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl CanonicalSerialize for BLSSignKey {
     fn serialized_size(&self) -> usize {
         BLS_SIG_KEY_SIZE
@@ -64,15 +56,7 @@ impl CanonicalDeserialize for BLSSignKey {
 /// Newtype wrapper for a BLS Signature.
 #[tagged(tag::BLSSIG)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BLSSignature(Signature);
-
-impl core::ops::Deref for BLSSignature {
-    type Target = Signature;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub struct BLSSignature(pub(crate) Signature);
 
 impl CanonicalSerialize for BLSSignature {
     fn serialized_size(&self) -> usize {
@@ -104,14 +88,6 @@ impl CanonicalDeserialize for BLSSignature {
 #[tagged(tag::BLSVERKEY)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BLSVerKey(PublicKey);
-
-impl core::ops::Deref for BLSVerKey {
-    type Target = PublicKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl CanonicalSerialize for BLSVerKey {
     fn serialized_size(&self) -> usize {
@@ -190,7 +166,7 @@ impl SignatureScheme for BLSSignatureScheme {
         msg: M,
         _prng: &mut R,
     ) -> Result<Self::Signature, PrimitivesError> {
-        Ok(BLSSignature(sk.sign(
+        Ok(BLSSignature(sk.0.sign(
             msg.as_ref(),
             Self::CS_ID.as_bytes(),
             &[],
@@ -204,7 +180,14 @@ impl SignatureScheme for BLSSignatureScheme {
         msg: M,
         sig: &Self::Signature,
     ) -> Result<(), PrimitivesError> {
-        match sig.verify(false, msg.as_ref(), Self::CS_ID.as_bytes(), &[], vk, true) {
+        match sig.0.verify(
+            false,
+            msg.as_ref(),
+            Self::CS_ID.as_bytes(),
+            &[],
+            &vk.0,
+            true,
+        ) {
             BLST_ERROR::BLST_SUCCESS => Ok(()),
             e => Err(PrimitivesError::VerificationError(format!("{:?}", e))),
         }

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -20,10 +20,11 @@ use espresso_systems_common::jellyfish::tag;
 use tagged_base64::tagged;
 
 pub use blst::min_sig::{PublicKey, SecretKey, Signature};
+use zeroize::Zeroize;
 
 /// Newtype wrapper for a BLS Signing Key.
 #[tagged(tag::BLSSIGNINGKEY)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Zeroize)]
 pub struct BLSSignKey(SecretKey);
 
 impl core::ops::Deref for BLSSignKey {

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -27,6 +27,14 @@ use zeroize::Zeroize;
 #[derive(Clone, Debug, Zeroize)]
 pub struct BLSSignKey(SecretKey);
 
+impl core::ops::Deref for BLSSignKey {
+    type Target = SecretKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl CanonicalSerialize for BLSSignKey {
     fn serialized_size(&self) -> usize {
         BLS_SIG_KEY_SIZE
@@ -64,7 +72,15 @@ impl Eq for BLSSignKey {}
 /// Newtype wrapper for a BLS Signature.
 #[tagged(tag::BLS_SIG)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BLSSignature(pub(crate) Signature);
+pub struct BLSSignature(Signature);
+
+impl core::ops::Deref for BLSSignature {
+    type Target = Signature;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl CanonicalSerialize for BLSSignature {
     fn serialized_size(&self) -> usize {
@@ -96,6 +112,14 @@ impl CanonicalDeserialize for BLSSignature {
 #[tagged(tag::BLS_VER_KEY)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BLSVerKey(PublicKey);
+
+impl core::ops::Deref for BLSVerKey {
+    type Target = PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl CanonicalSerialize for BLSVerKey {
     fn serialized_size(&self) -> usize {
@@ -174,7 +198,7 @@ impl SignatureScheme for BLSSignatureScheme {
         msg: M,
         _prng: &mut R,
     ) -> Result<Self::Signature, PrimitivesError> {
-        Ok(BLSSignature(sk.0.sign(
+        Ok(BLSSignature(sk.sign(
             msg.as_ref(),
             Self::CS_ID.as_bytes(),
             &[],
@@ -188,14 +212,7 @@ impl SignatureScheme for BLSSignatureScheme {
         msg: M,
         sig: &Self::Signature,
     ) -> Result<(), PrimitivesError> {
-        match sig.0.verify(
-            false,
-            msg.as_ref(),
-            Self::CS_ID.as_bytes(),
-            &[],
-            &vk.0,
-            true,
-        ) {
+        match sig.verify(false, msg.as_ref(), Self::CS_ID.as_bytes(), &[], vk, true) {
             BLST_ERROR::BLST_SUCCESS => Ok(()),
             e => Err(PrimitivesError::VerificationError(format!("{:?}", e))),
         }

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -3,21 +3,30 @@
 use super::SignatureScheme;
 use crate::{constants::CS_ID_BLS_SIG_NAIVE, errors::PrimitivesError};
 
-use ark_serialize::CanonicalSerialize;
-use ark_serialize::SerializationError;
-use ark_std::fmt::Write;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{
+    convert::TryInto,
     format,
     rand::{CryptoRng, RngCore},
 };
 
-use blst::{min_sig::*, BLST_ERROR};
+use blst::BLST_ERROR;
+use espresso_systems_common::jellyfish::tag;
+use tagged_base64::tagged;
 
-pub use blst::min_sig::{PublicKey as BLSVerKey, SecretKey, Signature as BLSSignature};
-use serde::{Deserialize, Serialize, Serializer};
+pub use blst::min_sig::{PublicKey, SecretKey, Signature};
 
-#[derive(Debug, Clone, CanonicalSerialize)]
-pub struct BLSSignKey(pub SecretKey);
+/// Size in bytes of a secret key in our BLS signature scheme.
+pub const BLS_SIG_KEY_SIZE: usize = 32;
+/// Size in bytes of a signature in our BLS signature scheme.
+pub const BLS_SIG_SIGNATURE_SIZE: usize = 96;
+/// Size in bytes of a verification key in our BLS signature scheme.
+pub const BLS_SIG_VERKEY_SIZE: usize = 192;
+
+/// Newtype wrapper for a BLS Signing Key.
+#[tagged(tag::BLSSIGNINGKEY)]
+#[derive(Clone, Debug)]
+pub struct BLSSignKey(SecretKey);
 
 impl core::ops::Deref for BLSSignKey {
     type Target = SecretKey;
@@ -27,18 +36,104 @@ impl core::ops::Deref for BLSSignKey {
     }
 }
 
-impl Serialize for BLSSignKey {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let out = &self.0.serialize();
-        serializer.serialize_newtype_struct("SecretKey", out)
+impl CanonicalSerialize for BLSSignKey {
+    fn serialized_size(&self) -> usize {
+        BLS_SIG_KEY_SIZE
+    }
+
+    fn serialize<W: ark_serialize::Write>(&self, writer: W) -> Result<(), SerializationError> {
+        let bytes = &self.0.serialize();
+        CanonicalSerialize::serialize(bytes.as_ref(), writer)
     }
 }
 
-impl<'de> Deserialize<'de> for BLSSignKey {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Deserialize::deserialize(deserializer)
+impl CanonicalDeserialize for BLSSignKey {
+    fn deserialize<R: ark_serialize::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = <usize as ark_serialize::CanonicalDeserialize>::deserialize(&mut reader)?;
+        if len != BLS_SIG_KEY_SIZE {
+            return Err(SerializationError::InvalidData);
+        }
+
+        let mut key = [0u8; BLS_SIG_KEY_SIZE];
+        reader.read_exact(&mut key)?;
+        Ok(Self(SecretKey::deserialize(&key).unwrap()))
     }
 }
+
+/// Newtype wrapper for a BLS Signature.
+#[tagged(tag::BLSSIG)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BLSSignature(Signature);
+
+impl core::ops::Deref for BLSSignature {
+    type Target = Signature;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl CanonicalSerialize for BLSSignature {
+    fn serialized_size(&self) -> usize {
+        BLS_SIG_SIGNATURE_SIZE
+    }
+
+    fn serialize<W: ark_serialize::Write>(&self, writer: W) -> Result<(), SerializationError> {
+        let bytes = &self.0.serialize();
+        CanonicalSerialize::serialize(bytes.as_ref(), writer)
+    }
+}
+
+impl CanonicalDeserialize for BLSSignature {
+    fn deserialize<R: ark_serialize::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = <usize as ark_serialize::CanonicalDeserialize>::deserialize(&mut reader)?;
+        if len != BLS_SIG_SIGNATURE_SIZE {
+            return Err(SerializationError::InvalidData);
+        }
+
+        let mut sig = [0u8; BLS_SIG_SIGNATURE_SIZE];
+        reader.read_exact(&mut sig)?;
+        Ok(Self(Signature::deserialize(&sig).unwrap()))
+    }
+}
+
+/// Newtype wrapper for a BLS Verification Key.
+#[tagged(tag::BLSVERKEY)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BLSVerKey(PublicKey);
+
+impl core::ops::Deref for BLSVerKey {
+    type Target = PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl CanonicalSerialize for BLSVerKey {
+    fn serialized_size(&self) -> usize {
+        BLS_SIG_VERKEY_SIZE
+    }
+
+    fn serialize<W: ark_serialize::Write>(&self, writer: W) -> Result<(), SerializationError> {
+        let bytes = &self.0.serialize();
+        CanonicalSerialize::serialize(bytes.as_ref(), writer)
+    }
+}
+
+impl CanonicalDeserialize for BLSVerKey {
+    fn deserialize<R: ark_serialize::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = <usize as ark_serialize::CanonicalDeserialize>::deserialize(&mut reader)?;
+        if len != BLS_SIG_VERKEY_SIZE {
+            return Err(SerializationError::InvalidData);
+        }
+
+        let mut key = [0u8; BLS_SIG_VERKEY_SIZE];
+        reader.read_exact(&mut key)?;
+        Ok(Self(PublicKey::deserialize(&key).unwrap()))
+    }
+}
+
 /// BLS signature scheme. Imports blst library.
 pub struct BLSSignatureScheme;
 
@@ -80,7 +175,7 @@ impl SignatureScheme for BLSSignatureScheme {
             Err(e) => return Err(PrimitivesError::InternalError(format!("{:?}", e))),
         };
         let vk = sk.sk_to_pk();
-        Ok((BLSSignKey(sk), vk))
+        Ok((BLSSignKey(sk), BLSVerKey(vk)))
     }
 
     /// Sign a message
@@ -90,7 +185,11 @@ impl SignatureScheme for BLSSignatureScheme {
         msg: M,
         _prng: &mut R,
     ) -> Result<Self::Signature, PrimitivesError> {
-        Ok(sk.sign(msg.as_ref(), Self::CS_ID.as_bytes(), &[]))
+        Ok(BLSSignature(sk.sign(
+            msg.as_ref(),
+            Self::CS_ID.as_bytes(),
+            &[],
+        )))
     }
 
     /// Verify a signature.
@@ -109,7 +208,7 @@ impl SignatureScheme for BLSSignatureScheme {
 
 #[cfg(test)]
 mod test {
-    use ark_std::test_rng;
+    use ark_std::{test_rng, vec::Vec};
 
     use super::*;
     use crate::signatures::tests::{failed_verification, sign_and_verify};
@@ -123,9 +222,27 @@ mod test {
     }
 
     #[test]
-    fn test_serialize() {
+    fn test_bls_sig_serde() {
         let rng = &mut test_rng();
         let parameters = BLSSignatureScheme::param_gen(Some(rng)).unwrap();
-        let (sk, pk) = BLSSignatureScheme::key_gen(&parameters, rng).unwrap();
+        let (sk, vk) = BLSSignatureScheme::key_gen(&parameters, rng).unwrap();
+
+        // serde for Verification Key
+        let mut keypair_bytes = Vec::new();
+        vk.serialize(&mut keypair_bytes).unwrap();
+        let keypair_de = BLSVerKey::deserialize(&keypair_bytes[..]).unwrap();
+        assert_eq!(vk, keypair_de);
+        // wrong byte length
+        assert!(BLSVerKey::deserialize(&keypair_bytes[1..]).is_err());
+
+        // serde for Signature
+        let message = "this is a test message";
+        let sig = BLSSignatureScheme::sign(&parameters, &sk, message.as_bytes(), rng).unwrap();
+        let mut sig_bytes = Vec::new();
+        sig.serialize(&mut sig_bytes).unwrap();
+        let sig_de = BLSSignature::deserialize(&sig_bytes[..]).unwrap();
+        assert_eq!(sig, sig_de);
+        // wrong byte length
+        assert!(BLSSignature::deserialize(&sig_bytes[1..]).is_err());
     }
 }

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -55,7 +55,9 @@ impl CanonicalDeserialize for BLSSignKey {
 
         let mut key = [0u8; BLS_SIG_KEY_SIZE];
         reader.read_exact(&mut key)?;
-        Ok(Self(SecretKey::deserialize(&key).unwrap()))
+        SecretKey::deserialize(&key)
+            .map(Self)
+            .map_err(|_| SerializationError::InvalidData)
     }
 }
 
@@ -92,7 +94,9 @@ impl CanonicalDeserialize for BLSSignature {
 
         let mut sig = [0u8; BLS_SIG_SIGNATURE_SIZE];
         reader.read_exact(&mut sig)?;
-        Ok(Self(Signature::deserialize(&sig).unwrap()))
+        Signature::deserialize(&sig)
+            .map(Self)
+            .map_err(|_| SerializationError::InvalidData)
     }
 }
 
@@ -129,7 +133,9 @@ impl CanonicalDeserialize for BLSVerKey {
 
         let mut key = [0u8; BLS_SIG_VERKEY_SIZE];
         reader.read_exact(&mut key)?;
-        Ok(Self(PublicKey::deserialize(&key).unwrap()))
+        PublicKey::deserialize(&key)
+            .map(Self)
+            .map_err(|_| SerializationError::InvalidData)
     }
 }
 

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -23,7 +23,7 @@ pub use blst::min_sig::{PublicKey, SecretKey, Signature};
 use zeroize::Zeroize;
 
 /// Newtype wrapper for a BLS Signing Key.
-#[tagged(tag::BLSSIGNINGKEY)]
+#[tagged(tag::BLS_SIGNING_KEY)]
 #[derive(Clone, Debug, Zeroize)]
 pub struct BLSSignKey(SecretKey);
 
@@ -54,7 +54,7 @@ impl CanonicalDeserialize for BLSSignKey {
 }
 
 /// Newtype wrapper for a BLS Signature.
-#[tagged(tag::BLSSIG)]
+#[tagged(tag::BLS_SIG)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BLSSignature(pub(crate) Signature);
 
@@ -85,7 +85,7 @@ impl CanonicalDeserialize for BLSSignature {
 }
 
 /// Newtype wrapper for a BLS Verification Key.
-#[tagged(tag::BLSVERKEY)]
+#[tagged(tag::BLS_VER_KEY)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BLSVerKey(PublicKey);
 

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -53,6 +53,14 @@ impl CanonicalDeserialize for BLSSignKey {
     }
 }
 
+impl PartialEq for BLSSignKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.serialize() == other.0.serialize()
+    }
+}
+
+impl Eq for BLSSignKey {}
+
 /// Newtype wrapper for a BLS Signature.
 #[tagged(tag::BLS_SIG)]
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -1,7 +1,12 @@
 //! BLS Signature Scheme
 
 use super::SignatureScheme;
-use crate::{constants::CS_ID_BLS_SIG_NAIVE, errors::PrimitivesError};
+use crate::{
+    constants::{
+        BLS_SIG_KEY_SIZE, BLS_SIG_SIGNATURE_SIZE, BLS_SIG_VERKEY_SIZE, CS_ID_BLS_SIG_NAIVE,
+    },
+    errors::PrimitivesError,
+};
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{
@@ -15,13 +20,6 @@ use espresso_systems_common::jellyfish::tag;
 use tagged_base64::tagged;
 
 pub use blst::min_sig::{PublicKey, SecretKey, Signature};
-
-/// Size in bytes of a secret key in our BLS signature scheme.
-pub const BLS_SIG_KEY_SIZE: usize = 32;
-/// Size in bytes of a signature in our BLS signature scheme.
-pub const BLS_SIG_SIGNATURE_SIZE: usize = 96;
-/// Size in bytes of a verification key in our BLS signature scheme.
-pub const BLS_SIG_VERKEY_SIZE: usize = 192;
 
 /// Newtype wrapper for a BLS Signing Key.
 #[tagged(tag::BLSSIGNINGKEY)]

--- a/primitives/src/signatures/mod.rs
+++ b/primitives/src/signatures/mod.rs
@@ -8,6 +8,7 @@ pub mod schnorr;
 pub use bls::BLSSignatureScheme;
 pub use schnorr::SchnorrSignatureScheme;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 /// Trait definition for a signature scheme.
 // A signature scheme is associated with a hash function H that is
@@ -18,7 +19,7 @@ pub trait SignatureScheme {
     const CS_ID: &'static str;
 
     /// Signing key.
-    type SigningKey: Clone + Send + Sync;
+    type SigningKey: Clone + Send + Sync + Zeroize;
 
     /// Verification key
     type VerificationKey: Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize;

--- a/primitives/src/signatures/mod.rs
+++ b/primitives/src/signatures/mod.rs
@@ -7,6 +7,7 @@ pub mod bls;
 pub mod schnorr;
 pub use bls::BLSSignatureScheme;
 pub use schnorr::SchnorrSignatureScheme;
+use serde::{Deserialize, Serialize};
 
 /// Trait definition for a signature scheme.
 // A signature scheme is associated with a hash function H that is
@@ -17,16 +18,16 @@ pub trait SignatureScheme {
     const CS_ID: &'static str;
 
     /// Signing key.
-    type SigningKey;
+    type SigningKey: Clone + Send + Sync;
 
     /// Verification key
-    type VerificationKey;
+    type VerificationKey: Clone + Send + Sync;
 
     /// Public Parameter
     type PublicParameter;
 
     /// Signature
-    type Signature;
+    type Signature: Clone;
 
     /// A message is &\[MessageUnit\]
     type MessageUnit;

--- a/primitives/src/signatures/mod.rs
+++ b/primitives/src/signatures/mod.rs
@@ -21,13 +21,13 @@ pub trait SignatureScheme {
     type SigningKey: Clone + Send + Sync;
 
     /// Verification key
-    type VerificationKey: Clone + Send + Sync;
+    type VerificationKey: Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize;
 
     /// Public Parameter
     type PublicParameter;
 
     /// Signature
-    type Signature: Clone;
+    type Signature: Clone + for<'a> Deserialize<'a> + Serialize;
 
     /// A message is &\[MessageUnit\]
     type MessageUnit;

--- a/primitives/src/signatures/mod.rs
+++ b/primitives/src/signatures/mod.rs
@@ -19,7 +19,7 @@ pub trait SignatureScheme {
     const CS_ID: &'static str;
 
     /// Signing key.
-    type SigningKey: Clone + Send + Sync + Zeroize;
+    type SigningKey: Clone + Send + Sync + Zeroize + for<'a> Deserialize<'a> + Serialize;
 
     /// Verification key
     type VerificationKey: Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize;

--- a/primitives/src/signatures/mod.rs
+++ b/primitives/src/signatures/mod.rs
@@ -6,10 +6,10 @@ use ark_std::rand::{CryptoRng, RngCore};
 pub mod bls;
 pub mod schnorr;
 pub use bls::BLSSignatureScheme;
+use core::fmt::Debug;
 pub use schnorr::SchnorrSignatureScheme;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
-
 /// Trait definition for a signature scheme.
 // A signature scheme is associated with a hash function H that is
 // to be used for challenge generation.
@@ -19,19 +19,19 @@ pub trait SignatureScheme {
     const CS_ID: &'static str;
 
     /// Signing key.
-    type SigningKey: Clone + Send + Sync + Zeroize + for<'a> Deserialize<'a> + Serialize;
+    type SigningKey: Debug + Clone + Send + Sync + Zeroize + for<'a> Deserialize<'a> + Serialize;
 
     /// Verification key
-    type VerificationKey: Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize;
+    type VerificationKey: Debug + Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize;
 
     /// Public Parameter
     type PublicParameter;
 
     /// Signature
-    type Signature: Clone + for<'a> Deserialize<'a> + Serialize;
+    type Signature: Debug + Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize;
 
     /// A message is &\[MessageUnit\]
-    type MessageUnit;
+    type MessageUnit: Debug + Clone + Send + Sync;
 
     /// generate public parameters from RNG.
     /// If the RNG is not presented, use the default group generator.

--- a/primitives/src/signatures/mod.rs
+++ b/primitives/src/signatures/mod.rs
@@ -19,16 +19,38 @@ pub trait SignatureScheme {
     const CS_ID: &'static str;
 
     /// Signing key.
-    type SigningKey: Debug + Clone + Send + Sync + Zeroize + for<'a> Deserialize<'a> + Serialize;
+    type SigningKey: Debug
+        + Clone
+        + Send
+        + Sync
+        + Zeroize
+        + for<'a> Deserialize<'a>
+        + Serialize
+        + PartialEq
+        + Eq;
 
     /// Verification key
-    type VerificationKey: Debug + Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize;
+    type VerificationKey: Debug
+        + Clone
+        + Send
+        + Sync
+        + for<'a> Deserialize<'a>
+        + Serialize
+        + PartialEq
+        + Eq;
 
     /// Public Parameter
     type PublicParameter;
 
     /// Signature
-    type Signature: Debug + Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize;
+    type Signature: Debug
+        + Clone
+        + Send
+        + Sync
+        + for<'a> Deserialize<'a>
+        + Serialize
+        + PartialEq
+        + Eq;
 
     /// A message is &\[MessageUnit\]
     type MessageUnit: Debug + Clone + Send + Sync;

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -102,6 +102,7 @@ where
 // =====================================================
 // Signing key
 // =====================================================
+#[tagged(tag::SCHNORR_SIGNING_KEY)]
 #[derive(
     Clone, Hash, Default, Zeroize, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize, Debug,
 )]

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -127,7 +127,7 @@ impl<F: PrimeField> SignKey<F> {
 
 /// Signature public verification key
 // derive zeroize here so that keypair can be zeroized
-#[tagged(tag::SCHNORRVERKEY)]
+#[tagged(tag::SCHNORR_VER_KEY)]
 #[derive(CanonicalSerialize, CanonicalDeserialize, Derivative)]
 #[derivative(
     Debug(bound = "P: Parameters"),
@@ -196,7 +196,7 @@ impl<P: Parameters> VerKey<P> {
 
 /// Signature secret key pair used to sign messages
 // make sure sk can be zeroized
-#[tagged(tag::SIGNKEYPAIR)]
+#[tagged(tag::SCHNORR_KEY_PAIR)]
 #[derive(CanonicalSerialize, CanonicalDeserialize, Derivative)]
 #[derivative(
     Debug(bound = "P: Parameters"),
@@ -217,7 +217,7 @@ where
 // =====================================================
 
 /// The signature of Schnorr signature scheme
-#[tagged(tag::SIG)]
+#[tagged(tag::SCHNORR_SIG)]
 #[derive(CanonicalSerialize, CanonicalDeserialize, Derivative)]
 #[derivative(
     Debug(bound = "P: Parameters"),

--- a/primitives/src/vrf/blsvrf.rs
+++ b/primitives/src/vrf/blsvrf.rs
@@ -101,7 +101,7 @@ impl Vrf for BLSVRFScheme {
         _pp: &Self::PublicParameter,
         proof: &Self::Proof,
     ) -> Result<Self::Output, PrimitivesError> {
-        let proof_serialized = proof.serialize();
+        let proof_serialized = proof.0.serialize();
         let mut hasher = (*self.hasher).box_clone();
         hasher.update(&proof_serialized);
         let output = hasher.finalize();
@@ -151,7 +151,7 @@ mod test {
 
         // check the VRF output vs. hashing the proof directly
         let mut hasher = H::new();
-        hasher.update(vrf_proof.serialize());
+        hasher.update(vrf_proof.0.serialize());
         let direct_hash_output = hasher.finalize().to_vec();
         assert_eq!(direct_hash_output, vrf_output);
 

--- a/primitives/src/vrf/blsvrf.rs
+++ b/primitives/src/vrf/blsvrf.rs
@@ -101,7 +101,7 @@ impl Vrf for BLSVRFScheme {
         _pp: &Self::PublicParameter,
         proof: &Self::Proof,
     ) -> Result<Self::Output, PrimitivesError> {
-        let proof_serialized = proof.0.serialize();
+        let proof_serialized = proof.serialize();
         let mut hasher = (*self.hasher).box_clone();
         hasher.update(&proof_serialized);
         let output = hasher.finalize();
@@ -151,7 +151,7 @@ mod test {
 
         // check the VRF output vs. hashing the proof directly
         let mut hasher = H::new();
-        hasher.update(vrf_proof.0.serialize());
+        hasher.update(vrf_proof.serialize());
         let direct_hash_output = hasher.finalize().to_vec();
         assert_eq!(direct_hash_output, vrf_output);
 

--- a/utilities/src/serialize.rs
+++ b/utilities/src/serialize.rs
@@ -9,7 +9,7 @@
 use ark_std::vec::Vec;
 use serde::{Deserialize, Serialize};
 
-/// A helper for converting CanonicalSerde bytes to standard Serde bytes.
+/// A helper for converting ark_serialize::CanonicalSerialize bytes to standard Serde bytes.
 /// use this struct as intermediate target instead of directly deriving
 /// serde::Serialize/Deserialize to avoid implementation of Visitors.
 #[derive(Serialize, Deserialize)]

--- a/utilities/src/serialize.rs
+++ b/utilities/src/serialize.rs
@@ -9,9 +9,9 @@
 use ark_std::vec::Vec;
 use serde::{Deserialize, Serialize};
 
-/// A helper for converting ark_serialize::CanonicalSerialize bytes to standard Serde bytes.
-/// use this struct as intermediate target instead of directly deriving
-/// serde::Serialize/Deserialize to avoid implementation of Visitors.
+/// A helper for converting ark_serialize::CanonicalSerialize bytes to standard
+/// Serde bytes. Use this struct as intermediate target instead of directly
+/// deriving serde::Serialize/Deserialize to avoid implementation of Visitors.
 #[derive(Serialize, Deserialize)]
 pub struct CanonicalBytes(pub Vec<u8>);
 


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Add trait bounds on `SignatureScheme` trait.
Bounds not yet added for `SigningKey`, pending discussion in [espresso-common](https://github.com/EspressoSystems/espresso-systems-common/issues/7).

closes: #145, #155

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
