### PR TITLE
fix new clippy warnings

### DIFF
--- a/primitives/src/circuit/signature/schnorr.rs
+++ b/primitives/src/circuit/signature/schnorr.rs
@@ -186,7 +186,7 @@ where
         chal_input.extend(msg);
 
         let challenge = self.rescue_sponge_with_padding(&chal_input, 1)?[0];
-        let c_bits = self.unpack(challenge, field_bit_len::<F>() as usize)?;
+        let c_bits = self.unpack(challenge, field_bit_len::<F>())?;
         Ok(c_bits[..challenge_bit_len::<F>()].to_vec())
     }
 }


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

fixes unnecessary cast.
This was not caught before since it's a new improvement in 1.66 clippy: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-166

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
