### PR TITLE
Update naming for IOPTranscript

### DIFF
--- a/plonk/src/proof_system/prover.rs
+++ b/plonk/src/proof_system/prover.rs
@@ -82,7 +82,7 @@ impl<E: PairingEngine> Prover<E> {
             .into_iter()
             .map(|poly| self.mask_polynomial(prng, poly, 1))
             .collect();
-        let wires_poly_comms = UnivariateKzgPCS::multi_commit(ck, &wire_polys)?;
+        let wires_poly_comms = UnivariateKzgPCS::batch_commit(ck, &wire_polys)?;
         let pub_input_poly = cs.compute_pub_input_polynomial()?;
         Ok(((wires_poly_comms, wire_polys), pub_input_poly))
     }
@@ -106,7 +106,7 @@ impl<E: PairingEngine> Prover<E> {
         let h_1_poly = self.mask_polynomial(prng, h_1_poly, 2);
         let h_2_poly = self.mask_polynomial(prng, h_2_poly, 2);
         let h_polys = vec![h_1_poly, h_2_poly];
-        let h_poly_comms = UnivariateKzgPCS::multi_commit(ck, &h_polys)?;
+        let h_poly_comms = UnivariateKzgPCS::batch_commit(ck, &h_polys)?;
         Ok(((h_poly_comms, h_polys), sorted_vec, merged_lookup_table))
     }
 
@@ -176,7 +176,7 @@ impl<E: PairingEngine> Prover<E> {
         let quot_poly =
             self.compute_quotient_polynomial(challenges, pks, online_oracles, num_wire_types)?;
         let split_quot_polys = self.split_quotient_polynomial(prng, &quot_poly, num_wire_types)?;
-        let split_quot_poly_comms = UnivariateKzgPCS::multi_commit(ck, &split_quot_polys)?;
+        let split_quot_poly_comms = UnivariateKzgPCS::batch_commit(ck, &split_quot_polys)?;
 
         Ok((split_quot_poly_comms, split_quot_polys))
     }

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -92,13 +92,14 @@ pub trait PolynomialCommitmentScheme<E: PairingEngine> {
     /// &Self::ProverParam, ..)` or `commit(prover_param:
     /// Box<Self::ProverParam>, ..)` or `commit(prover_param:
     /// Arc<Self::ProverParam>, ..)` etc.
+    /// Also, the commitment is not necessarily hiding.
     fn commit(
         prover_param: impl Borrow<Self::ProverParam>,
         poly: &Self::Polynomial,
     ) -> Result<Self::Commitment, PCSError>;
 
-    /// Generate a commitment for a list of polynomials
-    fn multi_commit(
+    /// Batch commit a list of polynomials
+    fn batch_commit(
         prover_param: impl Borrow<Self::ProverParam>,
         polys: &[Self::Polynomial],
     ) -> Result<Self::BatchCommitment, PCSError>;
@@ -111,11 +112,11 @@ pub trait PolynomialCommitmentScheme<E: PairingEngine> {
         point: &Self::Point,
     ) -> Result<(Self::Proof, Self::Evaluation), PCSError>;
 
-    /// Input a list of multilinear extensions, and a same number of points, and
-    /// a transcript, compute a multi-opening for all the polynomials.
-    fn multi_open(
+    /// Input a list of polynomials, and a same number of points,
+    /// compute a batch opening for all the polynomials.
+    fn batch_open(
         prover_param: impl Borrow<Self::ProverParam>,
-        multi_commitment: &Self::BatchCommitment,
+        batch_commitment: &Self::BatchCommitment,
         polynomials: &[Self::Polynomial],
         points: &[Self::Point],
     ) -> Result<(Self::BatchProof, Vec<Self::Evaluation>), PCSError>;

--- a/primitives/src/pcs/multilinear_kzg/batching.rs
+++ b/primitives/src/pcs/multilinear_kzg/batching.rs
@@ -25,9 +25,9 @@ use ark_std::{end_timer, format, rc::Rc, start_timer, string::ToString, vec, vec
 /// - the prover parameters for univariate KZG,
 /// - the prover parameters for multilinear KZG,
 /// - a list of MLEs,
-/// - a commitment to all MLEs
+/// - a batch commitment to all MLEs
 /// - and a same number of points,
-/// compute a multi-opening for all the polynomials.
+/// compute a batch opening for all the polynomials.
 ///
 /// For simplicity, this API requires each MLE to have only one point. If
 /// the caller wish to use more than one points per MLE, it should be
@@ -52,14 +52,14 @@ use ark_std::{end_timer, format, rc::Rc, start_timer, string::ToString, vec, vec
 /// 7. get a point `p := l(r)`
 /// 8. output an opening of `w` over point `p`
 /// 9. output `w(p)`
-pub(super) fn multi_open_internal<E: PairingEngine>(
+pub(super) fn batch_open_internal<E: PairingEngine>(
     uni_prover_param: &UnivariateProverParam<E::G1Affine>,
     ml_prover_param: &MultilinearProverParam<E>,
     polynomials: &[Rc<DenseMultilinearExtension<E::Fr>>],
-    multi_commitment: &Commitment<E>,
+    batch_commitment: &Commitment<E>,
     points: &[Vec<E::Fr>],
 ) -> Result<(MultilinearKzgBatchProof<E>, Vec<E::Fr>), PCSError> {
-    let open_timer = start_timer!(|| "multi open");
+    let open_timer = start_timer!(|| "batch open");
 
     // ===================================
     // Sanity checks on inputs
@@ -106,7 +106,7 @@ pub(super) fn multi_open_internal<E: PairingEngine>(
     // 4. commit to q(x) and sample r from transcript
     // transcript contains: w commitment, points, q(x)'s commitment
     let mut transcript = IOPTranscript::new(b"ml kzg");
-    transcript.append_serializable_element(b"w", multi_commitment)?;
+    transcript.append_serializable_element(b"w", batch_commitment)?;
     for point in points {
         transcript.append_serializable_element(b"w", point)?;
     }
@@ -171,7 +171,7 @@ pub(super) fn multi_open_internal<E: PairingEngine>(
     ))
 }
 
-/// Verifies that the `multi_commitment` is a valid commitment
+/// Verifies that the `batch_commitment` is a valid commitment
 /// to a list of MLEs for the given openings and evaluations in
 /// the batch_proof.
 ///
@@ -188,7 +188,7 @@ pub(super) fn multi_open_internal<E: PairingEngine>(
 pub(super) fn batch_verify_internal<E: PairingEngine>(
     uni_verifier_param: &UnivariateVerifierParam<E>,
     ml_verifier_param: &MultilinearVerifierParam<E>,
-    multi_commitment: &Commitment<E>,
+    batch_commitment: &Commitment<E>,
     points: &[Vec<E::Fr>],
     values: &[E::Fr],
     batch_proof: &MultilinearKzgBatchProof<E>,
@@ -231,7 +231,7 @@ pub(super) fn batch_verify_internal<E: PairingEngine>(
 
     // 1. push w, points and q_com into transcript
     let mut transcript = IOPTranscript::new(b"ml kzg");
-    transcript.append_serializable_element(b"w", multi_commitment)?;
+    transcript.append_serializable_element(b"w", batch_commitment)?;
     for point in points {
         transcript.append_serializable_element(b"w", point)?;
     }
@@ -279,7 +279,7 @@ pub(super) fn batch_verify_internal<E: PairingEngine>(
     // 6. verifies `p` is valid against multilinear KZG proof
     let res = verify_internal(
         ml_verifier_param,
-        multi_commitment,
+        batch_commitment,
         &point,
         &values[points_len],
         &batch_proof.proof,
@@ -312,7 +312,7 @@ mod tests {
     use ark_std::{log2, rand::RngCore, test_rng, vec::Vec, UniformRand};
     type Fr = <E as PairingEngine>::Fr;
 
-    fn test_multi_commit_helper<R: RngCore + CryptoRng>(
+    fn test_batch_commit_helper<R: RngCore + CryptoRng>(
         uni_params: &UnivariateUniversalParams<E>,
         ml_params: &MultilinearUniversalParams<E>,
         polys: &[Rc<DenseMultilinearExtension<Fr>>],
@@ -335,9 +335,9 @@ mod tests {
 
         let evals = generate_evaluations(polys, &points)?;
 
-        let com = MultilinearKzgPCS::multi_commit(&(ml_ck.clone(), uni_ck.clone()), polys)?;
+        let com = MultilinearKzgPCS::batch_commit(&(ml_ck.clone(), uni_ck.clone()), polys)?;
         let (batch_proof, evaluations) =
-            multi_open_internal(&uni_ck, &ml_ck, polys, &com, &points)?;
+            batch_open_internal(&uni_ck, &ml_ck, polys, &com, &points)?;
 
         for (a, b) in evals.iter().zip(evaluations.iter()) {
             assert_eq!(a, b)
@@ -410,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_commit_internal() -> Result<(), PCSError> {
+    fn test_batch_commit_internal() -> Result<(), PCSError> {
         let mut rng = test_rng();
 
         let uni_params =
@@ -421,13 +421,13 @@ mod tests {
         let polys1: Vec<_> = (0..5)
             .map(|_| Rc::new(DenseMultilinearExtension::rand(4, &mut rng)))
             .collect();
-        test_multi_commit_helper(&uni_params, &ml_params, &polys1, &mut rng)?;
+        test_batch_commit_helper(&uni_params, &ml_params, &polys1, &mut rng)?;
 
         // single-variate polynomials
         let polys1: Vec<_> = (0..5)
             .map(|_| Rc::new(DenseMultilinearExtension::rand(1, &mut rng)))
             .collect();
-        test_multi_commit_helper(&uni_params, &ml_params, &polys1, &mut rng)?;
+        test_batch_commit_helper(&uni_params, &ml_params, &polys1, &mut rng)?;
 
         Ok(())
     }

--- a/primitives/src/pcs/transcript.rs
+++ b/primitives/src/pcs/transcript.rs
@@ -5,8 +5,6 @@
 // along with the Jellyfish library. If not, see <https://mit-license.org/>.
 
 //! Module for PolyIOP transcript.
-// TODO(chengyu): merge it with jf-plonk/transcript or remove transcript
-// dependency for pcs module
 
 mod errors {
     use ark_std::string::String;

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -123,7 +123,7 @@ impl<E: PairingEngine> PolynomialCommitmentScheme<E> for UnivariateKzgPCS<E> {
     }
 
     /// Generate a commitment for a list of polynomials
-    fn multi_commit(
+    fn batch_commit(
         prover_param: impl Borrow<Self::ProverParam>,
         polys: &[Self::Polynomial],
     ) -> Result<Self::BatchCommitment, PCSError> {
@@ -172,7 +172,7 @@ impl<E: PairingEngine> PolynomialCommitmentScheme<E> for UnivariateKzgPCS<E> {
     // This is a naive approach
     // TODO: to implement the more efficient batch opening algorithm
     // (e.g., the appendix C.4 in https://eprint.iacr.org/2020/1536.pdf)
-    fn multi_open(
+    fn batch_open(
         prover_param: impl Borrow<Self::ProverParam>,
         _multi_commitment: &Self::BatchCommitment,
         polynomials: &[Self::Polynomial],


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #159 
After investigation, the transcript modules in `primitives/pcs` and `plonk` are not overlapping. Former one is an IOPTranscript that help build batch commitment/opening for PCS and the later one is specific for plonk.
It's okay to keep both modules.
I do rename all the method `multi_*` to `batch_*`, because I think the later one is more clear. The former one may confuse users with the other term "multi-linear extension".

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
