### PR TITLE
Created CRHF trait and conform RescueCRH impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and follow [semantic versioning](https://semver.org/) for our releases.
     - New methods for enforcing constraints: `is_member` and `enforce_merkle_proof`.
     - Move the remaining methods to the internals of circuit implementation for `RescueMerkleTree`.
     - Implement `MerkleTreeGadget` for `RescueMerkleTree`.
+- [#169](https://github.com/EspressoSystems/jellyfish/pull/158) (`jf-primitives`) Stabilize API effort
+    - Introduced `trait CRHF` and moved current implementations under `struct FixedLengthRescueCRHF, VariableLengthRescueCRHF`.
+    - Introduced `trait CommitmentScheme` and moved current implementations under `struct FixedLengthRescueCommitment`.
 
 ### Fixed
 
@@ -72,6 +75,7 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 - [#105](https://github.com/EspressoSystems/jellyfish/pull/105) (all) Trait bound relaxation
 - [#108](https://github.com/EspressoSystems/jellyfish/pull/108) (`jf-utils`) Allowed more general input to `deserialize_canonical_bytes!()`
 - [#113](https://github.com/EspressoSystems/jellyfish/pull/113) (`jf-plonk`) Corrected error type for `PlonkVerifier` gadgets
+- [#162](https://github.com/EspressoSystems/jellyfish/pull/162) (`jf-utils`) Renamed `#serde(with="field_elem")` to `#serde(with="canonical")`
 
 ### Removed
 

--- a/plonk/src/errors.rs
+++ b/plonk/src/errors.rs
@@ -35,7 +35,7 @@ pub enum PlonkError {
     /// Plonk proof verification failed due to wrong proof
     WrongProof,
     /// Rescue Error
-    RescueError(jf_primitives::rescue::errors::RescueError),
+    PrimitiveError(jf_primitives::errors::PrimitivesError),
     /// Invalid parameters
     InvalidParameters(String),
     /// Non-native field overflow
@@ -66,9 +66,9 @@ impl From<ark_serialize::SerializationError> for PlonkError {
     }
 }
 
-impl From<jf_primitives::rescue::errors::RescueError> for PlonkError {
-    fn from(e: jf_primitives::rescue::errors::RescueError) -> Self {
-        Self::RescueError(e)
+impl From<jf_primitives::errors::PrimitivesError> for PlonkError {
+    fn from(e: jf_primitives::errors::PrimitivesError) -> Self {
+        Self::PrimitiveError(e)
     }
 }
 

--- a/plonk/src/transcript/mod.rs
+++ b/plonk/src/transcript/mod.rs
@@ -207,5 +207,5 @@ pub trait PlonkTranscript<F> {
     /// and then append it to the transcript.
     fn get_and_append_challenge<E>(&mut self, label: &'static [u8]) -> Result<E::Fr, PlonkError>
     where
-        E: PairingEngine;
+        E: PairingEngine<Fq = F>;
 }

--- a/plonk/src/transcript/rescue.rs
+++ b/plonk/src/transcript/rescue.rs
@@ -15,8 +15,9 @@ use ark_ec::{
 };
 use ark_std::vec::Vec;
 use jf_primitives::{
+    crhf::{VariableLengthRescueCRHF, CRHF},
     pcs::prelude::Commitment,
-    rescue::{sponge::RescueCRHF, RescueParameter, STATE_SIZE},
+    rescue::{RescueParameter, STATE_SIZE},
 };
 use jf_relation::gadgets::ecc::{Point, SWToTEConParam};
 use jf_utils::{bytes_to_field_elements, field_switching, fq_to_fr_with_mask};
@@ -169,14 +170,14 @@ where
     /// efficiency.
     fn get_and_append_challenge<E>(&mut self, _label: &'static [u8]) -> Result<E::Fr, PlonkError>
     where
-        E: PairingEngine,
+        E: PairingEngine<Fq = F>,
     {
         // 1. state: [F: STATE_SIZE] = hash(state|transcript)
         // 2. challenge = state[0] in Fr
         // 3. transcript = Vec::new()
 
         let input = [self.state.as_ref(), self.transcript.as_ref()].concat();
-        let tmp = RescueCRHF::sponge_with_padding(&input, STATE_SIZE);
+        let tmp: [F; STATE_SIZE] = VariableLengthRescueCRHF::evaluate(&(), &input)?;
         let challenge = fq_to_fr_with_mask::<F, E::Fr>(&tmp[0]);
         self.state.copy_from_slice(&tmp);
         self.transcript = Vec::new();

--- a/plonk/src/transcript/rescue.rs
+++ b/plonk/src/transcript/rescue.rs
@@ -177,7 +177,7 @@ where
         // 3. transcript = Vec::new()
 
         let input = [self.state.as_ref(), self.transcript.as_ref()].concat();
-        let tmp: [F; STATE_SIZE] = VariableLengthRescueCRHF::evaluate(&(), &input)?;
+        let tmp: [F; STATE_SIZE] = VariableLengthRescueCRHF::evaluate(&input)?;
         let challenge = fq_to_fr_with_mask::<F, E::Fr>(&tmp[0]);
         self.state.copy_from_slice(&tmp);
         self.transcript = Vec::new();

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -30,7 +30,7 @@ mod rescue_merkle_tree;
 /// let (_, proof) = mt.lookup(2).expect_ok().unwrap();
 ///
 /// // Circuit computation with a MT
-/// let leaf_var = circuit.create_leaf_variable(Fq::from(2_u64), Fq::from(100_u64)).unwrap();
+/// let leaf_var = circuit.create_leaf_variable(2_u64, Fq::from(100_u64)).unwrap();
 /// let path_vars = circuit.create_membership_proof_variable(&proof).unwrap();
 /// let root_var = circuit.create_root_variable(expected_root).unwrap();
 /// circuit.enforce_merkle_proof(leaf_var, path_vars, root_var).unwrap();

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -961,7 +961,7 @@ mod tests {
                 }
 
                 // Check consistency between outputs
-                let expected_hash = RescueCRHF::sponge_with_padding(&input_vec, output_len);
+                let expected_hash = RescueCRHF::sponge_with_bit_padding(&input_vec, output_len);
 
                 for (&e, &f) in expected_hash.iter().zip(out_var.iter()) {
                     assert_eq!(e, circuit.witness(f).unwrap());

--- a/primitives/src/circuit/rescue/non_native.rs
+++ b/primitives/src/circuit/rescue/non_native.rs
@@ -1073,7 +1073,7 @@ mod tests {
                 .map(|x| FpElemVar::new_from_field_element(&mut circuit, x, m, None).unwrap())
                 .collect();
 
-            let expected_sponge = RescueCRHF::sponge_with_padding(&data_t, 1);
+            let expected_sponge = RescueCRHF::sponge_with_bit_padding(&data_t, 1);
 
             // sponge with padding
             let sponge_var = RescueNonNativeGadget::<T, F>::rescue_sponge_with_padding(
@@ -1097,7 +1097,7 @@ mod tests {
 
             // sponge full with padding
             for output_len in 1..max_output_len {
-                let expected_sponge = RescueCRHF::sponge_with_padding(&data_t, output_len);
+                let expected_sponge = RescueCRHF::sponge_with_bit_padding(&data_t, output_len);
 
                 let sponge_var = RescueNonNativeGadget::<T, F>::rescue_sponge_with_padding(
                     &mut circuit,

--- a/primitives/src/commitment.rs
+++ b/primitives/src/commitment.rs
@@ -9,53 +9,83 @@
 use ark_std::marker::PhantomData;
 
 use crate::{
+    crhf::{FixedLengthRescueCRHF, CRHF},
     errors::PrimitivesError,
-    rescue::{sponge::RescueCRHF, RescueParameter, CRHF_RATE},
+    rescue::RescueParameter,
 };
-use ark_std::{format, string::String, vec};
-use jf_utils::pad_with_zeros;
+use ark_std::{
+    borrow::Borrow,
+    fmt::Debug,
+    hash::Hash,
+    string::{String, ToString},
+    UniformRand,
+};
 
-#[derive(Default)]
-/// Commitment instance for user defined input size (in scalar elements)
-pub struct Commitment<F: RescueParameter> {
-    input_len: usize,
-    phantom_f: PhantomData<F>,
+/// A trait for cryptographic commitment scheme
+pub trait CommitmentScheme {
+    /// Input to the commitment
+    type Input;
+    /// The type of output commitment value
+    type Output: Clone + Debug + PartialEq + Eq + Hash;
+    /// The type of the hiding/blinding factor
+    type Randomness: Clone + Debug + PartialEq + Eq + UniformRand;
+
+    /// Commit algorithm that takes `input` and blinding randomness `r`
+    /// (optional for hiding commitment schemes), outputs a commitment.
+    fn commit<T: Borrow<Self::Input>>(
+        input: T,
+        r: Option<&Self::Randomness>,
+    ) -> Result<Self::Output, PrimitivesError>;
+
+    /// Verify algorithm that output `Ok` if accepted, or `Err` if rejected.
+    fn verify<T: Borrow<Self::Input>>(
+        input: T,
+        r: Option<&Self::Randomness>,
+        comm: &Self::Output,
+    ) -> Result<(), PrimitivesError>;
 }
 
-impl<F: RescueParameter> Commitment<F> {
-    /// Create a new commitment instance for inputs of length `input_len`
-    pub fn new(input_len: usize) -> Commitment<F> {
-        assert!(input_len > 0, "input_len must be positive");
-        Commitment {
-            input_len,
-            phantom_f: PhantomData,
-        }
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+/// Rescue-based Commitment instance for fixed-length input
+///
+/// ## Note
+/// the current ugly existence of `INPUT_LEN_PLUS_ONE` is due to unstable
+/// feature of using const generic in expression (namely can't use `INPUT_LEN +
+/// 1` in code).
+// FIXME: (alex) when `feature(generic_const_exprs)` is stable, we should remove
+// the third generic param. See more: https://github.com/rust-lang/rust/issues/76560
+pub struct FixedLengthRescueCommitment<
+    F: RescueParameter,
+    const INPUT_LEN: usize,
+    const INPUT_LEN_PLUS_ONE: usize,
+>(PhantomData<F>);
+
+impl<F: RescueParameter, const INPUT_LEN: usize, const INPUT_LEN_PLUS_ONE: usize> CommitmentScheme
+    for FixedLengthRescueCommitment<F, INPUT_LEN, INPUT_LEN_PLUS_ONE>
+{
+    type Input = [F; INPUT_LEN];
+    type Output = F;
+    type Randomness = F;
+
+    fn commit<T: Borrow<Self::Input>>(
+        input: T,
+        r: Option<&Self::Randomness>,
+    ) -> Result<Self::Output, PrimitivesError> {
+        let mut msg = [F::zero(); INPUT_LEN_PLUS_ONE];
+        msg[0] = *r.ok_or_else(|| {
+            PrimitivesError::ParameterError("Expecting a blinding factor".to_string())
+        })?;
+        msg[1..INPUT_LEN_PLUS_ONE].copy_from_slice(&input.borrow()[..(INPUT_LEN)]);
+
+        Ok(FixedLengthRescueCRHF::<F, INPUT_LEN_PLUS_ONE, 1>::evaluate(&msg)?[0])
     }
-    /// Commits to `input` slice using blinding `blind`. Return
-    /// Err(PrimitivesError::ParameterError) if input.len() !=
-    /// self.input_len
-    pub fn commit(&self, input: &[F], blind: &F) -> Result<F, PrimitivesError> {
-        if input.len() != self.input_len {
-            return Err(PrimitivesError::ParameterError(format!(
-                "Commitment error: expected input length ({}). It must match \
-                instance's message length ({})",
-                self.input_len,
-                input.len(),
-            )));
-        }
-        let mut msg = vec![*blind];
-        msg.extend_from_slice(input);
-        // Ok to pad with 0's since input length is fixed for the commitment instance
-        pad_with_zeros(&mut msg, CRHF_RATE);
-        let result_vec = RescueCRHF::sponge_no_padding(msg.as_slice(), 1)?;
-        Ok(result_vec[0])
-    }
-    /// Verifies `commitment` against `input` and `blind`.
-    /// Returns Ok(()) on success. Otherwise, returns
-    /// PrimitivesError::ParameterError if input.len() != self.input_len,
-    /// and PrimitivesError::VerificationError if commitment is not valid.
-    pub fn verify(&self, input: &[F], blind: &F, commitment: &F) -> Result<(), PrimitivesError> {
-        if self.commit(input, blind)? == *commitment {
+
+    fn verify<T: Borrow<Self::Input>>(
+        input: T,
+        r: Option<&Self::Randomness>,
+        comm: &Self::Output,
+    ) -> Result<(), PrimitivesError> {
+        if <Self as CommitmentScheme>::commit(input, r)? == *comm {
             Ok(())
         } else {
             Err(PrimitivesError::VerificationError(String::from(
@@ -67,44 +97,56 @@ impl<F: RescueParameter> Commitment<F> {
 
 #[cfg(test)]
 mod test {
-    use crate::commitment::Commitment;
+    use crate::{
+        commitment::{CommitmentScheme, FixedLengthRescueCommitment},
+        rescue::{sponge::RescueCRHF, CRHF_RATE},
+    };
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
     use ark_ed_on_bls12_381::Fq as FqEd381;
     use ark_ed_on_bls12_381_bandersnatch::Fq as FqEd381b;
     use ark_ed_on_bn254::Fq as FqEd254;
     use ark_ff::UniformRand;
-    use core::ops::Add;
+    use ark_std::vec;
 
     macro_rules! test_commit {
         ($tr:tt) => {
             let mut prng = ark_std::test_rng();
-            let commitment = Commitment::new(3);
 
             let input = [$tr::from(1u64), $tr::from(2u64), $tr::from(3u64)];
             let blind = $tr::rand(&mut prng);
-            let c = commitment.commit(&input, &blind).unwrap();
-            assert!(commitment.verify(&input, &blind, &c).is_ok());
-            // smaller input size
-            assert!(commitment.verify(&input[0..2], &blind, &c).is_err());
-            // bad blinding factor
-            let bad_blind = blind.add($tr::from(1u8));
-            assert!(commitment.verify(&input, &bad_blind, &c).is_err());
-            // bad input
-            let bad_input = [$tr::from(2u64), $tr::from(1u64), $tr::from(3u64)];
-            assert!(commitment.verify(&bad_input, &blind, &c).is_err());
+
+            let c = FixedLengthRescueCommitment::<$tr, 3, 4>::commit(&input, Some(&blind)).unwrap();
+            assert!(
+                FixedLengthRescueCommitment::<$tr, 3, 4>::verify(&input, Some(&blind), &c).is_ok()
+            );
+            // test for correctness
+            let mut msg = vec![blind];
+            msg.extend_from_slice(&input);
+            if (input.len() + 1) % CRHF_RATE == 0 {
+                assert_eq!(c, RescueCRHF::sponge_no_padding(&msg, 1).unwrap()[0])
+            } else {
+                assert_eq!(c, RescueCRHF::sponge_with_zero_padding(&msg, 1)[0])
+            }
 
             // smaller input size
-            let bad_size_input = [$tr::from(2u64), $tr::from(1u64)];
-            assert!(commitment.commit(&bad_size_input, &blind).is_err());
-            // greater input size
-            let bad_size_input = [
-                $tr::from(2u64),
-                $tr::from(1u64),
-                $tr::from(1u64),
-                $tr::from(1u64),
-            ];
-            assert!(commitment.commit(&bad_size_input, &blind).is_err());
+            let bad_input = [input[0], input[1]];
+            assert!(
+                FixedLengthRescueCommitment::<$tr, 2, 3>::verify(&bad_input, Some(&blind), &c)
+                    .is_err()
+            );
+            // bad blinding factor
+            let bad_blind = blind + $tr::from(1u8);
+            assert!(
+                FixedLengthRescueCommitment::<$tr, 3, 4>::verify(&input, Some(&bad_blind), &c)
+                    .is_err()
+            );
+            // bad input
+            let bad_input = [$tr::from(2u64), $tr::from(1u64), $tr::from(3u64)];
+            assert!(
+                FixedLengthRescueCommitment::<$tr, 3, 4>::verify(&bad_input, Some(&blind), &c)
+                    .is_err()
+            );
         };
     }
 

--- a/primitives/src/crhf.rs
+++ b/primitives/src/crhf.rs
@@ -29,12 +29,6 @@ pub trait CRHF {
 
     /// evaluate inputs and return hash output
     fn evaluate<T: Borrow<Self::Input>>(input: T) -> Result<Self::Output, PrimitivesError>;
-
-    /// same as [`Self::evaluate`] with caller assurance that `input` won't
-    /// cause any error, mostly for internal use, invoke with caution!
-    fn evaluate_safe<T: Borrow<Self::Input>>(input: T) -> Self::Output {
-        Self::evaluate(input).expect("Should NOT panic")
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/primitives/src/crhf.rs
+++ b/primitives/src/crhf.rs
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Jellyfish library.
+
+// You should have received a copy of the MIT License
+// along with the Jellyfish library. If not, see <https://mit-license.org/>.
+
+//! Collision-resistant Hash Functions (CRHF) definitions and implementations.
+
+use ark_std::{
+    borrow::Borrow,
+    fmt::Debug,
+    hash::Hash,
+    marker::PhantomData,
+    rand::{CryptoRng, RngCore},
+    string::ToString,
+    vec::Vec,
+};
+
+use crate::{
+    errors::PrimitivesError,
+    rescue::{sponge::RescueCRHF, RescueParameter, CRHF_RATE},
+};
+
+/// A trait for CRHF
+/// (based on ark-primitives' definition, but self-declared for minimal
+/// dependency and easier future upgradability.)
+pub trait CRHF {
+    /// Input to the CRHF
+    type Input;
+    /// Output of the CRHF
+    // FIXME: (alex) wait until arkwork 0.4.0 to add the following:
+    // + Default + CanonicalSerialize + CanonicalDeserialize;
+    // right now, const-generic are not supported yet.
+    type Output: Clone + PartialEq + Eq + Hash + Debug;
+
+    /// Public parameters of the CRHF (if any)
+    type Parameters: Clone + Debug + Sync + Send;
+
+    /// picking the concrete CRHF from the parameterized hash family
+    fn setup<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self::Parameters, PrimitivesError>;
+
+    /// evaluate inputs and return hash output
+    fn evaluate<T: Borrow<Self::Input>>(
+        param: &Self::Parameters,
+        input: T,
+    ) -> Result<Self::Output, PrimitivesError>;
+}
+
+#[derive(Debug, Clone)]
+/// A rescue-sponge-based CRHF with fixed-input size (if not multiple of 3 will
+/// auto-padded) and variable-output size
+pub struct FixedLengthRescueCRHF<
+    F: RescueParameter,
+    const INPUT_LEN: usize,
+    const OUTPUT_LEN: usize,
+>(PhantomData<F>);
+
+impl<F: RescueParameter, const INPUT_LEN: usize, const OUTPUT_LEN: usize> CRHF
+    for FixedLengthRescueCRHF<F, INPUT_LEN, OUTPUT_LEN>
+{
+    type Input = [F; INPUT_LEN];
+    type Output = [F; OUTPUT_LEN];
+    type Parameters = ();
+
+    fn setup<R: RngCore + CryptoRng>(_rng: &mut R) -> Result<Self::Parameters, PrimitivesError> {
+        Ok(())
+    }
+
+    fn evaluate<T: Borrow<Self::Input>>(
+        _param: &Self::Parameters,
+        input: T,
+    ) -> Result<Self::Output, PrimitivesError> {
+        let mut output = [F::zero(); OUTPUT_LEN];
+
+        let res = match INPUT_LEN % CRHF_RATE {
+            0 => RescueCRHF::<F>::sponge_no_padding(input.borrow(), OUTPUT_LEN)?,
+            _ => RescueCRHF::<F>::sponge_with_padding(input.borrow(), OUTPUT_LEN),
+        };
+        if res.len() != OUTPUT_LEN {
+            return Err(PrimitivesError::InternalError(
+                "Unexpected rescue sponge return length".to_string(),
+            ));
+        }
+
+        output.copy_from_slice(&res[..]);
+        Ok(output)
+    }
+}
+
+#[derive(Debug, Clone)]
+/// A rescue-sponge-based CRHF with variable-input and variable-output size
+pub struct VariableLengthRescueCRHF<F: RescueParameter, const OUTPUT_LEN: usize>(PhantomData<F>);
+
+impl<F: RescueParameter, const OUTPUT_LEN: usize> CRHF for VariableLengthRescueCRHF<F, OUTPUT_LEN> {
+    type Input = Vec<F>;
+    type Output = [F; OUTPUT_LEN];
+    type Parameters = ();
+
+    fn setup<R: RngCore + CryptoRng>(_rng: &mut R) -> Result<Self::Parameters, PrimitivesError> {
+        Ok(())
+    }
+
+    fn evaluate<T: Borrow<Self::Input>>(
+        _param: &Self::Parameters,
+        input: T,
+    ) -> Result<Self::Output, PrimitivesError> {
+        let mut output = [F::zero(); OUTPUT_LEN];
+        let res = RescueCRHF::<F>::sponge_with_padding(input.borrow(), OUTPUT_LEN);
+        if res.len() != OUTPUT_LEN {
+            return Err(PrimitivesError::InternalError(
+                "Unexpected rescue sponge return length".to_string(),
+            ));
+        }
+        output.copy_from_slice(&res[..]);
+        Ok(output)
+    }
+}

--- a/primitives/src/crhf.rs
+++ b/primitives/src/crhf.rs
@@ -30,8 +30,8 @@ pub trait CRHF {
     /// evaluate inputs and return hash output
     fn evaluate<T: Borrow<Self::Input>>(input: T) -> Result<Self::Output, PrimitivesError>;
 
-    /// same as [`evaluate`] with caller assurance that `input` won't cause any
-    /// error, mostly for internal use, invoke with caution!
+    /// same as [`Self::evaluate`] with caller assurance that `input` won't
+    /// cause any error, mostly for internal use, invoke with caution!
     fn evaluate_safe<T: Borrow<Self::Input>>(input: T) -> Self::Output {
         Self::evaluate(input).expect("Should NOT panic")
     }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -20,6 +20,7 @@ pub mod aead;
 pub mod circuit;
 pub mod commitment;
 pub mod constants;
+pub mod crhf;
 pub mod elgamal;
 pub mod errors;
 pub mod hash_to_group;

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -868,11 +868,11 @@ mod test_permutation {
     }
     fn test_variable_output_sponge_and_fsks_helper<F: RescueParameter>() {
         let input = [F::zero(), F::one(), F::zero()];
-        assert_eq!(RescueCRHF::sponge_with_padding(&input, 0).len(), 0);
-        assert_eq!(RescueCRHF::sponge_with_padding(&input, 1).len(), 1);
-        assert_eq!(RescueCRHF::sponge_with_padding(&input, 2).len(), 2);
-        assert_eq!(RescueCRHF::sponge_with_padding(&input, 3).len(), 3);
-        assert_eq!(RescueCRHF::sponge_with_padding(&input, 10).len(), 10);
+        assert_eq!(RescueCRHF::sponge_with_bit_padding(&input, 0).len(), 0);
+        assert_eq!(RescueCRHF::sponge_with_bit_padding(&input, 1).len(), 1);
+        assert_eq!(RescueCRHF::sponge_with_bit_padding(&input, 2).len(), 2);
+        assert_eq!(RescueCRHF::sponge_with_bit_padding(&input, 3).len(), 3);
+        assert_eq!(RescueCRHF::sponge_with_bit_padding(&input, 10).len(), 10);
 
         assert_eq!(RescueCRHF::sponge_no_padding(&input, 0).unwrap().len(), 0);
         assert_eq!(RescueCRHF::sponge_no_padding(&input, 1).unwrap().len(), 1);

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -30,7 +30,7 @@ use ark_std::{vec, vec::Vec};
 /// The state size of rescue hash.
 pub const STATE_SIZE: usize = 4;
 /// The rate of the sponge used in RescueCRHF.
-pub(crate) const CRHF_RATE: usize = 3;
+pub const CRHF_RATE: usize = 3;
 
 /// The # of rounds of rescue hash.
 // In the paper, to derive ROUND:

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -30,7 +30,7 @@ use ark_std::{vec, vec::Vec};
 /// The state size of rescue hash.
 pub const STATE_SIZE: usize = 4;
 /// The rate of the sponge used in RescueCRHF.
-pub const CRHF_RATE: usize = 3;
+pub(crate) const CRHF_RATE: usize = 3;
 
 /// The # of rounds of rescue hash.
 // In the paper, to derive ROUND:
@@ -201,7 +201,7 @@ impl<F: Copy> From<&[F; STATE_SIZE]> for RescueVector<F> {
 }
 
 /// A matrix that consists of `STATE_SIZE` number of rescue vectors.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RescueMatrix<F> {
     matrix: [RescueVector<F>; STATE_SIZE],
 }
@@ -248,7 +248,7 @@ impl<F: PrimeField> RescueMatrix<F> {
 // input to 3 and output to 1
 //
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 /// Rescue pseudo-random permutation (PRP) instance
 pub struct PRP<F> {
@@ -371,7 +371,7 @@ impl<F: RescueParameter> PRP<F> {
 
 /// Instance of a unkeyed cryptographic permutation to be used for instantiation
 /// hashing, pseudo-random function, and other cryptographic primitives
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Permutation<F> {
     rescue_prp: PRP<F>,
     round_keys: Vec<RescueVector<F>>,

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -17,7 +17,7 @@ use super::{
     errors::RescueError, Permutation, RescueParameter, RescueVector, CRHF_RATE, STATE_SIZE,
 };
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 /// A rescue hash function consists of a permutation function and
 /// an internal state.
 struct RescueSponge<F: RescueParameter, const RATE: usize> {
@@ -26,7 +26,8 @@ struct RescueSponge<F: RescueParameter, const RATE: usize> {
 }
 
 /// CRHF
-pub struct RescueCRHF<F: RescueParameter> {
+#[derive(Debug, Clone)]
+pub(crate) struct RescueCRHF<F: RescueParameter> {
     sponge: RescueSponge<F, CRHF_RATE>,
 }
 

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -40,11 +40,27 @@ impl<F: RescueParameter> RescueCRHF<F> {
     /// Sponge hashing based on rescue permutation for RATE 3. It allows
     /// unrestricted variable length input and returns a vector of
     /// `num_outputs` elements.
-    pub fn sponge_with_padding(input: &[F], num_outputs: usize) -> Vec<F> {
-        // Pad input as follows: append a One, then pad with 0 until length is multiple
-        // of RATE
+    ///
+    /// we use ["bit padding"-style][padding] where "1" is always appended, then
+    /// as many "0" as required are added for the overall length to be a
+    /// multiple of RATE
+    ///
+    /// [padding]: https://en.wikipedia.org/wiki/Padding_(cryptography)#Bit_padding
+    pub(crate) fn sponge_with_bit_padding(input: &[F], num_outputs: usize) -> Vec<F> {
         let mut padded = input.to_vec();
         padded.push(F::one());
+        pad_with_zeros(&mut padded, CRHF_RATE);
+        Self::sponge_no_padding(padded.as_slice(), num_outputs)
+            .expect("Bug in JF Primitives : bad padding of input for FSKS construction")
+    }
+
+    /// Similar to [`RescueCRHF::sponge_with_bit_padding`] except we use ["zero
+    /// padding"][padding] where as many "0" as required are added for the
+    /// overall length to be a multiple of RATE.
+    ///
+    /// [padding]: https://en.wikipedia.org/wiki/Padding_(cryptography)#Zero_padding
+    pub(crate) fn sponge_with_zero_padding(input: &[F], num_outputs: usize) -> Vec<F> {
+        let mut padded = input.to_vec();
         pad_with_zeros(&mut padded, CRHF_RATE);
         Self::sponge_no_padding(padded.as_slice(), num_outputs)
             .expect("Bug in JF Primitives : bad padding of input for FSKS construction")
@@ -53,7 +69,7 @@ impl<F: RescueParameter> RescueCRHF<F> {
     /// Sponge hashing based on rescue permutation for RATE 3 and CAPACITY 1. It
     /// allows inputs with length that is a multiple of `CRHF_RATE` and
     /// returns a vector of `num_outputs` elements.
-    pub fn sponge_no_padding(input: &[F], num_output: usize) -> Result<Vec<F>, RescueError> {
+    pub(crate) fn sponge_no_padding(input: &[F], num_output: usize) -> Result<Vec<F>, RescueError> {
         if input.len() % CRHF_RATE != 0 {
             return Err(RescueError::ParameterError(
                 "Rescue sponge Error : input to sponge hashing function is not multiple of RATE."

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -300,7 +300,8 @@ where
         let mut msg_input = vec![instance_description, fr_to_fq::<F, P>(&self.sk.0)];
         msg_input.extend(msg.iter());
 
-        let r = fq_to_fr::<F, P>(&VariableLengthRescueCRHF::<F, 1>::evaluate_safe(&msg_input)[0]);
+        let r =
+            fq_to_fr::<F, P>(&VariableLengthRescueCRHF::<F, 1>::evaluate(&msg_input).unwrap()[0]); // safe unwrap
         let R = Group::mul(&GroupProjective::<P>::prime_subgroup_generator(), &r);
         let c = self.vk.challenge(&R, msg, csid);
         let s = c * self.sk.0 + r;
@@ -412,7 +413,7 @@ where
             ]
         };
         challenge_input.extend(msg);
-        let challenge_fq = VariableLengthRescueCRHF::<F, 1>::evaluate_safe(challenge_input)[0];
+        let challenge_fq = VariableLengthRescueCRHF::<F, 1>::evaluate(challenge_input).unwrap()[0]; // safe unwrap
 
         // this masking will drop the last byte, and the resulting
         // challenge will be 248 bits

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -10,8 +10,9 @@
 use super::SignatureScheme;
 use crate::{
     constants::CS_ID_SCHNORR,
+    crhf::{VariableLengthRescueCRHF, CRHF},
     errors::PrimitivesError,
-    rescue::{sponge::RescueCRHF, RescueParameter},
+    rescue::RescueParameter,
     utils::curve_cofactor,
 };
 use ark_ec::{
@@ -299,7 +300,7 @@ where
         let mut msg_input = vec![instance_description, fr_to_fq::<F, P>(&self.sk.0)];
         msg_input.extend(msg.iter());
 
-        let r = fq_to_fr::<F, P>(&RescueCRHF::sponge_with_padding(&msg_input, 1)[0]);
+        let r = fq_to_fr::<F, P>(&VariableLengthRescueCRHF::<F, 1>::evaluate_safe(&msg_input)[0]);
         let R = Group::mul(&GroupProjective::<P>::prime_subgroup_generator(), &r);
         let c = self.vk.challenge(&R, msg, csid);
         let s = c * self.sk.0 + r;
@@ -411,7 +412,7 @@ where
             ]
         };
         challenge_input.extend(msg);
-        let challenge_fq = RescueCRHF::sponge_with_padding(&challenge_input, 1)[0];
+        let challenge_fq = VariableLengthRescueCRHF::<F, 1>::evaluate_safe(challenge_input)[0];
 
         // this masking will drop the last byte, and the resulting
         // challenge will be 248 bits

--- a/relation/src/gadgets/ecc/mod.rs
+++ b/relation/src/gadgets/ecc/mod.rs
@@ -331,7 +331,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
     }
     /// Constrain a point to be on certain curve, namely its coordinates satisfy
     /// the curve equation, which is curve-dependent. Currently we only support
-    /// checks of a GroupAffine::<P> over a base field which is the bls12-381
+    /// checks of a `GroupAffine::<P>` over a base field which is the bls12-381
     /// scalar field
     ///
     /// Returns error if input variables are invalid
@@ -390,7 +390,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
 
     /// Obtain a variable to the point addition result of `point_a` + `point_b`
     /// where "+" is the group operation over an elliptic curve.
-    /// Currently only supports GroupAffine::<P> addition.
+    /// Currently only supports `GroupAffine::<P>` addition.
     ///
     /// Returns error if inputs are invalid
     pub fn ecc_add<P: Parameters<BaseField = F>>(
@@ -415,7 +415,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
     }
 
     /// Obtain the fixed-based scalar multiplication result of `scalar` * `Base`
-    /// Currently only supports GroupAffine::<P> scalar multiplication.
+    /// Currently only supports `GroupAffine::<P>` scalar multiplication.
     pub fn fixed_base_scalar_mul<P: Parameters<BaseField = F>>(
         &mut self,
         scalar: Variable,
@@ -463,7 +463,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
 
     /// Obtain a variable of the result of a variable base scalar
     /// multiplication. both `scalar` and `base` are variables.
-    /// Currently only supports GroupAffine::<P>.
+    /// Currently only supports `GroupAffine::<P>`.
     /// If the parameter is bandersnatch, we will use GLV multiplication.
     pub fn variable_base_scalar_mul<P: Parameters<BaseField = F>>(
         &mut self,
@@ -490,7 +490,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
     /// Obtain a variable of the result of a variable base scalar
     /// multiplication. Both `scalar_bits_le` and `base` are variables,
     /// where `scalar_bits_le` is the little-endian form of the scalar.
-    /// Currently only supports GroupAffine::<P>.
+    /// Currently only supports `GroupAffine::<P>`.
     pub fn variable_base_binary_scalar_mul<P: Parameters<BaseField = F>>(
         &mut self,
         scalar_bits_le: &[BoolVar],


### PR DESCRIPTION
## Description

Part of: #168 

Changes include:
- add `trait CRHF`
- Provide `struct FixedLengthRescueCRHF` and `struct VariableLengthRescueCRHF` conforming to the trait.
- add `trait CommitmentScheme`
- Provide `struct FixedLengthRescueCRHF`

NOTE:
to hack around some nightly-only feature on using const generic in an expression, we have a temporarily excessive generic parameter on `FixedLengthRescueCRHF<F, INPUT_LEN, INPUT_LEN_PLUS_ONE>` which will be fixed in the future.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
