### PR TITLE
Add ForgetableUniversalMerkleTreeScheme

### DIFF
--- a/primitives/src/merkle_tree/prelude.rs
+++ b/primitives/src/merkle_tree/prelude.rs
@@ -10,9 +10,9 @@ pub use crate::{
     impl_to_traversal_path_biguint, impl_to_traversal_path_primitives,
     merkle_tree::{
         append_only::MerkleTree, universal_merkle_tree::UniversalMerkleTree,
-        AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
-        LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
-        UniversalMerkleTreeScheme,
+        AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme,
+        ForgetableUniversalMerkleTreeScheme, Index, LookupResult, MerkleCommitment,
+        MerkleTreeScheme, NodeValue, ToTraversalPath, UniversalMerkleTreeScheme,
     },
 };
 

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -7,8 +7,9 @@
 //! Implementation of a typical Sparse Merkle Tree.
 use super::{
     internal::{build_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment},
-    DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index, LookupResult, MerkleCommitment,
-    MerkleTreeScheme, NodeValue, ToTraversalPath, UniversalMerkleTreeScheme,
+    DigestAlgorithm, Element, ForgetableMerkleTreeScheme, ForgetableUniversalMerkleTreeScheme,
+    Index, LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
+    UniversalMerkleTreeScheme,
 };
 use crate::{errors::PrimitivesError, impl_forgetable_merkle_tree_scheme, impl_merkle_tree_scheme};
 use ark_std::{
@@ -101,13 +102,84 @@ where
     }
 }
 
+impl<E, H, I, Arity, T> ForgetableUniversalMerkleTreeScheme
+    for UniversalMerkleTree<E, H, I, Arity, T>
+where
+    E: Element,
+    H: DigestAlgorithm<E, I, T>,
+    I: Index + From<u64> + ToTraversalPath<Arity>,
+    Arity: Unsigned,
+    T: NodeValue,
+{
+    fn universal_forget(
+        &mut self,
+        pos: Self::Index,
+    ) -> LookupResult<Self::Element, Self::MembershipProof, Self::NonMembershipProof> {
+        let traversal_path = pos.to_traversal_path(self.height);
+        match self.root.forget_internal(self.height, &traversal_path) {
+            LookupResult::Ok(elem, proof) => LookupResult::Ok(elem, MerkleProof::new(pos, proof)),
+            LookupResult::NotInMemory => LookupResult::NotInMemory,
+            LookupResult::NotFound(proof) => LookupResult::NotFound(MerkleProof::new(pos, proof)),
+        }
+    }
+
+    fn non_membership_remember(
+        &mut self,
+        pos: Self::Index,
+        proof: impl Borrow<Self::NonMembershipProof>,
+    ) -> Result<(), PrimitivesError> {
+        let proof = proof.borrow();
+        let traversal_path = pos.to_traversal_path(self.height);
+        if matches!(&proof.proof[0], MerkleNode::Empty) {
+            let empty_value = T::default();
+            let mut path_values = vec![empty_value];
+            traversal_path.iter().zip(proof.proof.iter().skip(1)).fold(
+                Ok(empty_value),
+                |result, (branch, node)| -> Result<T, PrimitivesError> {
+                    match result {
+                        Ok(val) => match node {
+                            MerkleNode::Branch { value: _, children } => {
+                                let mut data: Vec<_> =
+                                    children.iter().map(|node| node.value()).collect();
+                                data[*branch] = val;
+                                let digest = H::digest(&data);
+                                path_values.push(digest);
+                                Ok(digest)
+                            },
+                            MerkleNode::Empty => {
+                                path_values.push(empty_value);
+                                Ok(empty_value)
+                            },
+                            _ => Err(PrimitivesError::ParameterError(
+                                "Incompatible proof for this merkle tree".to_string(),
+                            )),
+                        },
+                        Err(e) => Err(e),
+                    }
+                },
+            )?;
+            self.root.remember_internal::<H, Arity>(
+                self.height,
+                &traversal_path,
+                &path_values,
+                &proof.proof,
+            )
+        } else {
+            Err(PrimitivesError::ParameterError(
+                "Invalid proof type".to_string(),
+            ))
+        }
+    }
+}
+
 #[cfg(test)]
 mod mt_tests {
     use crate::{
         merkle_tree::{
+            internal::{MerkleNode, MerkleProof},
             prelude::{RescueHash, RescueSparseMerkleTree},
-            DigestAlgorithm, Index, LookupResult, MerkleTreeScheme, ToTraversalPath,
-            UniversalMerkleTreeScheme,
+            DigestAlgorithm, ForgetableMerkleTreeScheme, ForgetableUniversalMerkleTreeScheme,
+            Index, LookupResult, MerkleTreeScheme, ToTraversalPath, UniversalMerkleTreeScheme,
         },
         rescue::RescueParameter,
     };
@@ -198,6 +270,172 @@ mod mt_tests {
             assert_eq!(val, F::from(i as u64));
             assert_eq!(*proof.elem().unwrap(), val);
             assert!(mt.verify(I::from(i as u64), &proof).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_universal_mt_forget_remember() {
+        test_universal_mt_forget_remember_helper::<Fq254>();
+        test_universal_mt_forget_remember_helper::<Fq377>();
+        test_universal_mt_forget_remember_helper::<Fq381>();
+    }
+
+    fn test_universal_mt_forget_remember_helper<F: RescueParameter>() {
+        let mut mt = RescueSparseMerkleTree::<BigUint, F, F>::from_kv_set(
+            10,
+            [
+                (BigUint::from(0u64), F::from(1u64)),
+                (BigUint::from(2u64), F::from(3u64)),
+            ],
+        )
+        .unwrap();
+
+        // Look up and forget an element that is in the tree.
+        let (lookup_elem, lookup_mem_proof) = mt
+            .universal_lookup(BigUint::from(0u64))
+            .expect_ok()
+            .unwrap();
+        let (elem, mem_proof) = mt.universal_forget(0u64.into()).expect_ok().unwrap();
+        assert_eq!(lookup_elem, elem);
+        assert_eq!(lookup_mem_proof, mem_proof);
+        assert_eq!(elem, 1u64.into());
+        assert_eq!(mem_proof.tree_height(), 11);
+        assert!(mt.verify(BigUint::from(0u64), &lookup_mem_proof).unwrap());
+        assert!(mt.verify(BigUint::from(0u64), &mem_proof).unwrap());
+
+        // Forgetting or looking up an element that is already forgotten should fail.
+        assert!(matches!(
+            mt.universal_forget(0u64.into()),
+            LookupResult::NotInMemory
+        ));
+        assert!(matches!(
+            mt.universal_lookup(BigUint::from(0u64)),
+            LookupResult::NotInMemory
+        ));
+
+        // We should still be able to look up an element that is not forgotten.
+        let (elem, proof) = mt
+            .universal_lookup(BigUint::from(2u64))
+            .expect_ok()
+            .unwrap();
+        assert_eq!(elem, 3u64.into());
+        assert!(mt.verify(BigUint::from(2u64), &proof).unwrap());
+
+        // Look up and forget an empty sub-tree.
+        let lookup_non_mem_proof = match mt.universal_lookup(BigUint::from(1u64)) {
+            LookupResult::NotFound(proof) => proof,
+            res => panic!("expected NotFound, got {:?}", res),
+        };
+        let non_mem_proof = match mt.universal_forget(BigUint::from(1u64)) {
+            LookupResult::NotFound(proof) => proof,
+            res => panic!("expected NotFound, got {:?}", res),
+        };
+        assert_eq!(lookup_non_mem_proof, non_mem_proof);
+        assert_eq!(non_mem_proof.tree_height(), 11);
+        assert!(mt
+            .non_membership_verify(BigUint::from(1u64), &lookup_non_mem_proof)
+            .unwrap());
+        assert!(mt
+            .non_membership_verify(BigUint::from(1u64), &non_mem_proof)
+            .unwrap());
+
+        // Forgetting an empty sub-tree will never actually cause any new entries to be
+        // forgotten, since empty sub-trees are _already_ treated as if they
+        // were forgotten when deciding whether to forget their parent. So even
+        // though we "forgot" it, the empty sub-tree is still in memory.
+        match mt.universal_lookup(BigUint::from(1u64)) {
+            LookupResult::NotFound(proof) => {
+                assert!(mt
+                    .non_membership_verify(BigUint::from(1u64), &proof)
+                    .unwrap());
+            },
+            res => {
+                panic!("expected NotFound, got {:?}", res);
+            },
+        }
+
+        // We should still be able to look up an element that is not forgotten.
+        let (elem, proof) = mt
+            .universal_lookup(BigUint::from(2u64))
+            .expect_ok()
+            .unwrap();
+        assert_eq!(elem, 3u64.into());
+        assert!(mt.verify(BigUint::from(2u64), &proof).unwrap());
+
+        // Now if we forget the last entry, which is the only thing keeping the root
+        // branch in memory, every entry will be forgotten.
+        mt.universal_forget(BigUint::from(2u64))
+            .expect_ok()
+            .unwrap();
+        assert!(matches!(
+            mt.universal_lookup(BigUint::from(0u64)),
+            LookupResult::NotInMemory
+        ));
+        assert!(matches!(
+            mt.universal_lookup(BigUint::from(1u64)),
+            LookupResult::NotInMemory
+        ));
+        assert!(matches!(
+            mt.universal_lookup(BigUint::from(2u64)),
+            LookupResult::NotInMemory
+        ));
+
+        // Remember should fail if the proof is invalid.
+        let mut bad_mem_proof = mem_proof.clone();
+        if let MerkleNode::Leaf { elem, .. } = &mut bad_mem_proof.proof[0] {
+            *elem = F::from(4u64);
+        } else {
+            panic!("expected membership proof to end in a Leaf");
+        }
+        mt.remember(0u64.into(), F::from(1u64), &bad_mem_proof)
+            .unwrap_err();
+
+        let mut bad_non_mem_proof = non_mem_proof.clone();
+        bad_non_mem_proof.proof[0] = MerkleNode::Leaf {
+            pos: 1u64.into(),
+            elem: Default::default(),
+            value: Default::default(),
+        };
+        mt.non_membership_remember(1u64.into(), &bad_non_mem_proof)
+            .unwrap_err();
+
+        let mut forge_mem_proof = MerkleProof::new(1u64.into(), mem_proof.proof.clone());
+        if let MerkleNode::Leaf { pos, elem, .. } = &mut forge_mem_proof.proof[0] {
+            *pos = 1u64.into();
+            *elem = F::from(0u64);
+        } else {
+            panic!("expected membership proof to end in a Leaf");
+        }
+        mt.remember(BigUint::from(1u64), F::from(0u64), &forge_mem_proof)
+            .unwrap_err();
+
+        let forge_non_mem_proof = non_mem_proof.clone();
+        assert!(matches!(forge_non_mem_proof.proof[0], MerkleNode::Empty));
+        mt.non_membership_remember(0u64.into(), &forge_non_mem_proof)
+            .unwrap_err();
+
+        // Remember an occupied and an empty  sub-tree.
+        mt.remember(0u64.into(), F::from(1u64), &mem_proof).unwrap();
+        mt.non_membership_remember(1u64.into(), &non_mem_proof)
+            .unwrap();
+
+        // We should be able to look up everything we remembered.
+        let (elem, proof) = mt
+            .universal_lookup(BigUint::from(0u64))
+            .expect_ok()
+            .unwrap();
+        assert_eq!(elem, 1u64.into());
+        assert!(mt.verify(BigUint::from(0u64), &proof).unwrap());
+
+        match mt.universal_lookup(BigUint::from(1u64)) {
+            LookupResult::NotFound(proof) => {
+                assert!(mt
+                    .non_membership_verify(BigUint::from(1u64), &proof)
+                    .unwrap());
+            },
+            res => {
+                panic!("expected NotFound, got {:?}", res);
+            },
         }
     }
 


### PR DESCRIPTION
_Needed this for a personal project, not work-related. Review at your leisure. I believe it does fix a bug, though._

This trait extends the existing `UniversalMerkleTreeScheme` with two new functions:
* `universal_forget` is like `forget` from `ForgetableMerkleTreeScheme`, but returns a non-membership proof if the result is `NotFound`
* `non_membership_remember` re-inserts an empty sub-tree given a non-membership proof

Also fixes a bug in `forget_internal` where `height` was not decremented in recursive calls.