### PR TITLE
Simplify `MerkleNode::Empty` match branch in `verify_non_membership_proof`

### DIFF
--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -668,15 +668,7 @@ where
                                     data[*branch] = val;
                                     Ok(H::digest(&data))
                                 },
-                                MerkleNode::Empty => {
-                                    if init == T::default() {
-                                        Ok(init)
-                                    } else {
-                                        Err(PrimitivesError::ParameterError(
-                                            "In valid proof".to_string(),
-                                        ))
-                                    }
-                                },
+                                MerkleNode::Empty => Ok(init),
                                 _ => Err(PrimitivesError::ParameterError(
                                     "Incompatible proof for this merkle tree".to_string(),
                                 )),


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Just a minor code simplification. Notice that since `init` is immutable, it will always be set to `T::default()`. 
I would have expected clippy to pick it up, but maybe it's nested too deeply.

@mrain 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests N/A
- [ ] Updated relevant documentation in the code N/A
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` N/A
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
