### PR TITLE
Stablize PRF API

### DIFF
--- a/primitives/src/circuit/prf.rs
+++ b/primitives/src/circuit/prf.rs
@@ -40,7 +40,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::PrfGadget;
-    use crate::prf::{PrfKey, PRF};
+    use crate::prf::{RescuePRF, PRF};
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
     use ark_ed_on_bls12_381::Fq as FqEd381;
@@ -48,7 +48,6 @@ mod tests {
     use ark_ed_on_bn254::Fq as FqEd254;
     use ark_ff::UniformRand;
     use ark_std::vec::Vec;
-    use itertools::Itertools;
     use jf_relation::{Circuit, PlonkCircuit, Variable};
 
     macro_rules! test_prf_circuit {
@@ -56,20 +55,19 @@ mod tests {
             let mut circuit: PlonkCircuit<$base_field> = PlonkCircuit::new_turbo_plonk();
             let mut prng = ark_std::test_rng();
             let rand_scalar = $base_field::rand(&mut prng);
-            let key = PrfKey::from(rand_scalar);
             let key_var = circuit.create_variable(rand_scalar).unwrap();
             let input_len = 10;
-            let data: Vec<$base_field> = (0..input_len)
-                .map(|_| $base_field::rand(&mut prng))
-                .collect_vec();
+            let mut data = [$base_field::from(0u8); 10];
+            for i in 0..input_len {
+                data[i] = $base_field::rand(&mut prng);
+            }
             let data_vars: Vec<Variable> = data
                 .iter()
                 .map(|&x| circuit.create_variable(x).unwrap())
-                .collect_vec();
+                .collect();
 
-            let prf = PRF::new(input_len, 1);
-            let expected_prf_output = prf.eval(&key, &data).unwrap();
-
+            let expected_prf_output =
+                RescuePRF::<$base_field, 10, 1>::evaluate(&rand_scalar, &data).unwrap();
             let prf_var = circuit.eval_prf(key_var, &data_vars).unwrap();
 
             // Check prf output consistency

--- a/primitives/src/circuit/rescue/mod.rs
+++ b/primitives/src/circuit/rescue/mod.rs
@@ -79,6 +79,14 @@ where
         data_vars: &[R::Var],
     ) -> Result<R::Var, CircuitError>;
 
+    /// Similar to [`Self::rescue_full_state_keyed_sponge_no_padding`] except
+    /// `data_var` are padded with "zero_var"
+    fn rescue_full_state_keyed_sponge_with_zero_padding(
+        &mut self,
+        key: R::Var,
+        data_vars: &[R::Var],
+    ) -> Result<R::Var, CircuitError>;
+
     /// Return the round keys variables for the Rescue block cipher
     /// * `mds_states` - Rescue MDS matrix
     /// * `key_var` - state variable representing the cipher key

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -532,7 +532,7 @@ mod tests {
     use crate::{
         circuit::rescue::RescueNativeGadget,
         rescue::{
-            sponge::{RescueCRHF, RescuePRF},
+            sponge::{RescueCRHF, RescuePRFCore},
             Permutation, RescueMatrix, RescueParameter, RescueVector, CRHF_RATE, PRP, STATE_SIZE,
         },
     };
@@ -1021,7 +1021,7 @@ mod tests {
             .collect_vec();
 
         let expected_fsks_output =
-            RescuePRF::full_state_keyed_sponge_no_padding(&key, &data, 1).unwrap();
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, &data, 1).unwrap();
 
         let fsks_var = RescueNativeGadget::<F>::rescue_full_state_keyed_sponge_no_padding(
             &mut circuit,

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -227,6 +227,29 @@ where
         Ok(state.0[0])
     }
 
+    fn rescue_full_state_keyed_sponge_with_zero_padding(
+        &mut self,
+        key: Variable,
+        data_vars: &[Variable],
+    ) -> Result<Variable, CircuitError> {
+        if data_vars.is_empty() {
+            return Err(ParameterError("empty data vars".to_string()));
+        }
+
+        let zero_var = self.zero();
+        let data_vars = [
+            data_vars,
+            vec![
+                zero_var;
+                compute_len_to_next_multiple(data_vars.len(), STATE_SIZE) - data_vars.len()
+            ]
+            .as_ref(),
+        ]
+        .concat();
+
+        RescueNativeGadget::<F>::rescue_full_state_keyed_sponge_no_padding(self, key, &data_vars)
+    }
+
     fn key_schedule(
         &mut self,
         mds: &RescueMatrix<F>,

--- a/primitives/src/circuit/rescue/non_native.rs
+++ b/primitives/src/circuit/rescue/non_native.rs
@@ -665,7 +665,7 @@ mod tests {
     use crate::{
         circuit::rescue::RescueGadget,
         rescue::{
-            sponge::{RescueCRHF, RescuePRF},
+            sponge::{RescueCRHF, RescuePRFCore},
             Permutation, RescueMatrix, RescueParameter, RescueVector, CRHF_RATE, PRP, STATE_SIZE,
         },
     };
@@ -1224,7 +1224,7 @@ mod tests {
             .collect();
 
         let expected_fsks_output =
-            RescuePRF::full_state_keyed_sponge_no_padding(&key_t, &data_t, 1).unwrap();
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key_t, &data_t, 1).unwrap();
 
         let fsks_var = RescueNonNativeGadget::<T, F>::rescue_full_state_keyed_sponge_no_padding(
             &mut circuit,

--- a/primitives/src/prf.rs
+++ b/primitives/src/prf.rs
@@ -7,116 +7,101 @@
 //! This module implements a pseudo random function that is derived from
 //! the rescue hash function.
 
-use ark_std::marker::PhantomData;
-
 use crate::{
     errors::PrimitivesError,
-    rescue::{sponge::RescuePRF, RescueParameter, STATE_SIZE},
+    rescue::{sponge::RescuePRF as InnerRescuePRF, RescueParameter},
 };
-use ark_ff::PrimeField;
-use ark_serialize::*;
-use ark_std::{borrow::ToOwned, format, string::ToString, vec::Vec};
-use jf_utils::pad_with_zeros;
-use zeroize::Zeroize;
+use ark_std::{
+    borrow::Borrow,
+    fmt::Debug,
+    marker::PhantomData,
+    rand::{CryptoRng, RngCore},
+    UniformRand,
+};
 
-#[allow(clippy::upper_case_acronyms)]
-/// Pseudo-random function (PRF) instance for user defined input and output size
-pub struct PRF<F: RescueParameter> {
-    /// Length of the input.
-    pub input_len: usize,
-    /// Length of the output.
-    pub output_len: usize,
-    phantom_f: PhantomData<F>,
-}
+/// Trait for Pseudo-random Functions
+pub trait PRF {
+    // TODO: (alex) add `CanonicalDeserialize` to `Input`, `CanonicalSerialize` to
+    // `Output`, both to `Seed`, when we move to arkwork 0.2.0
+    /// Input to the PRF
+    type Input: Clone;
+    /// Output of the PRF
+    type Output: Clone + Debug + PartialEq + Eq;
+    /// The random seed/key that index a specific function from the PRF
+    /// ensembles
+    type Seed: Clone + Debug + Default + UniformRand;
 
-#[derive(
-    Clone, Default, Debug, PartialEq, Eq, Hash, Zeroize, CanonicalSerialize, CanonicalDeserialize,
-)]
-/// Key data-type of Pseudo-random function consisting on a single scalar
-/// element.
-pub struct PrfKey<F: PrimeField>(pub(crate) F);
+    /// Compute PRF output with a user-provided randomly generated `seed`
+    fn evaluate<S: Borrow<Self::Seed>, I: Borrow<Self::Input>>(
+        seed: S,
+        input: I,
+    ) -> Result<Self::Output, PrimitivesError>;
 
-impl<F: PrimeField> Drop for PrfKey<F> {
-    fn drop(&mut self) {
-        self.0.zeroize();
+    /// same as [`Self::evaluate`] except that we generate a fresh random seed
+    /// for the evaluation
+    fn evaluate_with_rand_seed<R: RngCore + CryptoRng, T: Borrow<Self::Input>>(
+        rng: &mut R,
+        input: T,
+    ) -> Result<(Self::Seed, Self::Output), PrimitivesError> {
+        let seed = Self::Seed::rand(rng);
+        let output = Self::evaluate(&seed, input)?;
+        Ok((seed, output))
     }
 }
 
-impl<F: PrimeField> From<F> for PrfKey<F> {
-    fn from(key: F) -> Self {
-        PrfKey(key)
+#[derive(Debug, Clone)]
+/// A rescue-based PRF that leverages on Full State Keyed (FSK) sponge
+/// construction
+pub struct RescuePRF<F: RescueParameter, const INPUT_LEN: usize, const OUTPUT_LEN: usize>(
+    PhantomData<F>,
+);
+
+impl<F: RescueParameter, const INPUT_LEN: usize, const OUTPUT_LEN: usize> PRF
+    for RescuePRF<F, INPUT_LEN, OUTPUT_LEN>
+{
+    type Input = [F; INPUT_LEN];
+    type Output = [F; OUTPUT_LEN];
+    type Seed = F;
+
+    fn evaluate<S: Borrow<Self::Seed>, I: Borrow<Self::Input>>(
+        seed: S,
+        input: I,
+    ) -> Result<Self::Output, PrimitivesError> {
+        let mut output = [F::zero(); OUTPUT_LEN];
+        output.clone_from_slice(&InnerRescuePRF::full_state_keyed_sponge_with_zero_padding(
+            seed.borrow(),
+            input.borrow(),
+            OUTPUT_LEN,
+        )?);
+        Ok(output)
     }
 }
-
-impl<F: PrimeField> PrfKey<F> {
-    /// return the internal field value
-    pub fn internal(&self) -> F {
-        self.0
-    }
-}
-
-impl<F: RescueParameter> PRF<F> {
-    /// Pseudo-random function instance constructor
-    /// `input_len`: number of input scalars for the function
-    /// `output_len`: number of scalar outputs for the function
-    pub fn new(input_len: usize, output_len: usize) -> PRF<F> {
-        PRF {
-            input_len,
-            output_len,
-            phantom_f: PhantomData,
-        }
-    }
-
-    /// Key generation for Pseudo-random function
-    pub fn key_gen<R: ark_std::rand::RngCore>(&self, rng: &mut R) -> PrfKey<F> {
-        PrfKey::from(F::rand(rng))
-    }
-
-    /// Compute output of pseudo-random function for a given key and input
-    /// Return Err(PrimitivesError::ParameterError) if input length does not
-    /// match instance defined input length
-    pub fn eval(&self, key: &PrfKey<F>, input: &[F]) -> Result<Vec<F>, PrimitivesError> {
-        if input.len() != self.input_len {
-            return Err(PrimitivesError::ParameterError(format!(
-                "PRF Error: input length ({}) does not match instance ({})",
-                input.len(),
-                self.input_len
-            )));
-        }
-        // Ok to pad with 0's since input length is fixed for the PRF instance
-        let mut padded = input.to_owned();
-        pad_with_zeros(&mut padded, STATE_SIZE);
-        RescuePRF::full_state_keyed_sponge_no_padding(&key.0, &padded, self.output_len).map_err(
-            |_| PrimitivesError::InternalError("Bug in PRF: bad padding for input".to_string()),
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::prf::PRF;
+    use crate::{
+        prf::{RescuePRF, PRF},
+        rescue::sponge::RescuePRF as InnerRescuePRF,
+    };
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
     use ark_ed_on_bls12_381::Fq as FqEd381;
     use ark_ed_on_bn254::Fq as FqEd254;
-    use ark_ff::One;
-    use ark_std::vec;
+    use ark_std::UniformRand;
     macro_rules! test_prf {
         ($tr:tt) => {
-            let mut prng = ark_std::test_rng();
-            let prf = PRF::new(1, 15);
-            let key = prf.key_gen(&mut prng);
-            let input = vec![$tr::one()];
-            let out = prf.eval(&key, &input);
-            assert!(out.is_ok());
+            let mut rng = ark_std::test_rng();
+            let seed = $tr::rand(&mut rng);
+            let input = [$tr::from(1u8)];
 
-            let input = vec![];
-            let out = prf.eval(&key, &input);
-            assert!(out.is_err());
-
-            let input = vec![$tr::one(); 2];
-            let out = prf.eval(&key, &input);
-            assert!(out.is_err());
+            assert!(RescuePRF::<$tr, 1, 15>::evaluate(&seed, &input).is_ok());
+            // check correctness
+            assert_eq!(
+                RescuePRF::<$tr, 1, 15>::evaluate(&seed, &input)
+                    .unwrap()
+                    .to_vec(),
+                InnerRescuePRF::full_state_keyed_sponge_with_zero_padding(&seed, &input, 15)
+                    .unwrap()
+            );
         };
     }
 

--- a/primitives/src/prf.rs
+++ b/primitives/src/prf.rs
@@ -22,7 +22,7 @@ use ark_std::{
 /// Trait for Pseudo-random Functions
 pub trait PRF {
     // TODO: (alex) add `CanonicalDeserialize` to `Input`, `CanonicalSerialize` to
-    // `Output`, both to `Seed`, when we move to arkwork 0.2.0
+    // `Output`, both to `Seed`, when we move to arkworks 0.4.0
     /// Input to the PRF
     type Input: Clone;
     /// Output of the PRF

--- a/primitives/src/prf.rs
+++ b/primitives/src/prf.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     errors::PrimitivesError,
-    rescue::{sponge::RescuePRF as InnerRescuePRF, RescueParameter},
+    rescue::{sponge::RescuePRFCore, RescueParameter},
 };
 use ark_std::{
     borrow::Borrow,
@@ -68,7 +68,7 @@ impl<F: RescueParameter, const INPUT_LEN: usize, const OUTPUT_LEN: usize> PRF
         input: I,
     ) -> Result<Self::Output, PrimitivesError> {
         let mut output = [F::zero(); OUTPUT_LEN];
-        output.clone_from_slice(&InnerRescuePRF::full_state_keyed_sponge_with_zero_padding(
+        output.clone_from_slice(&RescuePRFCore::full_state_keyed_sponge_with_zero_padding(
             seed.borrow(),
             input.borrow(),
             OUTPUT_LEN,
@@ -80,7 +80,7 @@ impl<F: RescueParameter, const INPUT_LEN: usize, const OUTPUT_LEN: usize> PRF
 mod tests {
     use crate::{
         prf::{RescuePRF, PRF},
-        rescue::sponge::RescuePRF as InnerRescuePRF,
+        rescue::sponge::RescuePRFCore,
     };
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
@@ -99,7 +99,7 @@ mod tests {
                 RescuePRF::<$tr, 1, 15>::evaluate(&seed, &input)
                     .unwrap()
                     .to_vec(),
-                InnerRescuePRF::full_state_keyed_sponge_with_zero_padding(&seed, &input, 15)
+                RescuePRFCore::full_state_keyed_sponge_with_zero_padding(&seed, &input, 15)
                     .unwrap()
             );
         };

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -883,23 +883,33 @@ mod test_permutation {
         let key = F::rand(&mut ark_std::test_rng());
         let input = [F::zero(), F::one(), F::zero(), F::zero()];
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 0).len(),
+            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 0)
+                .unwrap()
+                .len(),
             0
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 1).len(),
+            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 1)
+                .unwrap()
+                .len(),
             1
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 2).len(),
+            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 2)
+                .unwrap()
+                .len(),
             2
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 4).len(),
+            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 4)
+                .unwrap()
+                .len(),
             4
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_padding(&key, &input, 10).len(),
+            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 10)
+                .unwrap()
+                .len(),
             10
         );
         assert_eq!(

--- a/primitives/src/rescue/mod.rs
+++ b/primitives/src/rescue/mod.rs
@@ -629,7 +629,7 @@ mod test_prp {
 #[cfg(test)]
 mod test_permutation {
     use crate::rescue::{
-        sponge::{RescueCRHF, RescuePRF},
+        sponge::{RescueCRHF, RescuePRFCore},
         Permutation, RescueParameter, RescueVector, PRP,
     };
     use ark_bls12_377::Fq as Fq377;
@@ -845,18 +845,28 @@ mod test_permutation {
     fn test_fsks_no_padding_errors_helper<F: RescueParameter>() {
         let key = F::rand(&mut ark_std::test_rng());
         let input = vec![F::from(9u64); 4];
-        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok());
+        assert!(
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok()
+        );
         let input = vec![F::from(9u64); 12];
-        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok());
+        assert!(
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok()
+        );
 
         // test should panic because number of inputs is not multiple of 3
         let input = vec![F::from(9u64); 10];
-        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_err());
+        assert!(
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_err()
+        );
         let input = vec![F::from(9u64)];
-        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_err());
+        assert!(
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_err()
+        );
 
         let input = vec![];
-        assert!(RescuePRF::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok());
+        assert!(
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, input.as_slice(), 1).is_ok()
+        );
     }
 
     #[test]
@@ -883,61 +893,61 @@ mod test_permutation {
         let key = F::rand(&mut ark_std::test_rng());
         let input = [F::zero(), F::one(), F::zero(), F::zero()];
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 0)
+            RescuePRFCore::full_state_keyed_sponge_with_zero_padding(&key, &input, 0)
                 .unwrap()
                 .len(),
             0
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 1)
+            RescuePRFCore::full_state_keyed_sponge_with_zero_padding(&key, &input, 1)
                 .unwrap()
                 .len(),
             1
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 2)
+            RescuePRFCore::full_state_keyed_sponge_with_zero_padding(&key, &input, 2)
                 .unwrap()
                 .len(),
             2
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 4)
+            RescuePRFCore::full_state_keyed_sponge_with_zero_padding(&key, &input, 4)
                 .unwrap()
                 .len(),
             4
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_with_bit_padding(&key, &input, 10)
+            RescuePRFCore::full_state_keyed_sponge_with_zero_padding(&key, &input, 10)
                 .unwrap()
                 .len(),
             10
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 0)
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, &input, 0)
                 .unwrap()
                 .len(),
             0
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 1)
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, &input, 1)
                 .unwrap()
                 .len(),
             1
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 2)
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, &input, 2)
                 .unwrap()
                 .len(),
             2
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 4)
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, &input, 4)
                 .unwrap()
                 .len(),
             4
         );
         assert_eq!(
-            RescuePRF::full_state_keyed_sponge_no_padding(&key, &input, 10)
+            RescuePRFCore::full_state_keyed_sponge_no_padding(&key, &input, 10)
                 .unwrap()
                 .len(),
             10

--- a/primitives/src/rescue/sponge.rs
+++ b/primitives/src/rescue/sponge.rs
@@ -32,7 +32,8 @@ pub(crate) struct RescueCRHF<F: RescueParameter> {
 }
 
 /// PRF
-pub(crate) struct RescuePRF<F: RescueParameter> {
+#[derive(Debug, Clone)]
+pub(crate) struct RescuePRFCore<F: RescueParameter> {
     sponge: RescueSponge<F, STATE_SIZE>,
 }
 
@@ -87,25 +88,7 @@ impl<F: RescueParameter> RescueCRHF<F> {
     }
 }
 
-impl<F: RescueParameter> RescuePRF<F> {
-    #[allow(dead_code)]
-    /// Pseudorandom function based on rescue permutation for RATE 4. It allows
-    /// unrestricted variable length input and returns a vector of
-    /// `num_outputs` elements.
-    ///
-    /// ## Padding
-    /// Same as that in [`RescueCRHF::sponge_with_bit_padding`].
-    pub(crate) fn full_state_keyed_sponge_with_bit_padding(
-        key: &F,
-        input: &[F],
-        num_outputs: usize,
-    ) -> Result<Vec<F>, RescueError> {
-        let mut padded_input = input.to_vec();
-        padded_input.push(F::one());
-        pad_with_zeros(&mut padded_input, STATE_SIZE);
-        Self::full_state_keyed_sponge_no_padding(key, padded_input.as_slice(), num_outputs)
-    }
-
+impl<F: RescueParameter> RescuePRFCore<F> {
     /// Similar to [`Self::full_state_keyed_sponge_with_bit_padding`] except the
     /// padding scheme are all "0" until the length of padded input is a
     /// multiple of `STATE_SIZE`


### PR DESCRIPTION
## Description

Major changes include:
- Introduced `trait PRF` 
- Conform existing impl in `prf.rs` to the new trait
- Add missing method rescue_full_state_keyed_sponge_with_padding on [RescueGadget](https://github.com/EspressoSystems/jellyfish/blob/9b7beb26360fb72eb80259330e37aa942e3bf854/primitives/src/circuit/rescue/native.rs#L188)
- Rename `PrfGadget` to `PRFGadget`

(the last two points or so are suggested by @tessico in #160)

Closes: #168, #160 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
