### PR TITLE
Ergonomic `MerkleTreeGadget`

### DIFF
--- a/primitives/src/circuit/merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree.rs
@@ -49,7 +49,7 @@ pub trait MerkleTreeGadget<F: RescueParameter> {
     ) -> Result<MerklePathVar, CircuitError>;
 
     /// Allocate a variable for the merkle root.
-    fn create_root_variable(&mut self, root: F) -> Result<Variable, CircuitError>;
+    fn create_root_variable(&mut self, root: NodeVal<F>) -> Result<Variable, CircuitError>;
 
     /// Given a leaf element and its merkle proof,
     /// return `BoolVar` indicating the correctness of its membership proof

--- a/primitives/src/circuit/merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree.rs
@@ -21,6 +21,7 @@ use jf_relation::{errors::CircuitError, BoolVar, Circuit, PlonkCircuit, Variable
 
 type NodeVal<F> = <RescueMerkleTree<F> as MerkleTreeScheme>::NodeValue;
 type MembershipProof<F> = <RescueMerkleTree<F> as MerkleTreeScheme>::MembershipProof;
+type Element<F> = <RescueMerkleTree<F> as MerkleTreeScheme>::Element;
 use typenum::U3;
 
 #[derive(Debug, Clone)]
@@ -39,7 +40,7 @@ pub struct LeafVar {
 /// Gadgets for rescue-based merkle tree
 pub trait MerkleTreeGadget<F: RescueParameter> {
     /// Allocate a variable for the leaf element.
-    fn create_leaf_variable(&mut self, pos: F, elem: F) -> Result<LeafVar, CircuitError>;
+    fn create_leaf_variable(&mut self, pos: F, elem: Element<F>) -> Result<LeafVar, CircuitError>;
 
     /// Allocate a variable for the membership proof.
     fn create_membership_proof_variable(
@@ -70,7 +71,7 @@ pub trait MerkleTreeGadget<F: RescueParameter> {
 }
 
 impl<F: RescueParameter> MerkleTreeGadget<F> for PlonkCircuit<F> {
-    fn create_leaf_variable(&mut self, pos: F, elem: F) -> Result<LeafVar, CircuitError> {
+    fn create_leaf_variable(&mut self, pos: F, elem: Element<F>) -> Result<LeafVar, CircuitError> {
         let committed_elem = LeafVar {
             uid: self.create_variable(pos)?,
             elem: self.create_variable(elem)?,

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -11,15 +11,6 @@ use jf_relation::{errors::CircuitError, BoolVar, Variable};
 
 mod rescue_merkle_tree;
 
-/// Circuit variable for a leaf element.
-#[derive(Debug, Clone)]
-pub struct LeafVar {
-    /// Position of the leaf element in the MT. Serves as UID.
-    pub uid: Variable,
-    /// The value of the leaf element.
-    pub elem: Variable,
-}
-
 /// Gadget for a Merkle tree
 ///
 /// # Examples
@@ -49,8 +40,11 @@ pub trait MerkleTreeGadget<M>
 where
     M: MerkleTreeScheme,
 {
-    /// Type to represent the merkle path of the concrete instantiation.
-    /// It is MT-specific, since arity will affect the exact definition of the
+    /// Type to represent the leaf element of the concrete MT instantiation.
+    type LeafVar;
+
+    /// Type to represent the merkle path of the concrete MT instantiation.
+    /// It is MT-specific, e.g arity will affect the exact definition of the
     /// Merkle path.
     type MerklePathVar;
 
@@ -59,7 +53,7 @@ where
         &mut self,
         pos: M::Index,
         elem: M::Element,
-    ) -> Result<LeafVar, CircuitError>;
+    ) -> Result<Self::LeafVar, CircuitError>;
 
     /// Allocate a variable for the membership proof.
     fn create_membership_proof_variable(
@@ -74,7 +68,7 @@ where
     /// return `BoolVar` indicating the correctness of its membership proof
     fn is_member(
         &mut self,
-        elem: LeafVar,
+        elem: Self::LeafVar,
         merkle_proof: Self::MerklePathVar,
         merkle_root: Variable,
     ) -> Result<BoolVar, CircuitError>;
@@ -83,7 +77,7 @@ where
     /// `expected_merkle_root`.
     fn enforce_merkle_proof(
         &mut self,
-        elem: LeafVar,
+        elem: Self::LeafVar,
         merkle_proof: Self::MerklePathVar,
         expected_merkle_root: Variable,
     ) -> Result<(), CircuitError>;

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Jellyfish library.
+
+// You should have received a copy of the MIT License
+// along with the Jellyfish library. If not, see <https://mit-license.org/>.
+
+#![allow(missing_docs)]
+
+//! Circuit implementation of an append-only, 3-ary Merkle tree, instantiated
+//! with a Rescue hash function.
+
+use crate::merkle_tree::MerkleTreeScheme;
+use ark_ff::PrimeField;
+use ark_std::vec::Vec;
+use jf_relation::{errors::CircuitError, BoolVar, Variable};
+
+mod rescue_merkle_tree;
+
+#[derive(Debug, Clone)]
+/// Circuit variable for a Merkle authentication path.
+pub struct MerklePathVar<MV: MerkleTreeSchemeVar> {
+    nodes: Vec<MV::MerkleNodeVar>,
+}
+
+/// Circuit variable for an accumulated element.
+#[derive(Debug, Clone)]
+pub struct LeafVar {
+    pub uid: Variable,
+    pub elem: Variable,
+}
+
+pub trait MerkleTreeSchemeVar {
+    type MerkleNodeVar;
+}
+
+/// Gadgets for rescue-based merkle tree
+pub trait MerkleTreeGadget<F, M, MV>
+where
+    F: PrimeField,
+    M: MerkleTreeScheme,
+    MV: MerkleTreeSchemeVar,
+{
+    /// Allocate a variable for the leaf element.
+    fn create_leaf_variable(&mut self, pos: F, elem: M::Element) -> Result<LeafVar, CircuitError>;
+
+    /// Allocate a variable for the membership proof.
+    fn create_membership_proof_variable(
+        &mut self,
+        membership_proof: &M::MembershipProof,
+    ) -> Result<MerklePathVar<MV>, CircuitError>;
+
+    /// Allocate a variable for the merkle root.
+    fn create_root_variable(&mut self, root: M::NodeValue) -> Result<Variable, CircuitError>;
+
+    /// Given a leaf element and its merkle proof,
+    /// return `BoolVar` indicating the correctness of its membership proof
+    fn is_member(
+        &mut self,
+        elem: LeafVar,
+        merkle_proof: MerklePathVar<MV>,
+        merkle_root: Variable,
+    ) -> Result<BoolVar, CircuitError>;
+
+    /// Enforce correct `merkle_proof` for the `elem` against
+    /// `expected_merkle_root`.
+    fn enforce_merkle_proof(
+        &mut self,
+        elem: LeafVar,
+        merkle_proof: MerklePathVar<MV>,
+        expected_merkle_root: Variable,
+    ) -> Result<(), CircuitError>;
+}

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -4,8 +4,6 @@
 // You should have received a copy of the MIT License
 // along with the Jellyfish library. If not, see <https://mit-license.org/>.
 
-#![allow(missing_docs)]
-
 //! Trait definitions for a Merkle tree gadget.
 
 use crate::merkle_tree::MerkleTreeScheme;
@@ -14,10 +12,12 @@ use jf_relation::{errors::CircuitError, BoolVar, Variable};
 
 mod rescue_merkle_tree;
 
-/// Circuit variable for an accumulated element.
+/// Circuit variable for a leaf element.
 #[derive(Debug, Clone)]
 pub struct LeafVar {
+    /// Position of the leaf element in the MT. Serves as UID.
     pub uid: Variable,
+    /// The value of the leaf element.
     pub elem: Variable,
 }
 
@@ -51,9 +51,9 @@ where
     F: PrimeField,
     M: MerkleTreeScheme,
 {
-    // Type to represent the merkle path of the concrete instantiation.
-    // It is MT-specific, since arity will affect the exact definition of the Merkle
-    // path.
+    /// Type to represent the merkle path of the concrete instantiation.
+    /// It is MT-specific, since arity will affect the exact definition of the
+    /// Merkle path.
     type MerklePathVar;
 
     /// Allocate a variable for the leaf element.

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -7,7 +7,6 @@
 //! Trait definitions for a Merkle tree gadget.
 
 use crate::merkle_tree::MerkleTreeScheme;
-use ark_ff::PrimeField;
 use jf_relation::{errors::CircuitError, BoolVar, Variable};
 
 mod rescue_merkle_tree;
@@ -46,9 +45,8 @@ pub struct LeafVar {
 /// circuit.enforce_merkle_proof(leaf_var, path_vars, root_var).unwrap();
 /// assert!(circuit.check_circuit_satisfiability(&[]).is_ok());
 /// ```
-pub trait MerkleTreeGadget<F, M>
+pub trait MerkleTreeGadget<M>
 where
-    F: PrimeField,
     M: MerkleTreeScheme,
 {
     /// Type to represent the merkle path of the concrete instantiation.
@@ -57,7 +55,11 @@ where
     type MerklePathVar;
 
     /// Allocate a variable for the leaf element.
-    fn create_leaf_variable(&mut self, pos: F, elem: M::Element) -> Result<LeafVar, CircuitError>;
+    fn create_leaf_variable(
+        &mut self,
+        pos: M::Index,
+        elem: M::Element,
+    ) -> Result<LeafVar, CircuitError>;
 
     /// Allocate a variable for the membership proof.
     fn create_membership_proof_variable(

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -21,7 +21,31 @@ pub struct LeafVar {
     pub elem: Variable,
 }
 
-/// Gadgets for rescue-based merkle tree
+/// Gadget for a Merkle tree
+///
+/// # Examples
+///
+/// ```
+/// use ark_bls12_377::Fq;
+/// use jf_primitives::circuit::merkle_tree::MerkleTreeGadget;
+/// use jf_relation::{Circuit, PlonkCircuit};
+/// use jf_primitives::merkle_tree::{prelude::RescueMerkleTree, MerkleTreeScheme, MerkleCommitment};
+///
+/// let mut circuit = PlonkCircuit::<Fq>::new_turbo_plonk();
+/// // Create a 3-ary MT, instantiated with a Rescue-based hash, of height 1.
+/// let elements = vec![Fq::from(1_u64), Fq::from(2_u64), Fq::from(100_u64)];
+/// let mt = RescueMerkleTree::<Fq>::from_elems(1, elements).unwrap();
+/// let expected_root = mt.commitment().digest();
+/// // Get a proof for the element in position 2
+/// let (_, proof) = mt.lookup(2).expect_ok().unwrap();
+///
+/// // Circuit computation with a MT
+/// let leaf_var = circuit.create_leaf_variable(Fq::from(2_u64), Fq::from(100_u64)).unwrap();
+/// let path_vars = circuit.create_membership_proof_variable(&proof).unwrap();
+/// let root_var = circuit.create_root_variable(expected_root).unwrap();
+/// circuit.enforce_merkle_proof(leaf_var, path_vars, root_var).unwrap();
+/// assert!(circuit.check_circuit_satisfiability(&[]).is_ok());
+/// ```
 pub trait MerkleTreeGadget<F, M>
 where
     F: PrimeField,

--- a/primitives/src/circuit/merkle_tree/rescue_merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree/rescue_merkle_tree.rs
@@ -25,7 +25,8 @@ use typenum::U3;
 use super::{LeafVar, MerkleTreeGadget};
 
 #[derive(Debug, Clone)]
-/// Circuit variable for a Merkle authentication path.
+/// Circuit variable for a Merkle authentication path for a Rescue-based, 3-ary
+/// Merkle tree.
 pub struct MerklePathVar {
     nodes: Vec<Rescue3AryNodeVar>,
 }


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

closes: #https://github.com/EspressoSystems/jellyfish/issues/88
as well as some indirect progress towards https://github.com/EspressoSystems/jellyfish/issues/142.

Note that non membership proofs are out of scope of this PR, but we can still close the referenced issue #88, if approved, since we already have a separate issue for non-membership proof constraints: https://github.com/EspressoSystems/jellyfish/issues/99.

Regarding the design, the initial refactor I had started doing was based on the API proposed by @alxiong in #88 - thanks a lot for this! You will see that it has changed in that methods don't accept native field elements/structs, but rather variables representing these items in the circuit. This was done for two reasons:
- There would otherwise be no way to (efficiently) enforce multiple constraints with the same proof. E.g. given a Merkle path, it would be impossible (without allocating the path variables twice) to enforce that e.g. one element is a member and another is not.
- API consistency. Most of our other APIs follow the format of `create_<>_variable -> Result<SomeVariable, ()>` and then using `SomeVariable` in enforcing constraints. I feel that this is a clean abstraction, and we should probably stick to not enforcing constraints "directly" from native items.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
