### PR TITLE
Fix clippy error in CI

### DIFF
--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "jf-plonk"
 description = "UltraPlonk implementation"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
-rust-version.workspace = true
+# can change back to version.workspace = true after the following issue is fixed:
+# https://github.com/DevinR528/cargo-sort/issues/47
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }

--- a/plonk/src/errors.rs
+++ b/plonk/src/errors.rs
@@ -103,6 +103,6 @@ impl From<PlonkError> for CircuitError {
     // this happen during invocation of Plonk proof system API inside Verifier
     // gadget
     fn from(e: PlonkError) -> Self {
-        Self::ParameterError(format!("Plonk proof system err: {:?}", e))
+        Self::ParameterError(format!("Plonk proof system err: {e:?}"))
     }
 }

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -93,8 +93,7 @@ where
             }
             if vk.plookup_vk.is_some() != batch_proof.plookup_proofs_vec[i].is_some() {
                 return Err(ParameterError(format!(
-                    "Mismatched proof type and verification key type for the {}-th instance",
-                    i
+                    "Mismatched proof type and verification key type for the {i}-th instance",
                 ))
                 .into());
             }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "jf-primitives"
 description = "Cryptographic primitives"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
-rust-version.workspace = true
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }

--- a/primitives/src/aead.rs
+++ b/primitives/src/aead.rs
@@ -98,7 +98,7 @@ impl EncKey {
         // encrypt the message and associated data using crypto box
         let ct = my_box
             .encrypt(&nonce, Payload { msg: message, aad })
-            .map_err(|e| PrimitivesError::InternalError(format!("{}", e)))?;
+            .map_err(|e| PrimitivesError::InternalError(format!("{e:?}")))?;
 
         Ok(Ciphertext {
             nonce,
@@ -204,7 +204,7 @@ impl KeyPair {
                     aad,
                 },
             )
-            .map_err(|e| PrimitivesError::FailedDecryption(format!("{}", e)))?;
+            .map_err(|e| PrimitivesError::FailedDecryption(format!("{e:?}")))?;
         Ok(plaintext)
     }
 }

--- a/primitives/src/errors.rs
+++ b/primitives/src/errors.rs
@@ -53,8 +53,8 @@ impl From<BLST_ERROR> for PrimitivesError {
             BLST_ERROR::BLST_SUCCESS => {
                 Self::InternalError("Expecting an error, but got a sucess.".to_string())
             },
-            BLST_ERROR::BLST_VERIFY_FAIL => Self::VerificationError(format!("{:?}", e)),
-            _ => Self::ParameterError(format!("{:?}", e)),
+            BLST_ERROR::BLST_VERIFY_FAIL => Self::VerificationError(format!("{e:?}")),
+            _ => Self::ParameterError(format!("{e:?}")),
         }
     }
 }

--- a/primitives/src/pcs/multilinear_kzg/srs.rs
+++ b/primitives/src/pcs/multilinear_kzg/srs.rs
@@ -103,8 +103,7 @@ impl<E: PairingEngine> StructuredReferenceString<E> for MultilinearUniversalPara
     ) -> Result<(Self::ProverParam, Self::VerifierParam), PCSError> {
         if supported_num_vars > self.prover_param.num_vars {
             return Err(PCSError::InvalidParameters(format!(
-                "SRS does not support target number of vars {}",
-                supported_num_vars
+                "SRS does not support target number of vars {supported_num_vars}"
             )));
         }
 

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -221,7 +221,7 @@ impl<E: PairingEngine> PolynomialCommitmentScheme<E> for UnivariateKzgPCS<E> {
 
         let res = E::product_of_pairings(pairing_inputs.iter()).is_one();
 
-        end_timer!(check_time, || format!("Result: {}", res));
+        end_timer!(check_time, || format!("Result: {res}"));
         Ok(res)
     }
 
@@ -281,7 +281,7 @@ impl<E: PairingEngine> PolynomialCommitmentScheme<E> for UnivariateKzgPCS<E> {
         ])
         .is_one();
         end_timer!(pairing_time);
-        end_timer!(check_time, || format!("Result: {}", result));
+        end_timer!(check_time, || format!("Result: {result}"));
         Ok(result)
     }
 }

--- a/primitives/src/signatures/bls.rs
+++ b/primitives/src/signatures/bls.rs
@@ -346,7 +346,7 @@ impl SignatureScheme for BLSSignatureScheme {
     ) -> Result<(), PrimitivesError> {
         match sig.verify(false, msg.as_ref(), Self::CS_ID.as_bytes(), &[], vk, true) {
             BLST_ERROR::BLST_SUCCESS => Ok(()),
-            e => Err(PrimitivesError::VerificationError(format!("{:?}", e))),
+            e => Err(PrimitivesError::VerificationError(format!("{e:?}"))),
         }
     }
 }

--- a/relation/Cargo.toml
+++ b/relation/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "jf-relation"
 description = "Jellyfish constraint system for PLONK"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
-rust-version.workspace = true
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", rev = "677b4ae751a274037880ede86e9b6f30f62635af" }

--- a/relation/src/constraint_system.rs
+++ b/relation/src/constraint_system.rs
@@ -629,8 +629,7 @@ impl<F: FftField> Circuit<F> for PlonkCircuit<F> {
                         return Err(GateCheckFailure(
                             gate_id,
                             format!(
-                                "Lookup gate failed: ({}, {}, {}, {}) not in the table",
-                                q_dom_sep, key, val0, val1
+                                "Lookup gate failed: ({q_dom_sep}, {key}, {val0}, {val1}) not in the table",
                             ),
                         ));
                     }

--- a/relation/src/gadgets/ultraplonk/mod_arith.rs
+++ b/relation/src/gadgets/ultraplonk/mod_arith.rs
@@ -261,8 +261,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
         let z_range = F::from(range_size as u32);
         if z >= z_range {
             return Err(ParameterError(format!(
-                "z = {} is out of range, the sum of variable values = {} might be too large for modulus = {}",
-                z, sum_x, p
+                "z = {z} is out of range, the sum of variable values = {sum_x} might be too large for modulus = {p}",
             )));
         }
 
@@ -396,8 +395,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
         let divisor_range = F::from(range_size as u32);
         if divisor >= divisor_range {
             return Err(ParameterError(format!(
-              "divisor = {} is out of range, the sum of variable values = {} might be too large for modulus = {}",
-              divisor, sum, p_f
+              "divisor = {divisor} is out of range, the sum of variable values = {sum} might be too large for modulus = {p_f}",
           ))
           );
         }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "jf-utils"
 description = "Utilities for Jellyfish cryptographic library"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
-license.workspace = true
-rust-version.workspace = true
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 ark-ec = { version = "0.3.0", default-features = false }

--- a/utilities/src/serialize.rs
+++ b/utilities/src/serialize.rs
@@ -65,7 +65,7 @@ pub mod canonical {
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         let mut bytes = Vec::new();
-        T::serialize(elem, &mut bytes).map_err(|err| S::Error::custom(format!("{}", err)))?;
+        T::serialize(elem, &mut bytes).map_err(|e| S::Error::custom(format!("{e:?}")))?;
         Serialize::serialize(&TaggedBase64::new("FIELD", &bytes).unwrap(), serializer)
     }
 
@@ -74,7 +74,7 @@ pub mod canonical {
     ) -> Result<T, D::Error> {
         let tb64 = <TaggedBase64 as Deserialize>::deserialize(deserializer)?;
         if tb64.tag() == "FIELD" {
-            T::deserialize(tb64.as_ref()).map_err(|err| D::Error::custom(format!("{}", err)))
+            T::deserialize(tb64.as_ref()).map_err(|e| D::Error::custom(format!("{e:?}")))
         } else {
             Err(D::Error::custom(format!(
                 "incorrect tag (expected FIELD, got {})",


### PR DESCRIPTION
## Description

Quick fix CI error [here](https://github.com/EspressoSystems/jellyfish/runs/11123870191).

Changes include:
- Inlined all format args, see clippy [hints here](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args): e.g. `format!("{:?}, error")` -> `format!("{error:?}")` for better readability
  - reason why we didn't catch previously in CI or locally is because our CI is not running inside nix-shell, thus two CI runs might end up using different clippy and rust (based on upstream release), and there has been a new release `1.67.0` which add this clippy rule. No big deal.
- temporarily use `version = {workspace = true}` instead of `version.workspace = true` syntax, due to https://github.com/DevinR528/cargo-sort/issues/47 (so that our precommit hook won't fail) 

## Post PR TODO:
- [ ] re-tag `0.2.0` 