### PR TITLE
Digest-generic MerkleTreeGadget

### DIFF
--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -60,10 +60,10 @@ use super::rescue::RescueNativeGadget;
 /// .unwrap();
 /// assert!(circuit.check_circuit_satisfiability(&[]).is_ok());
 /// ```
-pub trait MerkleTreeGadget<M, F>
+pub trait MerkleTreeGadget<M>
 where
     M: MerkleTreeScheme,
-    F: PrimeField,
+    M::NodeValue: PrimeField,
 {
     /// Type to represent the merkle proof of the concrete MT instantiation.
     /// It is MT-specific, e.g arity will affect the exact definition of the
@@ -71,7 +71,7 @@ where
     type MembershipProofVar;
 
     /// Gadget for the digest algorithm.
-    type DigestGadget: DigestAlgorithmGadget<F>;
+    type DigestGadget: DigestAlgorithmGadget<M::NodeValue>;
 
     /// Allocate a variable for the membership proof.
     fn create_membership_proof_variable(
@@ -153,10 +153,10 @@ where
 /// .unwrap();
 /// assert!(circuit.check_circuit_satisfiability(&[]).is_ok());
 /// ```
-pub trait UniversalMerkleTreeGadget<M, F>: MerkleTreeGadget<M, F>
+pub trait UniversalMerkleTreeGadget<M>: MerkleTreeGadget<M>
 where
     M: UniversalMerkleTreeScheme,
-    F: PrimeField,
+    M::NodeValue: PrimeField,
 {
     /// Type to represent the merkle non-membership proof of the concrete MT
     /// instantiation. It is MT-specific, e.g arity will affect the exact

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -274,7 +274,7 @@ impl<F: RescueParameter> DigestAlgorithmGadget<F> for RescueDigestGadget {
 
     fn digest_leaf(
         circuit: &mut PlonkCircuit<F>,
-        pos: usize,
+        pos: Variable,
         elem: Variable,
     ) -> Result<Variable, CircuitError> {
         let zero = circuit.zero();

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -220,13 +220,13 @@ fn constrain_sibling_order<F: RescueParameter>(
 /// Circuit variable for a node in the Merkle path.
 pub struct Merkle3AryNodeVar {
     /// First sibling of the node.
-    pub sibling1: Variable,
+    sibling1: Variable,
     /// Second sibling of the node.
-    pub sibling2: Variable,
+    sibling2: Variable,
     /// Boolean variable indicating whether the node is a left child.
-    pub is_left_child: BoolVar,
+    is_left_child: BoolVar,
     /// Boolean variable indicating whether the node is a right child.
-    pub is_right_child: BoolVar,
+    is_right_child: BoolVar,
 }
 
 /// Circuit variable for a Merkle non-membership proof of a 3-ary Merkle tree.

--- a/primitives/src/circuit/merkle_tree/rescue_merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree/rescue_merkle_tree.rs
@@ -23,13 +23,16 @@ use typenum::U3;
 
 use super::{
     constrain_sibling_order, Merkle3AryMembershipProofVar, Merkle3AryNodeVar, MerkleTreeGadget,
+    RescueDigestGadget,
 };
 
-impl<F> MerkleTreeGadget<RescueMerkleTree<F>> for PlonkCircuit<F>
+impl<F> MerkleTreeGadget<RescueMerkleTree<F>, F> for PlonkCircuit<F>
 where
     F: RescueParameter,
 {
     type MembershipProofVar = Merkle3AryMembershipProofVar;
+
+    type DigestGadget = RescueDigestGadget;
 
     fn create_membership_proof_variable(
         &mut self,
@@ -129,7 +132,7 @@ where
         proof_var: Merkle3AryMembershipProofVar,
         expected_root_var: Variable,
     ) -> Result<(), CircuitError> {
-        let bool_val = MerkleTreeGadget::<RescueMerkleTree<F>>::is_member(
+        let bool_val = MerkleTreeGadget::<RescueMerkleTree<F>, F>::is_member(
             self,
             elem_idx_var,
             proof_var,
@@ -274,18 +277,18 @@ mod test {
         // Circuit computation with a MT
         let elem_idx_var: Variable = circuit.create_variable(uid.into()).unwrap();
         let proof_var: Merkle3AryMembershipProofVar =
-            MerkleTreeGadget::<RescueMerkleTree<F>>::create_membership_proof_variable(
+            MerkleTreeGadget::<RescueMerkleTree<F>, F>::create_membership_proof_variable(
                 &mut circuit,
                 &proof,
             )
             .unwrap();
-        let root_var = MerkleTreeGadget::<RescueMerkleTree<F>>::create_root_variable(
+        let root_var = MerkleTreeGadget::<RescueMerkleTree<F>, F>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        MerkleTreeGadget::<RescueMerkleTree<F>>::enforce_membership_proof(
+        MerkleTreeGadget::<RescueMerkleTree<F>, F>::enforce_membership_proof(
             &mut circuit,
             elem_idx_var,
             proof_var,
@@ -313,18 +316,18 @@ mod test {
             });
         }
         let path_vars: Merkle3AryMembershipProofVar =
-            MerkleTreeGadget::<RescueMerkleTree<F>>::create_membership_proof_variable(
+            MerkleTreeGadget::<RescueMerkleTree<F>, F>::create_membership_proof_variable(
                 &mut circuit,
                 &bad_proof,
             )
             .unwrap();
-        let root_var = MerkleTreeGadget::<RescueMerkleTree<F>>::create_root_variable(
+        let root_var = MerkleTreeGadget::<RescueMerkleTree<F>, F>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        MerkleTreeGadget::<RescueMerkleTree<F>>::enforce_membership_proof(
+        MerkleTreeGadget::<RescueMerkleTree<F>, F>::enforce_membership_proof(
             &mut circuit,
             elem_idx_var.clone(),
             path_vars.clone(),

--- a/primitives/src/circuit/merkle_tree/rescue_merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree/rescue_merkle_tree.rs
@@ -25,7 +25,7 @@ use super::{
     RescueDigestGadget,
 };
 
-impl<F> MerkleTreeGadget<RescueMerkleTree<F>, F> for PlonkCircuit<F>
+impl<F> MerkleTreeGadget<RescueMerkleTree<F>> for PlonkCircuit<F>
 where
     F: RescueParameter,
 {
@@ -126,7 +126,7 @@ where
         proof_var: Merkle3AryMembershipProofVar,
         expected_root_var: Variable,
     ) -> Result<(), CircuitError> {
-        let bool_val = MerkleTreeGadget::<RescueMerkleTree<F>, F>::is_member(
+        let bool_val = MerkleTreeGadget::<RescueMerkleTree<F>>::is_member(
             self,
             elem_idx_var,
             proof_var,
@@ -271,18 +271,18 @@ mod test {
         // Circuit computation with a MT
         let elem_idx_var: Variable = circuit.create_variable(uid.into()).unwrap();
         let proof_var: Merkle3AryMembershipProofVar =
-            MerkleTreeGadget::<RescueMerkleTree<F>, F>::create_membership_proof_variable(
+            MerkleTreeGadget::<RescueMerkleTree<F>>::create_membership_proof_variable(
                 &mut circuit,
                 &proof,
             )
             .unwrap();
-        let root_var = MerkleTreeGadget::<RescueMerkleTree<F>, F>::create_root_variable(
+        let root_var = MerkleTreeGadget::<RescueMerkleTree<F>>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        MerkleTreeGadget::<RescueMerkleTree<F>, F>::enforce_membership_proof(
+        MerkleTreeGadget::<RescueMerkleTree<F>>::enforce_membership_proof(
             &mut circuit,
             elem_idx_var,
             proof_var,
@@ -310,18 +310,18 @@ mod test {
             });
         }
         let path_vars: Merkle3AryMembershipProofVar =
-            MerkleTreeGadget::<RescueMerkleTree<F>, F>::create_membership_proof_variable(
+            MerkleTreeGadget::<RescueMerkleTree<F>>::create_membership_proof_variable(
                 &mut circuit,
                 &bad_proof,
             )
             .unwrap();
-        let root_var = MerkleTreeGadget::<RescueMerkleTree<F>, F>::create_root_variable(
+        let root_var = MerkleTreeGadget::<RescueMerkleTree<F>>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        MerkleTreeGadget::<RescueMerkleTree<F>, F>::enforce_membership_proof(
+        MerkleTreeGadget::<RescueMerkleTree<F>>::enforce_membership_proof(
             &mut circuit,
             elem_idx_var.clone(),
             path_vars.clone(),

--- a/primitives/src/circuit/merkle_tree/rescue_merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree/rescue_merkle_tree.rs
@@ -8,7 +8,7 @@
 //! with a Rescue hash function.
 
 use crate::{
-    circuit::rescue::RescueNativeGadget,
+    circuit::merkle_tree::DigestAlgorithmGadget,
     merkle_tree::{
         internal::MerkleNode, prelude::RescueMerkleTree, MerkleTreeScheme, ToTraversalPath,
     },
@@ -16,7 +16,6 @@ use crate::{
 };
 use ark_std::{string::ToString, vec::Vec};
 use jf_relation::{errors::CircuitError, BoolVar, Circuit, PlonkCircuit, Variable};
-
 type NodeVal<F> = <RescueMerkleTree<F> as MerkleTreeScheme>::NodeValue;
 type MembershipProof<F> = <RescueMerkleTree<F> as MerkleTreeScheme>::MembershipProof;
 use typenum::U3;
@@ -99,14 +98,10 @@ where
     ) -> Result<BoolVar, CircuitError> {
         let computed_root_var = {
             let proof_var = &proof_var;
-            let zero_var = self.zero();
 
             // elem label = H(0, uid, elem)
-            let mut cur_label = RescueNativeGadget::<F>::rescue_sponge_no_padding(
-                self,
-                &[zero_var, elem_idx_var, proof_var.elem_var],
-                1,
-            )?[0];
+            let mut cur_label =
+                Self::DigestGadget::digest_leaf(self, elem_idx_var, proof_var.elem_var)?;
             for cur_node in proof_var.node_vars.iter() {
                 let input_labels = constrain_sibling_order(
                     self,
@@ -118,8 +113,7 @@ where
                 )?;
                 // check that the left child's label is non-zero
                 self.non_zero_gate(input_labels[0])?;
-                cur_label =
-                    RescueNativeGadget::<F>::rescue_sponge_no_padding(self, &input_labels, 1)?[0];
+                cur_label = Self::DigestGadget::digest(self, &input_labels)?;
             }
             Ok(cur_label)
         }?;

--- a/primitives/src/circuit/merkle_tree/sparse_merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree/sparse_merkle_tree.rs
@@ -29,7 +29,7 @@ use super::{
     UniversalMerkleTreeGadget,
 };
 
-impl<F> UniversalMerkleTreeGadget<SparseMerkleTree<F>, F> for PlonkCircuit<F>
+impl<F> UniversalMerkleTreeGadget<SparseMerkleTree<F>> for PlonkCircuit<F>
 where
     F: RescueParameter,
 {
@@ -119,7 +119,7 @@ where
     }
 }
 
-impl<F> MerkleTreeGadget<SparseMerkleTree<F>, F> for PlonkCircuit<F>
+impl<F> MerkleTreeGadget<SparseMerkleTree<F>> for PlonkCircuit<F>
 where
     F: RescueParameter,
 {
@@ -220,7 +220,7 @@ where
         proof_var: Self::MembershipProofVar,
         expected_root_var: Variable,
     ) -> Result<(), CircuitError> {
-        let bool_val = MerkleTreeGadget::<SparseMerkleTree<F>, F>::is_member(
+        let bool_val = MerkleTreeGadget::<SparseMerkleTree<F>>::is_member(
             self,
             elem_idx_var,
             proof_var,
@@ -369,19 +369,18 @@ mod test {
 
         // Circuit computation with a MT
         let elem_idx_var = circuit.create_variable(uid.clone().into()).unwrap();
-        let proof_var =
-            MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_membership_proof_variable(
-                &mut circuit,
-                &proof,
-            )
-            .unwrap();
-        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_root_variable(
+        let proof_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_membership_proof_variable(
+            &mut circuit,
+            &proof,
+        )
+        .unwrap();
+        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        MerkleTreeGadget::<SparseMerkleTree<F>, F>::enforce_membership_proof(
+        MerkleTreeGadget::<SparseMerkleTree<F>>::enforce_membership_proof(
             &mut circuit,
             elem_idx_var,
             proof_var,
@@ -408,19 +407,18 @@ mod test {
                 elem: F::one(),
             });
         }
-        let path_vars =
-            MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_membership_proof_variable(
-                &mut circuit,
-                &bad_proof,
-            )
-            .unwrap();
-        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_root_variable(
+        let path_vars = MerkleTreeGadget::<SparseMerkleTree<F>>::create_membership_proof_variable(
+            &mut circuit,
+            &bad_proof,
+        )
+        .unwrap();
+        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        MerkleTreeGadget::<SparseMerkleTree<F>, F>::enforce_membership_proof(
+        MerkleTreeGadget::<SparseMerkleTree<F>>::enforce_membership_proof(
             &mut circuit,
             elem_idx_var.clone(),
             path_vars.clone(),
@@ -454,19 +452,19 @@ mod test {
         // Circuit computation with a MT
         let non_elem_idx_var = circuit.create_variable(uid.into()).unwrap();
         let proof_var =
-            UniversalMerkleTreeGadget::<SparseMerkleTree<F>, F>::create_non_membership_proof_variable(
+            UniversalMerkleTreeGadget::<SparseMerkleTree<F>>::create_non_membership_proof_variable(
                 &mut circuit,
                 &proof,
             )
             .unwrap();
 
-        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_root_variable(
+        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        UniversalMerkleTreeGadget::<SparseMerkleTree<F>, F>::enforce_non_membership_proof(
+        UniversalMerkleTreeGadget::<SparseMerkleTree<F>>::enforce_non_membership_proof(
             &mut circuit,
             non_elem_idx_var,
             proof_var,
@@ -485,19 +483,19 @@ mod test {
         let elem_idx_var = circuit.create_variable(2u64.into()).unwrap();
 
         let path_vars =
-            UniversalMerkleTreeGadget::<SparseMerkleTree<F>, F>::create_non_membership_proof_variable(
+            UniversalMerkleTreeGadget::<SparseMerkleTree<F>>::create_non_membership_proof_variable(
                 &mut circuit,
                 &proof,
             )
             .unwrap();
 
-        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_root_variable(
+        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        UniversalMerkleTreeGadget::<SparseMerkleTree<F>, F>::enforce_non_membership_proof(
+        UniversalMerkleTreeGadget::<SparseMerkleTree<F>>::enforce_non_membership_proof(
             &mut circuit,
             elem_idx_var.clone(),
             path_vars.clone(),

--- a/primitives/src/circuit/merkle_tree/sparse_merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree/sparse_merkle_tree.rs
@@ -8,7 +8,7 @@
 //! with a Rescue hash function.
 
 use crate::{
-    circuit::rescue::RescueNativeGadget,
+    circuit::merkle_tree::DigestAlgorithmGadget,
     merkle_tree::{
         internal::MerkleNode, prelude::RescueSparseMerkleTree, MerkleTreeScheme, ToTraversalPath,
     },
@@ -18,7 +18,6 @@ use ark_std::{string::ToString, vec::Vec};
 use jf_relation::{errors::CircuitError, BoolVar, Circuit, PlonkCircuit, Variable};
 
 type SparseMerkleTree<F> = RescueSparseMerkleTree<BigUint, F>;
-
 type NodeVal<F> = <SparseMerkleTree<F> as MerkleTreeScheme>::NodeValue;
 type MembershipProof<F> = <SparseMerkleTree<F> as MerkleTreeScheme>::MembershipProof;
 use num_bigint::BigUint;
@@ -58,8 +57,7 @@ where
                 )?;
                 // check that the left child's label is non-zero
                 self.non_zero_gate(input_labels[0])?;
-                cur_label =
-                    RescueNativeGadget::<F>::rescue_sponge_no_padding(self, &input_labels, 1)?[0];
+                cur_label = Self::DigestGadget::digest(self, &input_labels)?;
             }
             Ok(cur_label)
         }?;
@@ -194,14 +192,10 @@ where
     ) -> Result<BoolVar, CircuitError> {
         let computed_root_var = {
             let proof_var = &proof_var;
-            let zero_var = self.zero();
 
             // elem label = H(0, uid, elem)
-            let mut cur_label = RescueNativeGadget::<F>::rescue_sponge_no_padding(
-                self,
-                &[zero_var, elem_idx_var, proof_var.elem_var],
-                1,
-            )?[0];
+            let mut cur_label =
+                Self::DigestGadget::digest_leaf(self, elem_idx_var, proof_var.elem_var)?;
             for cur_node in proof_var.node_vars.iter() {
                 let input_labels = constrain_sibling_order(
                     self,
@@ -213,8 +207,7 @@ where
                 )?;
                 // check that the left child's label is non-zero
                 self.non_zero_gate(input_labels[0])?;
-                cur_label =
-                    RescueNativeGadget::<F>::rescue_sponge_no_padding(self, &input_labels, 1)?[0];
+                cur_label = Self::DigestGadget::digest(self, &input_labels)?;
             }
             Ok(cur_label)
         }?;

--- a/primitives/src/circuit/merkle_tree/sparse_merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree/sparse_merkle_tree.rs
@@ -26,10 +26,11 @@ use typenum::U3;
 
 use super::{
     constrain_sibling_order, Merkle3AryMembershipProofVar, Merkle3AryNodeVar,
-    Merkle3AryNonMembershipProofVar, MerkleTreeGadget, UniversalMerkleTreeGadget,
+    Merkle3AryNonMembershipProofVar, MerkleTreeGadget, RescueDigestGadget,
+    UniversalMerkleTreeGadget,
 };
 
-impl<F> UniversalMerkleTreeGadget<SparseMerkleTree<F>> for PlonkCircuit<F>
+impl<F> UniversalMerkleTreeGadget<SparseMerkleTree<F>, F> for PlonkCircuit<F>
 where
     F: RescueParameter,
 {
@@ -120,11 +121,13 @@ where
     }
 }
 
-impl<F> MerkleTreeGadget<SparseMerkleTree<F>> for PlonkCircuit<F>
+impl<F> MerkleTreeGadget<SparseMerkleTree<F>, F> for PlonkCircuit<F>
 where
     F: RescueParameter,
 {
     type MembershipProofVar = Merkle3AryMembershipProofVar;
+
+    type DigestGadget = RescueDigestGadget;
 
     fn create_membership_proof_variable(
         &mut self,
@@ -224,7 +227,7 @@ where
         proof_var: Self::MembershipProofVar,
         expected_root_var: Variable,
     ) -> Result<(), CircuitError> {
-        let bool_val = MerkleTreeGadget::<SparseMerkleTree<F>>::is_member(
+        let bool_val = MerkleTreeGadget::<SparseMerkleTree<F>, F>::is_member(
             self,
             elem_idx_var,
             proof_var,
@@ -373,18 +376,19 @@ mod test {
 
         // Circuit computation with a MT
         let elem_idx_var = circuit.create_variable(uid.clone().into()).unwrap();
-        let proof_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_membership_proof_variable(
-            &mut circuit,
-            &proof,
-        )
-        .unwrap();
-        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_root_variable(
+        let proof_var =
+            MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_membership_proof_variable(
+                &mut circuit,
+                &proof,
+            )
+            .unwrap();
+        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        MerkleTreeGadget::<SparseMerkleTree<F>>::enforce_membership_proof(
+        MerkleTreeGadget::<SparseMerkleTree<F>, F>::enforce_membership_proof(
             &mut circuit,
             elem_idx_var,
             proof_var,
@@ -411,18 +415,19 @@ mod test {
                 elem: F::one(),
             });
         }
-        let path_vars = MerkleTreeGadget::<SparseMerkleTree<F>>::create_membership_proof_variable(
-            &mut circuit,
-            &bad_proof,
-        )
-        .unwrap();
-        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_root_variable(
+        let path_vars =
+            MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_membership_proof_variable(
+                &mut circuit,
+                &bad_proof,
+            )
+            .unwrap();
+        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        MerkleTreeGadget::<SparseMerkleTree<F>>::enforce_membership_proof(
+        MerkleTreeGadget::<SparseMerkleTree<F>, F>::enforce_membership_proof(
             &mut circuit,
             elem_idx_var.clone(),
             path_vars.clone(),
@@ -456,19 +461,19 @@ mod test {
         // Circuit computation with a MT
         let non_elem_idx_var = circuit.create_variable(uid.into()).unwrap();
         let proof_var =
-            UniversalMerkleTreeGadget::<SparseMerkleTree<F>>::create_non_membership_proof_variable(
+            UniversalMerkleTreeGadget::<SparseMerkleTree<F>, F>::create_non_membership_proof_variable(
                 &mut circuit,
                 &proof,
             )
             .unwrap();
 
-        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_root_variable(
+        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        UniversalMerkleTreeGadget::<SparseMerkleTree<F>>::enforce_non_membership_proof(
+        UniversalMerkleTreeGadget::<SparseMerkleTree<F>, F>::enforce_non_membership_proof(
             &mut circuit,
             non_elem_idx_var,
             proof_var,
@@ -487,19 +492,19 @@ mod test {
         let elem_idx_var = circuit.create_variable(2u64.into()).unwrap();
 
         let path_vars =
-            UniversalMerkleTreeGadget::<SparseMerkleTree<F>>::create_non_membership_proof_variable(
+            UniversalMerkleTreeGadget::<SparseMerkleTree<F>, F>::create_non_membership_proof_variable(
                 &mut circuit,
                 &proof,
             )
             .unwrap();
 
-        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>>::create_root_variable(
+        let root_var = MerkleTreeGadget::<SparseMerkleTree<F>, F>::create_root_variable(
             &mut circuit,
             expected_root,
         )
         .unwrap();
 
-        UniversalMerkleTreeGadget::<SparseMerkleTree<F>>::enforce_non_membership_proof(
+        UniversalMerkleTreeGadget::<SparseMerkleTree<F>, F>::enforce_non_membership_proof(
             &mut circuit,
             elem_idx_var.clone(),
             path_vars.clone(),


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Making the circuit equivalent of MerkleTree generic over a digest algorithm is more tricky, because both the `MerkleTreeGadget` and `DigestAlgorithmGadget` need to be implemented for `PlonkCircuit`.

I'm proposing two designs here. One is to add it as a generic parameter to `MerkleTreeGadget`, see [the last commit](https://github.com/EspressoSystems/jellyfish/pull/167/commits/4e3a09c80fac905b26f2632f1d4e33ece9bd3398). The other option is to add `DigestAlgorithmGadget` as an associated type on the `MerkleTreeGadget` trait, see [here](https://github.com/EspressoSystems/jellyfish/pull/167/commits/371e87470b2261ee1ea459d9f7e87a5d634d0397). Both options work, it's just a matter of convenience and ergonomics. Please let me know your opinions.

(Note that initially I thought that the associated type would not work in the case where in the future we need to provide multiple implementations of the `MerkleTreeGadget` trait. But since the trait already is generic over `MerkleTreeScheme`, which, implicitly, will be using the counterpart of `DigestAlgorithmGadget`, it should still be possible to provide multiple impl even with `DigestAlgorithmGadget` being an associated type. See [the rust book](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types) for more explanation on the difference between the two.)

closes: #142 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
