### PR TITLE
Add trait bounds to VRF's associated types

### DIFF
--- a/primitives/src/vrf/mod.rs
+++ b/primitives/src/vrf/mod.rs
@@ -4,6 +4,9 @@ use crate::errors::PrimitivesError;
 use ark_std::rand::{CryptoRng, RngCore};
 pub mod blsvrf;
 pub mod ecvrf;
+use core::fmt::Debug;
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 /// A trait for VRF proof, evaluation and verification.
 pub trait Vrf {
@@ -11,19 +14,34 @@ pub trait Vrf {
     type PublicParameter;
 
     /// VRF public key.
-    type PublicKey;
+    type PublicKey: Debug
+        + Clone
+        + Send
+        + Sync
+        + for<'a> Deserialize<'a>
+        + Serialize
+        + PartialEq
+        + Eq;
 
     /// VRF secret key.
-    type SecretKey;
+    type SecretKey: Debug
+        + Clone
+        + Send
+        + Sync
+        + Zeroize
+        + for<'a> Deserialize<'a>
+        + Serialize
+        + PartialEq
+        + Eq;
 
     /// VRF signature.
-    type Proof;
+    type Proof: Debug + Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize + PartialEq + Eq;
 
     /// The input of VRF proof.
-    type Input;
+    type Input: Debug + Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize + PartialEq + Eq;
 
     /// The output of VRF evaluation.
-    type Output;
+    type Output: Debug + Clone + Send + Sync + for<'a> Deserialize<'a> + Serialize + PartialEq + Eq;
 
     /// generate public parameters from RNG.
     /// If the RNG is not presented, use the default group generator.


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: https://github.com/EspressoSystems/jellyfish/issues/166

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
