### PR TITLE
Bug fixes for universal Merkle tree

### DIFF
--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -151,7 +151,7 @@ where
     }
 
     pub fn elem(&self) -> Option<&E> {
-        match self.proof.last() {
+        match self.proof.first() {
             Some(MerkleNode::Leaf { elem, .. }) => Some(elem),
             _ => None,
         }
@@ -467,13 +467,24 @@ where
                 *value = H::digest_leaf(pos, elem);
                 LookupResult::Ok(ret, ())
             },
-            MerkleNode::Branch { value: _, children } => (*children[traversal_path[height - 1]])
-                .update_internal::<H, Arity>(
-                height - 1,
-                pos,
-                traversal_path,
-                elem,
-            ),
+            MerkleNode::Branch { value, children } => {
+                let res = (*children[traversal_path[height - 1]]).update_internal::<H, Arity>(
+                    height - 1,
+                    pos,
+                    traversal_path,
+                    elem,
+                );
+                // If the branch containing the update was not in memory, the update failed and
+                // nothing was changed, so we can short-circuit without recomputing this node's
+                // value.
+                if res == LookupResult::NotInMemory {
+                    return res;
+                }
+                // Otherwise, an entry has been updated and the value of one of our children has
+                // changed, so we must recompute our own value.
+                *value = digest_branch::<E, H, I, T>(children);
+                res
+            },
             MerkleNode::Empty => {
                 *self = if height == 0 {
                     MerkleNode::Leaf {


### PR DESCRIPTION
* MerkleProof::elem() was looking at the last node in the proof; it should look at the first, since the proof goes from the leaf to the root.
* update_internal was not updating the value of parent nodes when one of their children was changed due to an update. This caused the tree invariants to be violated after an update, and proof verification to fail.

<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
