### PR TITLE
Add FK23 batch opening of univariate polynomials 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,19 +59,19 @@ jobs:
           token: ${{ github.token }}
 
       - name: Check Bench
-        run: cargo bench --no-run
+        run: cargo bench --features test-srs --no-run
 
-      - name: Check Ignored Tests
-        run: cargo test --no-run -- --ignored
+      - name: Check all tests and binaries compilation
+        run: cargo check --workspace --tests --lib --bins
 
       - name: Check no_std compilation
-        run: cargo test --no-run --no-default-features
+        run: cargo check --workspace --lib --no-default-features
 
       - name: Test
         run: bash ./scripts/run_tests.sh
 
       - name: Example
-        run: cargo run --release --example proof_of_exp
+        run: cargo run --release --example proof_of_exp --features test-srs
 
       - name: Generate Documentation
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /target
 cargo-system-config.toml
 Cargo.lock
+*.org
 
 # Test coverage (grcov)
 default.profraw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 
 - [#233](https://github.com/EspressoSystems/jellyfish/pull/233) BLS aggregation APIs
 - [#234](https://github.com/EspressoSystems/jellyfish/pull/234) New `bytes_from_field_elements` util
+- [#231](https://github.com/EspressoSystems/jellyfish/pull/231) Implemented FK23 for fast amortized opening for univariate PCS
 
 ### Changed
 

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -56,3 +56,4 @@ test_apis = [] # exposing apis for testing purpose
 parallel = ["ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", 
             "jf-utils/parallel", "jf-relation/parallel", "jf-primitives/parallel",
             "rayon" ]
+test-srs = []

--- a/plonk/examples/proof_of_exp.rs
+++ b/plonk/examples/proof_of_exp.rs
@@ -51,7 +51,12 @@ fn main() -> Result<(), PlonkError> {
     //
     // The required SRS size can be obtained from the circuit.
     let srs_size = circuit.srs_size()?;
-    let srs = PlonkKzgSnark::<Bls12_381>::universal_setup(srs_size, &mut rng)?;
+    // in production:
+    // let srs = PlonkKzgSnark::<Bls12_381>::universal_setup(srs_size, &mut rng)?;
+    // in test (with `test-srs` feature flag):
+    let srs = <PlonkKzgSnark<Bls12_381> as UniversalSNARK<Bls12_381>>::universal_setup_for_testing(
+        srs_size, &mut rng,
+    )?;
 
     // Then, we generate the proving key and verification key from the SRS and
     // circuit.

--- a/plonk/src/circuit/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/plonk_verifier/gadgets.rs
@@ -485,7 +485,7 @@ mod test {
         let rng = &mut test_rng();
         let n = 128;
         let max_degree = n + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         // 2. Setup instances
         let shared_public_input = E::ScalarField::rand(rng);

--- a/plonk/src/circuit/plonk_verifier/mod.rs
+++ b/plonk/src/circuit/plonk_verifier/mod.rs
@@ -357,7 +357,7 @@ mod test {
         let rng = &mut test_rng();
         let n = 32;
         let max_degree = n + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         // Setup instances and create verifying keys
         let mut vks_type_a = vec![];
@@ -478,7 +478,7 @@ mod test {
             // 1. Simulate universal setup
             let n = 1 << log_circuit_size;
             let max_degree = n + 2;
-            let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+            let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
             // 2. Setup instances
             let shared_public_input = E::ScalarField::rand(rng);
@@ -764,7 +764,7 @@ mod test {
         // 1. Simulate universal setup
         let n = 1 << i;
         let max_degree = n + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         for _ in 0..2 {
             // =======================================

--- a/plonk/src/proof_system/batch_arg.rs
+++ b/plonk/src/proof_system/batch_arg.rs
@@ -300,7 +300,7 @@ mod test {
         let rng = &mut test_rng();
         let n = 128;
         let max_degree = n + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         // 2. Setup instances
         let shared_public_input = E::ScalarField::rand(rng);

--- a/plonk/src/proof_system/mod.rs
+++ b/plonk/src/proof_system/mod.rs
@@ -49,8 +49,18 @@ pub trait UniversalSNARK<E: Pairing> {
     /// out to have higher assurance on the "toxic waste"/trapdoor being thrown
     /// away to ensure soundness of the argument system.
     fn universal_setup<R: RngCore + CryptoRng>(
-        max_degree: usize,
-        rng: &mut R,
+        _max_degree: usize,
+        _rng: &mut R,
+    ) -> Result<Self::UniversalSRS, Self::Error> {
+        unimplemented!("Should load from files in practice.");
+    }
+
+    /// Same as `universal_setup`, but for testing and benchmarking code only.
+    /// Insecure local generation for trusted setup! Don't use in production!
+    #[cfg(any(test, feature = "test-srs"))]
+    fn universal_setup_for_testing<R: RngCore + CryptoRng>(
+        _max_degree: usize,
+        _rng: &mut R,
     ) -> Result<Self::UniversalSRS, Self::Error>;
 
     /// Circuit-specific preprocessing to compute the proving/verifying keys.

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -439,11 +439,53 @@ where
     type UniversalSRS = UniversalSrs<E>;
     type Error = PlonkError;
 
-    fn universal_setup<R: RngCore + CryptoRng>(
+    // FIXME: (alex) COPY FROM jf-primitives, can't think of a better way atm.
+    // On one hand, we want `gen_srs_for_testing` to compile only for test and
+    // bench; OTOH, we want to access it in separate crate (this one).
+    #[cfg(any(test, feature = "test-srs"))]
+    fn universal_setup_for_testing<R: RngCore + CryptoRng>(
         max_degree: usize,
         rng: &mut R,
     ) -> Result<Self::UniversalSRS, Self::Error> {
-        UnivariateKzgPCS::<E>::setup_for_testing(rng, max_degree).map_err(PlonkError::PCSError)
+        use ark_ec::{scalar_mul::fixed_base::FixedBase, CurveGroup};
+        use ark_ff::PrimeField;
+        use ark_std::{end_timer, start_timer, UniformRand};
+
+        let setup_time = start_timer!(|| format!("KZG10::Setup with degree {}", max_degree));
+        let beta = E::ScalarField::rand(rng);
+        let g = E::G1::rand(rng);
+        let h = E::G2::rand(rng);
+
+        let mut powers_of_beta = vec![E::ScalarField::one()];
+
+        let mut cur = beta;
+        for _ in 0..max_degree {
+            powers_of_beta.push(cur);
+            cur *= &beta;
+        }
+
+        let window_size = FixedBase::get_mul_window_size(max_degree + 1);
+
+        let scalar_bits = E::ScalarField::MODULUS_BIT_SIZE as usize;
+        let g_time = start_timer!(|| "Generating powers of G");
+        // TODO: parallelization
+        let g_table = FixedBase::get_window_table(scalar_bits, window_size, g);
+        let powers_of_g =
+            FixedBase::msm::<E::G1>(scalar_bits, window_size, &g_table, &powers_of_beta);
+        end_timer!(g_time);
+
+        let powers_of_g = E::G1::normalize_batch(&powers_of_g);
+
+        let h = h.into_affine();
+        let beta_h = (h * beta).into_affine();
+
+        let pp = UniversalSrs {
+            powers_of_g,
+            h,
+            beta_h,
+        };
+        end_timer!(setup_time);
+        Ok(pp)
     }
 
     /// Input a circuit and the SRS, precompute the proving key and verification
@@ -735,7 +777,7 @@ pub mod test {
         let sigmas = circuit.compute_extended_permutation_polynomials()?;
 
         let max_degree = 64 + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
         let (pk, vk) = PlonkKzgSnark::<E>::preprocess(&srs, &circuit)?;
 
         // check proving key
@@ -867,7 +909,7 @@ pub mod test {
         let rng = &mut test_rng();
         let n = 64;
         let max_degree = n + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         // 2. Create circuits
         let circuits = (0..6)
@@ -1083,7 +1125,7 @@ pub mod test {
         let rng = &mut test_rng();
         let n = 8;
         let max_degree = n + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         // 2. Create circuits
         let mut cs1: PlonkCircuit<E::ScalarField> = match plonk_type {
@@ -1182,7 +1224,7 @@ pub mod test {
         let rng = &mut test_rng();
         let n = 64;
         let max_degree = n + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         // 2. Create the circuit
         let circuit = gen_circuit_for_test(10, 3, plonk_type)?;
@@ -1451,7 +1493,7 @@ pub mod test {
         let rng = &mut jf_utils::test_rng();
         let circuit = gen_circuit_for_test(3, 4, PlonkType::TurboPlonk)?;
         let max_degree = 80;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         let (pk, _) = PlonkKzgSnark::<E>::preprocess(&srs, &circuit)?;
         let proof =
@@ -1497,7 +1539,7 @@ pub mod test {
         let rng = &mut jf_utils::test_rng();
         let circuit = gen_circuit_for_test(3, 4, plonk_type)?;
         let max_degree = 80;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         let (pk, vk) = PlonkKzgSnark::<E>::preprocess(&srs, &circuit)?;
         let proof = PlonkKzgSnark::<E>::prove::<_, _, T>(rng, &circuit, &pk, None)?;
@@ -1561,7 +1603,7 @@ pub mod test {
         let rng = &mut test_rng();
         let n = 128;
         let max_degree = n + 2;
-        let srs = PlonkKzgSnark::<E>::universal_setup(max_degree, rng)?;
+        let srs = PlonkKzgSnark::<E>::universal_setup_for_testing(max_degree, rng)?;
 
         // 2. Create many circuits with same domain size
         let circuits = (6..13)

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -439,9 +439,7 @@ where
     type UniversalSRS = UniversalSrs<E>;
     type Error = PlonkError;
 
-    // FIXME: (alex) COPY FROM jf-primitives, can't think of a better way atm.
-    // On one hand, we want `gen_srs_for_testing` to compile only for test and
-    // bench; OTOH, we want to access it in separate crate (this one).
+    // FIXME: (alex) see <https://github.com/EspressoSystems/jellyfish/issues/249>
     #[cfg(any(test, feature = "test-srs"))]
     fn universal_setup_for_testing<R: RngCore + CryptoRng>(
         max_degree: usize,

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -443,7 +443,7 @@ where
         max_degree: usize,
         rng: &mut R,
     ) -> Result<Self::UniversalSRS, Self::Error> {
-        UnivariateKzgPCS::<E>::gen_srs_for_testing(rng, max_degree).map_err(PlonkError::PCSError)
+        UnivariateKzgPCS::<E>::setup_for_testing(rng, max_degree).map_err(PlonkError::PCSError)
     }
 
     /// Input a circuit and the SRS, precompute the proving key and verification

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -50,7 +50,7 @@ use tagged_base64::tagged;
 /// Universal StructuredReferenceString
 pub type UniversalSrs<E> = UnivariateUniversalParams<E>;
 /// Commitment key
-pub type CommitKey<E> = UnivariateProverParam<<E as Pairing>::G1Affine>;
+pub type CommitKey<E> = UnivariateProverParam<E>;
 /// Key for verifying PCS opening proof.
 pub type OpenKey<E> = UnivariateVerifierParam<E>;
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -70,3 +70,4 @@ std = []
 print-trace = ["ark-std/print-trace"] 
 parallel = ["ark-ff/parallel", "ark-ec/parallel", "jf-utils/parallel", 
             "jf-relation/parallel", "rayon" ]
+test-srs = []

--- a/primitives/benches/pcs.rs
+++ b/primitives/benches/pcs.rs
@@ -17,7 +17,7 @@ fn bench_pcs() -> Result<(), PCSError> {
     let mut rng = test_rng();
 
     // normal polynomials
-    let uni_params = MultilinearKzgPCS::<Bls12_381>::gen_srs_for_testing(&mut rng, 18)?;
+    let uni_params = MultilinearKzgPCS::<Bls12_381>::setup_for_testing(&mut rng, 18)?;
 
     for nv in 4..19 {
         let repetition = if nv < 10 {

--- a/primitives/benches/pcs.rs
+++ b/primitives/benches/pcs.rs
@@ -1,89 +1,98 @@
-use ark_bls12_381::{Bls12_381, Fr};
-use ark_ff::UniformRand;
-use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
-use ark_std::sync::Arc;
-use jf_primitives::pcs::{
-    prelude::{MultilinearKzgPCS, PCSError, PolynomialCommitmentScheme},
-    StructuredReferenceString,
-};
-use jf_utils::test_rng;
-use std::time::Instant;
-
-fn main() -> Result<(), PCSError> {
-    bench_pcs()
+#[cfg(not(feature = "test-srs"))]
+fn main() {
+    panic!("We need features=['bench'] to run this benchmark.");
 }
 
-fn bench_pcs() -> Result<(), PCSError> {
-    let mut rng = test_rng();
+#[cfg(feature = "test-srs")]
+fn main() -> Result<(), jf_primitives::pcs::prelude::PCSError> {
+    bench::bench_pcs()
+}
 
-    // normal polynomials
-    let uni_params = MultilinearKzgPCS::<Bls12_381>::setup_for_testing(&mut rng, 18)?;
+#[cfg(feature = "test-srs")]
+mod bench {
+    use ark_bls12_381::{Bls12_381, Fr};
+    use ark_ff::UniformRand;
+    use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
+    use ark_std::sync::Arc;
+    use jf_primitives::pcs::{
+        prelude::{MultilinearKzgPCS, PCSError, PolynomialCommitmentScheme},
+        StructuredReferenceString,
+    };
+    use jf_utils::test_rng;
+    use std::time::Instant;
 
-    for nv in 4..19 {
-        let repetition = if nv < 10 {
-            100
-        } else if nv < 20 {
-            50
-        } else {
-            10
-        };
+    pub(crate) fn bench_pcs() -> Result<(), PCSError> {
+        let mut rng = test_rng();
 
-        let poly = Arc::new(DenseMultilinearExtension::rand(nv, &mut rng));
-        let (ml_ck, ml_vk) = uni_params.0.trim(nv)?;
-        let (uni_ck, uni_vk) = uni_params.1.trim(nv)?;
-        let ck = (ml_ck, uni_ck);
-        let vk = (ml_vk, uni_vk);
+        // normal polynomials
+        let uni_params = MultilinearKzgPCS::<Bls12_381>::gen_srs_for_testing(&mut rng, 18)?;
 
-        let point: Vec<_> = (0..nv).map(|_| Fr::rand(&mut rng)).collect();
+        for nv in 4..19 {
+            let repetition = if nv < 10 {
+                100
+            } else if nv < 20 {
+                50
+            } else {
+                10
+            };
 
-        // commit
-        let com = {
-            let start = Instant::now();
-            for _ in 0..repetition {
-                let _commit = MultilinearKzgPCS::commit(&ck, &poly)?;
+            let poly = Arc::new(DenseMultilinearExtension::rand(nv, &mut rng));
+            let (ml_ck, ml_vk) = uni_params.0.trim(nv)?;
+            let (uni_ck, uni_vk) = uni_params.1.trim(nv)?;
+            let ck = (ml_ck, uni_ck);
+            let vk = (ml_vk, uni_vk);
+
+            let point: Vec<_> = (0..nv).map(|_| Fr::rand(&mut rng)).collect();
+
+            // commit
+            let com = {
+                let start = Instant::now();
+                for _ in 0..repetition {
+                    let _commit = MultilinearKzgPCS::commit(&ck, &poly)?;
+                }
+
+                println!(
+                    "KZG commit for {} variables: {} ns",
+                    nv,
+                    start.elapsed().as_nanos() / repetition as u128
+                );
+
+                MultilinearKzgPCS::commit(&ck, &poly)?
+            };
+
+            // open
+            let (proof, value) = {
+                let start = Instant::now();
+                for _ in 0..repetition {
+                    let _open = MultilinearKzgPCS::open(&ck, &poly, &point)?;
+                }
+
+                println!(
+                    "KZG open for {} variables: {} ns",
+                    nv,
+                    start.elapsed().as_nanos() / repetition as u128
+                );
+                MultilinearKzgPCS::open(&ck, &poly, &point)?
+            };
+
+            // verify
+            {
+                let start = Instant::now();
+                for _ in 0..repetition {
+                    assert!(MultilinearKzgPCS::verify(
+                        &vk, &com, &point, &value, &proof
+                    )?);
+                }
+                println!(
+                    "KZG verify for {} variables: {} ns",
+                    nv,
+                    start.elapsed().as_nanos() / repetition as u128
+                );
             }
 
-            println!(
-                "KZG commit for {} variables: {} ns",
-                nv,
-                start.elapsed().as_nanos() / repetition as u128
-            );
-
-            MultilinearKzgPCS::commit(&ck, &poly)?
-        };
-
-        // open
-        let (proof, value) = {
-            let start = Instant::now();
-            for _ in 0..repetition {
-                let _open = MultilinearKzgPCS::open(&ck, &poly, &point)?;
-            }
-
-            println!(
-                "KZG open for {} variables: {} ns",
-                nv,
-                start.elapsed().as_nanos() / repetition as u128
-            );
-            MultilinearKzgPCS::open(&ck, &poly, &point)?
-        };
-
-        // verify
-        {
-            let start = Instant::now();
-            for _ in 0..repetition {
-                assert!(MultilinearKzgPCS::verify(
-                    &vk, &com, &point, &value, &proof
-                )?);
-            }
-            println!(
-                "KZG verify for {} variables: {} ns",
-                nv,
-                start.elapsed().as_nanos() / repetition as u128
-            );
+            println!("====================================");
         }
 
-        println!("====================================");
+        Ok(())
     }
-
-    Ok(())
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -29,6 +29,7 @@ pub mod pcs;
 pub mod prf;
 pub mod rescue;
 pub mod signatures;
+pub mod toeplitz;
 pub mod vrf;
 
 pub(crate) mod utils;

--- a/primitives/src/pcs/errors.rs
+++ b/primitives/src/pcs/errors.rs
@@ -7,8 +7,9 @@
 //! Error module.
 
 use super::transcript::TranscriptError;
+use crate::errors::PrimitivesError;
 use ark_serialize::SerializationError;
-use ark_std::string::String;
+use ark_std::string::{String, ToString};
 use displaydoc::Display;
 
 /// A `enum` specifying the possible failure modes of the PCS.
@@ -26,6 +27,8 @@ pub enum PCSError {
     SerializationError(SerializationError),
     /// Transcript error {0}
     TranscriptError(TranscriptError),
+    /// Error from upstream dependencies: {0}
+    UpstreamError(String),
 }
 
 impl From<SerializationError> for PCSError {
@@ -37,5 +40,11 @@ impl From<SerializationError> for PCSError {
 impl From<TranscriptError> for PCSError {
     fn from(e: TranscriptError) -> Self {
         Self::TranscriptError(e)
+    }
+}
+
+impl From<PrimitivesError> for PCSError {
+    fn from(e: PrimitivesError) -> Self {
+        Self::UpstreamError(e.to_string())
     }
 }

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -224,7 +224,9 @@ pub trait StructuredReferenceString: Sized {
 }
 
 /// Super-trait specific for univariate polynomial commitment schemes.
-pub trait UnivariatePCS: PolynomialCommitmentScheme {
+pub trait UnivariatePCS:
+    PolynomialCommitmentScheme<Point = <Self as PolynomialCommitmentScheme>::Evaluation>
+{
     /// Same task as [`PolynomialCommitmentScheme::multi_open()`], except the
     /// points are [roots of unity](https://en.wikipedia.org/wiki/Root_of_unity).
     /// The first `num_points` of roots will be evaluated (in canonical order).

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -225,8 +225,8 @@ pub trait StructuredReferenceString: Sized {
 
 /// Super-trait specific for univariate polynomial commitment schemes.
 pub trait UnivariatePCS: PolynomialCommitmentScheme {
-    /// Same task as [`Self::multi_open()`], except the points are [roots of
-    /// unity](https://en.wikipedia.org/wiki/Root_of_unity).
+    /// Same task as [`PolynomialCommitmentScheme::multi_open()`], except the
+    /// points are [roots of unity](https://en.wikipedia.org/wiki/Root_of_unity).
     /// The first `num_points` of roots will be evaluated (in canonical order).
     #[allow(clippy::type_complexity)]
     fn multi_open_rou(

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -7,6 +7,7 @@
 //! Polynomial Commitment Scheme
 pub mod errors;
 mod multilinear_kzg;
+mod poly;
 pub mod prelude;
 mod structs;
 mod transcript;

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -227,9 +227,10 @@ pub trait StructuredReferenceString: Sized {
 pub trait UnivariatePCS:
     PolynomialCommitmentScheme<Point = <Self as PolynomialCommitmentScheme>::Evaluation>
 {
-    /// Similar to [`Self::trim()`], but trim to support the next power of two
-    /// degree. This is particularly useful for any operations that require
-    /// FFTs, such as [`Self::multi_open_rou()`] API.
+    /// Similar to [`PolynomialCommitmentScheme::trim()`], but trim to support
+    /// the next power of two degree. This is particularly useful for any
+    /// operations that require FFTs, such as [`Self::multi_open_rou()`]
+    /// API.
     #[allow(clippy::type_complexity)]
     fn trim_next_power_of_two(
         srs: impl Borrow<Self::SRS>,

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -97,17 +97,7 @@ pub trait PolynomialCommitmentScheme {
         PCSError,
     >;
 
-    /// Generate a commitment for a polynomial
-    /// ## Note on function signature
-    /// Usually, data structure like SRS and ProverParam are huge and users
-    /// might wish to keep them in heap using different kinds of smart pointers
-    /// (instead of only in stack) therefore our `impl Borrow<_>` interface
-    /// allows for passing in any pointer type, e.g.: `commit(prover_param:
-    /// &<Self::SRS as StructuredReferenceString>::ProverParam, ..)` or
-    /// `commit(prover_param: Box<<Self::SRS as
-    /// StructuredReferenceString>::ProverParam>, ..)` or `commit(prover_param:
-    /// Arc<<Self::SRS as StructuredReferenceString>::ProverParam>, ..)` etc.
-    /// Also, the commitment is not hiding.
+    /// Generate a binding (but not hiding) commitment for a polynomial
     fn commit(
         prover_param: impl Borrow<<Self::SRS as StructuredReferenceString>::ProverParam>,
         poly: &Self::Polynomial,

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -19,6 +19,7 @@ use ark_std::{
     borrow::Borrow,
     fmt::Debug,
     hash::Hash,
+    path::Path,
     rand::{CryptoRng, RngCore},
     vec::Vec,
 };
@@ -59,19 +60,25 @@ pub trait PolynomialCommitmentScheme {
     ///
     /// WARNING: THIS FUNCTION IS FOR TESTING PURPOSE ONLY.
     /// THE OUTPUT SRS SHOULD NOT BE USED IN PRODUCTION.
-    fn setup_for_testing<R: RngCore + CryptoRng>(
+    #[cfg(any(test, feature = "test-srs"))]
+    fn gen_srs_for_testing<R: RngCore + CryptoRng>(
         rng: &mut R,
         supported_size: usize,
     ) -> Result<Self::SRS, PCSError> {
         Self::SRS::gen_srs_for_testing(rng, supported_size)
     }
 
-    /// Setup public parameter in production environment.
+    /// Load public parameter in production environment.
     /// These parameters are loaded from files with serialized `pp` bytes, and
     /// the actual setup is usually carried out via MPC and should be
     /// implemented else where. We only load them into memory here.
-    fn setup(_supported_size: usize) -> Result<Self::SRS, PCSError> {
-        unimplemented!("TODO: implement loading SRS from files");
+    ///
+    /// If `file=None`, we load the default choice of SRS.
+    fn load_srs_from_file(
+        supported_size: usize,
+        file: Option<&Path>,
+    ) -> Result<Self::SRS, PCSError> {
+        Self::SRS::load_srs_from_file(supported_size, file)
     }
 
     /// Trim the universal parameters to specialize the public parameters.
@@ -182,8 +189,19 @@ pub trait StructuredReferenceString: Sized {
     ///
     /// WARNING: THIS FUNCTION IS FOR TESTING PURPOSE ONLY.
     /// THE OUTPUT SRS SHOULD NOT BE USED IN PRODUCTION.
+    #[cfg(any(test, feature = "test-srs"))]
     fn gen_srs_for_testing<R: RngCore + CryptoRng>(
         rng: &mut R,
         supported_size: usize,
     ) -> Result<Self, PCSError>;
+
+    /// Load public parameter in production environment.
+    /// These parameters are loaded from files with serialized `pp` bytes, and
+    /// the actual setup is usually carried out via MPC and should be
+    /// implemented else where. We only load them into memory here.
+    ///
+    /// If `file=None`, we load the default choice of SRS.
+    fn load_srs_from_file(_supported_size: usize, _file: Option<&Path>) -> Result<Self, PCSError> {
+        unimplemented!("TODO: implement loading SRS from files");
+    }
 }

--- a/primitives/src/pcs/multilinear_kzg/batching.rs
+++ b/primitives/src/pcs/multilinear_kzg/batching.rs
@@ -55,7 +55,7 @@ use ark_std::{end_timer, format, start_timer, string::ToString, sync::Arc, vec, 
 ///
 /// TODO: Migrate the batching algorithm in HyperPlonk repo
 pub(super) fn batch_open_internal<E: Pairing>(
-    uni_prover_param: &UnivariateProverParam<E::G1Affine>,
+    uni_prover_param: &UnivariateProverParam<E>,
     ml_prover_param: &MultilinearProverParam<E>,
     polynomials: &[Arc<DenseMultilinearExtension<E::ScalarField>>],
     batch_commitment: &Commitment<E>,

--- a/primitives/src/pcs/multilinear_kzg/mod.rs
+++ b/primitives/src/pcs/multilinear_kzg/mod.rs
@@ -83,23 +83,6 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     type Proof = MultilinearKzgProof<E>;
     type BatchProof = MultilinearKzgBatchProof<E>;
 
-    /// Build SRS for testing.
-    ///
-    /// - For univariate polynomials, `log_size` is the log of maximum degree.
-    /// - For multilinear polynomials, `log_size` is the number of variables.
-    ///
-    /// WARNING: THIS FUNCTION IS FOR TESTING PURPOSE ONLY.
-    /// THE OUTPUT SRS SHOULD NOT BE USED IN PRODUCTION.
-    fn setup_for_testing<R: RngCore + CryptoRng>(
-        rng: &mut R,
-        log_size: usize,
-    ) -> Result<Self::SRS, PCSError> {
-        Ok((
-            MultilinearUniversalParams::<E>::gen_srs_for_testing(rng, log_size)?,
-            UnivariateUniversalParams::<E>::gen_srs_for_testing(rng, log_size)?,
-        ))
-    }
-
     /// Trim the universal parameters to specialize the public parameters.
     /// Input both `supported_log_degree` for univariate and
     /// `supported_num_vars` for multilinear.
@@ -471,7 +454,7 @@ mod tests {
     fn test_single_commit() -> Result<(), PCSError> {
         let mut rng = test_rng();
 
-        let params = MultilinearKzgPCS::<E>::setup_for_testing(&mut rng, 10)?;
+        let params = MultilinearKzgPCS::<E>::gen_srs_for_testing(&mut rng, 10)?;
 
         // normal polynomials
         let poly1 = Arc::new(DenseMultilinearExtension::rand(8, &mut rng));
@@ -489,6 +472,6 @@ mod tests {
         let mut rng = test_rng();
 
         // normal polynomials
-        assert!(MultilinearKzgPCS::<E>::setup_for_testing(&mut rng, 0).is_err());
+        assert!(MultilinearKzgPCS::<E>::gen_srs_for_testing(&mut rng, 0).is_err());
     }
 }

--- a/primitives/src/pcs/multilinear_kzg/mod.rs
+++ b/primitives/src/pcs/multilinear_kzg/mod.rs
@@ -11,9 +11,7 @@ pub(crate) mod srs;
 pub(crate) mod util;
 
 use crate::pcs::{
-    prelude::{
-        Commitment, UnivariateProverParam, UnivariateUniversalParams, UnivariateVerifierParam,
-    },
+    prelude::{Commitment, UnivariateUniversalParams},
     univariate_kzg::UnivariateKzgProof,
     PCSError, PolynomialCommitmentScheme, StructuredReferenceString,
 };
@@ -40,6 +38,11 @@ use ark_std::{
 use batching::{batch_open_internal, batch_verify_internal};
 use srs::{MultilinearProverParam, MultilinearUniversalParams, MultilinearVerifierParam};
 use util::merge_polynomials;
+
+// type alias for SRS
+type Srs<E> = (MultilinearUniversalParams<E>, UnivariateUniversalParams<E>);
+type ProverParam<E> = <Srs<E> as StructuredReferenceString>::ProverParam;
+type VerifierParam<E> = <Srs<E> as StructuredReferenceString>::VerifierParam;
 
 /// KZG Polynomial Commitment Scheme on multilinear polynomials.
 pub struct MultilinearKzgPCS<E: Pairing> {
@@ -69,12 +72,7 @@ pub struct MultilinearKzgBatchProof<E: Pairing> {
 
 impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     // Config
-    type ProverParam = (
-        MultilinearProverParam<E>,
-        UnivariateProverParam<E::G1Affine>,
-    );
-    type VerifierParam = (MultilinearVerifierParam<E>, UnivariateVerifierParam<E>);
-    type SRS = (MultilinearUniversalParams<E>, UnivariateUniversalParams<E>);
+    type SRS = Srs<E>;
     // Polynomial and its associated types
     type Polynomial = Arc<DenseMultilinearExtension<E::ScalarField>>;
     type Point = Vec<E::ScalarField>;
@@ -92,7 +90,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     ///
     /// WARNING: THIS FUNCTION IS FOR TESTING PURPOSE ONLY.
     /// THE OUTPUT SRS SHOULD NOT BE USED IN PRODUCTION.
-    fn gen_srs_for_testing<R: RngCore + CryptoRng>(
+    fn setup_for_testing<R: RngCore + CryptoRng>(
         rng: &mut R,
         log_size: usize,
     ) -> Result<Self::SRS, PCSError> {
@@ -109,7 +107,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
         srs: impl Borrow<Self::SRS>,
         supported_log_degree: usize,
         supported_num_vars: Option<usize>,
-    ) -> Result<(Self::ProverParam, Self::VerifierParam), PCSError> {
+    ) -> Result<(ProverParam<E>, VerifierParam<E>), PCSError> {
         let supported_num_vars = match supported_num_vars {
             Some(p) => p,
             None => {
@@ -129,7 +127,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     /// This function takes `2^num_vars` number of scalar multiplications over
     /// G1.
     fn commit(
-        prover_param: impl Borrow<Self::ProverParam>,
+        prover_param: impl Borrow<ProverParam<E>>,
         poly: &Self::Polynomial,
     ) -> Result<Self::Commitment, PCSError> {
         let prover_param = prover_param.borrow();
@@ -161,7 +159,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     /// This function takes `2^(num_vars + log(polys.len())` number of scalar
     /// multiplications over G1.
     fn batch_commit(
-        prover_param: impl Borrow<Self::ProverParam>,
+        prover_param: impl Borrow<ProverParam<E>>,
         polys: &[Self::Polynomial],
     ) -> Result<Self::Commitment, PCSError> {
         let prover_param = prover_param.borrow();
@@ -192,7 +190,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     /// - at round i, we compute an MSM for `2^{num_var - i + 1}` number of G2
     ///   elements.
     fn open(
-        prover_param: impl Borrow<Self::ProverParam>,
+        prover_param: impl Borrow<ProverParam<E>>,
         polynomial: &Self::Polynomial,
         point: &Self::Point,
     ) -> Result<(Self::Proof, Self::Evaluation), PCSError> {
@@ -231,7 +229,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     /// 8. output an opening of `w` over point `p`
     /// 9. output `w(p)`
     fn batch_open(
-        prover_param: impl Borrow<Self::ProverParam>,
+        prover_param: impl Borrow<ProverParam<E>>,
         batch_commitment: &Self::BatchCommitment,
         polynomials: &[Self::Polynomial],
         points: &[Self::Point],
@@ -252,7 +250,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     /// - num_var number of pairing product.
     /// - num_var number of MSM
     fn verify(
-        verifier_param: &Self::VerifierParam,
+        verifier_param: &VerifierParam<E>,
         commitment: &Self::Commitment,
         point: &Self::Point,
         value: &E::ScalarField,
@@ -273,7 +271,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     /// 5. get a point `p := l(r)`
     /// 6. verifies `p` is verifies against proof
     fn batch_verify<R: RngCore + CryptoRng>(
-        verifier_param: &Self::VerifierParam,
+        verifier_param: &VerifierParam<E>,
         batch_commitment: &Self::BatchCommitment,
         points: &[Self::Point],
         values: &[E::ScalarField],
@@ -473,7 +471,7 @@ mod tests {
     fn test_single_commit() -> Result<(), PCSError> {
         let mut rng = test_rng();
 
-        let params = MultilinearKzgPCS::<E>::gen_srs_for_testing(&mut rng, 10)?;
+        let params = MultilinearKzgPCS::<E>::setup_for_testing(&mut rng, 10)?;
 
         // normal polynomials
         let poly1 = Arc::new(DenseMultilinearExtension::rand(8, &mut rng));
@@ -491,6 +489,6 @@ mod tests {
         let mut rng = test_rng();
 
         // normal polynomials
-        assert!(MultilinearKzgPCS::<E>::gen_srs_for_testing(&mut rng, 0).is_err());
+        assert!(MultilinearKzgPCS::<E>::setup_for_testing(&mut rng, 0).is_err());
     }
 }

--- a/primitives/src/pcs/multilinear_kzg/srs.rs
+++ b/primitives/src/pcs/multilinear_kzg/srs.rs
@@ -6,28 +6,15 @@
 
 //! Implementing Structured Reference Strings for multilinear polynomial KZG
 use crate::pcs::{
-    multilinear_kzg::util::eq_eval,
     prelude::PCSError,
     univariate_kzg::srs::{
         UnivariateProverParam, UnivariateUniversalParams, UnivariateVerifierParam,
     },
     StructuredReferenceString,
 };
-use ark_ec::{pairing::Pairing, scalar_mul::fixed_base::FixedBase, AffineRepr, CurveGroup};
-use ark_ff::{Field, PrimeField, Zero};
-use ark_poly::DenseMultilinearExtension;
+use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::{
-    collections::LinkedList,
-    end_timer, format,
-    rand::{CryptoRng, RngCore},
-    start_timer,
-    string::ToString,
-    vec,
-    vec::Vec,
-    UniformRand,
-};
-use core::iter::FromIterator;
+use ark_std::{format, vec::Vec};
 
 /// Evaluations over {0,1}^n for G1 or G2
 #[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug)]
@@ -130,13 +117,148 @@ impl<E: Pairing> StructuredReferenceString for MultilinearUniversalParams<E> {
         Ok((ck, vk))
     }
 
-    /// Build SRS for testing.
-    /// WARNING: THIS FUNCTION IS FOR TESTING PURPOSE ONLY.
-    /// THE OUTPUT SRS SHOULD NOT BE USED IN PRODUCTION.
-    fn gen_srs_for_testing<R: RngCore + CryptoRng>(
+    #[cfg(any(test, feature = "test-srs"))]
+    fn gen_srs_for_testing<R>(rng: &mut R, num_vars: usize) -> Result<Self, PCSError>
+    where
+        R: ark_std::rand::RngCore + ark_std::rand::CryptoRng,
+    {
+        tests::gen_srs_for_testing(rng, num_vars)
+    }
+}
+
+// Implement `trait StructuredReferenceString` for (ML_pp, Uni_pp) to be used in
+// MLE PCS.
+impl<E: Pairing> StructuredReferenceString
+    for (MultilinearUniversalParams<E>, UnivariateUniversalParams<E>)
+{
+    type ProverParam = (MultilinearProverParam<E>, UnivariateProverParam<E>);
+    type VerifierParam = (MultilinearVerifierParam<E>, UnivariateVerifierParam<E>);
+
+    fn trim(
+        &self,
+        supported_size: usize,
+    ) -> Result<(Self::ProverParam, Self::VerifierParam), PCSError> {
+        let ml_pp = <MultilinearUniversalParams<E> as StructuredReferenceString>::trim(
+            &self.0,
+            supported_size,
+        )?;
+        let uni_pp = <UnivariateUniversalParams<E> as StructuredReferenceString>::trim(
+            &self.1,
+            supported_size,
+        )?;
+
+        Ok(((ml_pp.0, uni_pp.0), (ml_pp.1, uni_pp.1)))
+    }
+
+    fn extract_prover_param(&self, supported_size: usize) -> Self::ProverParam {
+        let ml_prover_param =
+            <MultilinearUniversalParams<E> as StructuredReferenceString>::extract_prover_param(
+                &self.0,
+                supported_size,
+            );
+        let uni_prover_param =
+            <UnivariateUniversalParams<E> as StructuredReferenceString>::extract_prover_param(
+                &self.1,
+                supported_size,
+            );
+
+        (ml_prover_param, uni_prover_param)
+    }
+
+    fn extract_verifier_param(&self, supported_size: usize) -> Self::VerifierParam {
+        let ml_verifier_param =
+            <MultilinearUniversalParams<E> as StructuredReferenceString>::extract_verifier_param(
+                &self.0,
+                supported_size,
+            );
+        let uni_verifier_param =
+            <UnivariateUniversalParams<E> as StructuredReferenceString>::extract_verifier_param(
+                &self.1,
+                supported_size,
+            );
+
+        (ml_verifier_param, uni_verifier_param)
+    }
+
+    #[cfg(any(test, feature = "test-srs"))]
+    fn gen_srs_for_testing<R>(rng: &mut R, supported_size: usize) -> Result<Self, PCSError>
+    where
+        R: ark_std::rand::RngCore + ark_std::rand::CryptoRng,
+    {
+        let ml_pp =
+            <MultilinearUniversalParams<E> as StructuredReferenceString>::gen_srs_for_testing(
+                rng,
+                supported_size,
+            )?;
+        let uni_pp =
+            <UnivariateUniversalParams<E> as StructuredReferenceString>::gen_srs_for_testing(
+                rng,
+                supported_size,
+            )?;
+        Ok((ml_pp, uni_pp))
+    }
+}
+
+#[cfg(any(test, feature = "test-srs"))]
+mod tests {
+    use super::*;
+    use crate::pcs::multilinear_kzg::util::eq_eval;
+    use ark_ec::{scalar_mul::fixed_base::FixedBase, CurveGroup};
+    use ark_ff::{Field, PrimeField, Zero};
+    use ark_poly::DenseMultilinearExtension;
+    use ark_std::{
+        collections::LinkedList,
+        end_timer,
+        iter::FromIterator,
+        rand::{CryptoRng, RngCore},
+        start_timer,
+        string::ToString,
+        vec,
+        vec::Vec,
+        UniformRand,
+    };
+
+    // fix first `pad` variables of `poly` represented in evaluation form to zero
+    fn remove_dummy_variable<F: Field>(poly: &[F], pad: usize) -> Result<Vec<F>, PCSError> {
+        if pad == 0 {
+            return Ok(poly.to_vec());
+        }
+        if !poly.len().is_power_of_two() {
+            return Err(PCSError::InvalidParameters(
+                "Size of polynomial should be power of two.".to_string(),
+            ));
+        }
+        let nv = ark_std::log2(poly.len()) as usize - pad;
+
+        Ok((0..(1 << nv)).map(|x| poly[x << pad]).collect())
+    }
+
+    // Generate eq(t,x), a product of multilinear polynomials with fixed t.
+    // eq(a,b) is takes extensions of a,b in {0,1}^num_vars such that if a and
+    // b in {0,1}^num_vars are equal then this polynomial evaluates to 1.
+    fn eq_extension<F: PrimeField>(t: &[F]) -> Vec<DenseMultilinearExtension<F>> {
+        let start = start_timer!(|| "eq extension");
+
+        let dim = t.len();
+        let mut result = Vec::new();
+        for (i, &ti) in t.iter().enumerate().take(dim) {
+            let mut poly = Vec::with_capacity(1 << dim);
+            for x in 0..(1 << dim) {
+                let xi = if x >> i & 1 == 1 { F::one() } else { F::zero() };
+                let ti_xi = ti * xi;
+                poly.push(ti_xi + ti_xi - xi - ti + F::one());
+            }
+            result.push(DenseMultilinearExtension::from_evaluations_vec(dim, poly));
+        }
+
+        end_timer!(start);
+        result
+    }
+
+    pub(crate) fn gen_srs_for_testing<E: Pairing, R: RngCore + CryptoRng>(
         rng: &mut R,
         num_vars: usize,
-    ) -> Result<Self, PCSError> {
+    ) -> Result<MultilinearUniversalParams<E>, PCSError> {
         if num_vars == 0 {
             return Err(PCSError::InvalidParameters(
                 "constant polynomial not supported".to_string(),
@@ -208,7 +330,7 @@ impl<E: Pairing> StructuredReferenceString for MultilinearUniversalParams<E> {
         };
         powers_of_g.push(gg);
 
-        let pp = Self::ProverParam {
+        let pp = MultilinearProverParam {
             num_vars,
             g: g.into_affine(),
             h: h.into_affine(),
@@ -225,131 +347,18 @@ impl<E: Pairing> StructuredReferenceString for MultilinearUniversalParams<E> {
         };
         end_timer!(vp_generation_timer);
         end_timer!(total_timer);
-        Ok(Self {
+        Ok(MultilinearUniversalParams {
             prover_param: pp,
             h_mask,
         })
     }
-}
-
-/// fix first `pad` variables of `poly` represented in evaluation form to zero
-fn remove_dummy_variable<F: Field>(poly: &[F], pad: usize) -> Result<Vec<F>, PCSError> {
-    if pad == 0 {
-        return Ok(poly.to_vec());
-    }
-    if !poly.len().is_power_of_two() {
-        return Err(PCSError::InvalidParameters(
-            "Size of polynomial should be power of two.".to_string(),
-        ));
-    }
-    let nv = ark_std::log2(poly.len()) as usize - pad;
-
-    Ok((0..(1 << nv)).map(|x| poly[x << pad]).collect())
-}
-
-/// Generate eq(t,x), a product of multilinear polynomials with fixed t.
-/// eq(a,b) is takes extensions of a,b in {0,1}^num_vars such that if a and b in
-/// {0,1}^num_vars are equal then this polynomial evaluates to 1.
-fn eq_extension<F: PrimeField>(t: &[F]) -> Vec<DenseMultilinearExtension<F>> {
-    let start = start_timer!(|| "eq extension");
-
-    let dim = t.len();
-    let mut result = Vec::new();
-    for (i, &ti) in t.iter().enumerate().take(dim) {
-        let mut poly = Vec::with_capacity(1 << dim);
-        for x in 0..(1 << dim) {
-            let xi = if x >> i & 1 == 1 { F::one() } else { F::zero() };
-            let ti_xi = ti * xi;
-            poly.push(ti_xi + ti_xi - xi - ti + F::one());
-        }
-        result.push(DenseMultilinearExtension::from_evaluations_vec(dim, poly));
-    }
-
-    end_timer!(start);
-    result
-}
-
-// Implement `trait StructuredReferenceString` for (ML_pp, Uni_pp) to be used in
-// MLE PCS.
-impl<E: Pairing> StructuredReferenceString
-    for (MultilinearUniversalParams<E>, UnivariateUniversalParams<E>)
-{
-    type ProverParam = (MultilinearProverParam<E>, UnivariateProverParam<E>);
-    type VerifierParam = (MultilinearVerifierParam<E>, UnivariateVerifierParam<E>);
-
-    fn trim(
-        &self,
-        supported_size: usize,
-    ) -> Result<(Self::ProverParam, Self::VerifierParam), PCSError> {
-        let ml_pp = <MultilinearUniversalParams<E> as StructuredReferenceString>::trim(
-            &self.0,
-            supported_size,
-        )?;
-        let uni_pp = <UnivariateUniversalParams<E> as StructuredReferenceString>::trim(
-            &self.1,
-            supported_size,
-        )?;
-
-        Ok(((ml_pp.0, uni_pp.0), (ml_pp.1, uni_pp.1)))
-    }
-
-    fn extract_prover_param(&self, supported_size: usize) -> Self::ProverParam {
-        let ml_prover_param =
-            <MultilinearUniversalParams<E> as StructuredReferenceString>::extract_prover_param(
-                &self.0,
-                supported_size,
-            );
-        let uni_prover_param =
-            <UnivariateUniversalParams<E> as StructuredReferenceString>::extract_prover_param(
-                &self.1,
-                supported_size,
-            );
-
-        (ml_prover_param, uni_prover_param)
-    }
-
-    fn extract_verifier_param(&self, supported_size: usize) -> Self::VerifierParam {
-        let ml_verifier_param =
-            <MultilinearUniversalParams<E> as StructuredReferenceString>::extract_verifier_param(
-                &self.0,
-                supported_size,
-            );
-        let uni_verifier_param =
-            <UnivariateUniversalParams<E> as StructuredReferenceString>::extract_verifier_param(
-                &self.1,
-                supported_size,
-            );
-
-        (ml_verifier_param, uni_verifier_param)
-    }
-
-    fn gen_srs_for_testing<R: RngCore + CryptoRng>(
-        rng: &mut R,
-        supported_size: usize,
-    ) -> Result<Self, PCSError> {
-        let ml_pp =
-            <MultilinearUniversalParams<E> as StructuredReferenceString>::gen_srs_for_testing(
-                rng,
-                supported_size,
-            )?;
-        let uni_pp =
-            <UnivariateUniversalParams<E> as StructuredReferenceString>::gen_srs_for_testing(
-                rng,
-                supported_size,
-            )?;
-        Ok((ml_pp, uni_pp))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ark_bls12_381::Bls12_381;
-    use jf_utils::test_rng;
-    type E = Bls12_381;
 
     #[test]
     fn test_srs_gen() -> Result<(), PCSError> {
+        use ark_bls12_381::Bls12_381;
+        use jf_utils::test_rng;
+        type E = Bls12_381;
+
         let mut rng = test_rng();
         for nv in 4..10 {
             let _ = MultilinearUniversalParams::<E>::gen_srs_for_testing(&mut rng, nv)?;

--- a/primitives/src/pcs/multilinear_kzg/util.rs
+++ b/primitives/src/pcs/multilinear_kzg/util.rs
@@ -15,7 +15,7 @@ use ark_poly::{
 use ark_std::{end_timer, format, log2, start_timer, string::ToString, sync::Arc, vec, vec::Vec};
 
 /// Evaluate eq polynomial. use the public one later
-#[allow(dead_code)]
+#[cfg(any(test, feature = "test-srs"))]
 pub(crate) fn eq_eval<F: PrimeField>(x: &[F], y: &[F]) -> Result<F, PCSError> {
     if x.len() != y.len() {
         return Err(PCSError::InvalidParameters(
@@ -33,7 +33,6 @@ pub(crate) fn eq_eval<F: PrimeField>(x: &[F], y: &[F]) -> Result<F, PCSError> {
 }
 
 /// Decompose an integer into a binary vector in little endian.
-#[allow(dead_code)]
 pub(crate) fn bit_decompose(input: u64, num_var: usize) -> Vec<bool> {
     let mut res = Vec::with_capacity(num_var);
     let mut i = input;
@@ -52,7 +51,7 @@ pub(crate) fn bit_decompose(input: u64, num_var: usize) -> Vec<bool> {
 // - mle has degree one
 // - worst case is `\prod_{i=0}^{mle_num_vars-1} l_i(x) < point_len * mle_num_vars`
 #[inline]
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn compute_qx_degree(mle_num_vars: usize, point_len: usize) -> usize {
     mle_num_vars * point_len
 }

--- a/primitives/src/pcs/multilinear_kzg/util.rs
+++ b/primitives/src/pcs/multilinear_kzg/util.rs
@@ -15,6 +15,7 @@ use ark_poly::{
 use ark_std::{end_timer, format, log2, start_timer, string::ToString, sync::Arc, vec, vec::Vec};
 
 /// Evaluate eq polynomial. use the public one later
+#[allow(dead_code)]
 pub(crate) fn eq_eval<F: PrimeField>(x: &[F], y: &[F]) -> Result<F, PCSError> {
     if x.len() != y.len() {
         return Err(PCSError::InvalidParameters(

--- a/primitives/src/pcs/poly.rs
+++ b/primitives/src/pcs/poly.rs
@@ -134,13 +134,13 @@ where
     /// Hwoever, when there are lots of points, will use FFT methods to get a
     /// lower amortized cost.
     pub fn batch_evaluate(&self, points: BatchEvalPoints<F>) -> Vec<T> {
-        // Horner: n * d
-        // FFT: ~ d*log^2(d)  (independent of n, as long as n<=d)
-        // naive cutoff-point, not taking parallelism into consideration:
-        let cutoff_size = <F as FftField>::TWO_ADICITY.pow(2);
-
         match points {
             BatchEvalPoints::General(points) => {
+                // Horner: n * d
+                // FFT: ~ d*log^2(d)  (independent of n, as long as n<=d)
+                // naive cutoff-point, not taking parallelism into consideration:
+                let cutoff_size = <F as FftField>::TWO_ADICITY.pow(2);
+
                 if points.is_empty() {
                     Vec::new()
                 } else if points.len() < cutoff_size as usize {
@@ -150,6 +150,7 @@ where
                 }
             },
             BatchEvalPoints::RootsOfUnity(m) => {
+                // using FFT, complexity: d*log(d) independent of m (<=d+1)
                 let domain: Radix2EvaluationDomain<F> =
                     Radix2EvaluationDomain::new(self.coeffs.len())
                         .expect("Should init an eval domain");
@@ -334,7 +335,7 @@ pub(crate) mod tests {
 
         for _ in 0..5 {
             // TODO: (alex) change to a higher degree when need to test cutoff point and
-            // FFT-based eval
+            // FFT-based eval on arbitrary points
             let degree = rng.gen_range(5..30);
             let num_points = rng.gen_range(5..30);
             let f = GeneralDensePolynomial::<Fr, Fr>::rand(degree, &mut rng);

--- a/primitives/src/pcs/poly.rs
+++ b/primitives/src/pcs/poly.rs
@@ -81,7 +81,7 @@ where
     /// Outputs a univariate polynomial of degree `d` where
     /// each coefficient is sampled uniformly at random.
     #[allow(dead_code)]
-    fn rand<R: Rng>(d: usize, rng: &mut R) -> Self {
+    pub fn rand<R: Rng>(d: usize, rng: &mut R) -> Self {
         let mut random_coeffs = Vec::new();
         for _ in 0..=d {
             random_coeffs.push(T::rand(rng));
@@ -249,11 +249,7 @@ pub(crate) mod tests {
     // helper function to generate all roots of unity for evaluating polynomial with
     // `num_coeffs` coeffs.
     pub(crate) fn get_roots_of_unity<F: FftField>(num_coeffs: usize) -> Vec<F> {
-        let size = if num_coeffs.is_power_of_two() {
-            num_coeffs
-        } else {
-            num_coeffs.checked_next_power_of_two().unwrap()
-        } as u64;
+        let size = num_coeffs.checked_next_power_of_two().unwrap() as u64;
 
         let group_gen = F::get_root_of_unity(size)
             .expect("Failed to get roots of unity, maybe wronge domain size");
@@ -316,12 +312,12 @@ pub(crate) mod tests {
     #[test]
     fn test_multi_open() {
         let mut rng = test_rng();
+        let degrees = [14, 15, 16, 17, 18];
 
-        for _ in 0..5 {
+        for degree in degrees {
             // TODO: (alex) change to a higher degree when need to test cutoff point and
             // FFT-based eval on arbitrary points
-            let degree = rng.gen_range(5..30);
-            let num_points = rng.gen_range(5..30);
+            let num_points = rng.gen_range(5..degree);
             let f = GeneralDensePolynomial::<Fr, Fr>::rand(degree, &mut rng);
             let g = GeneralDensePolynomial::<G1Projective, Fr>::rand(degree, &mut rng);
 

--- a/primitives/src/pcs/poly.rs
+++ b/primitives/src/pcs/poly.rs
@@ -8,8 +8,6 @@
 //! just field elemnts.
 //! Inspired by and natural extension of arkwork's `ark-poly` code.
 
-// FIXME: remove this
-#![allow(dead_code)]
 use ark_ff::{FftField, Field, Zero};
 use ark_poly::{domain::DomainCoeff, EvaluationDomain, Radix2EvaluationDomain};
 use ark_std::{
@@ -82,6 +80,7 @@ where
 
     /// Outputs a univariate polynomial of degree `d` where
     /// each coefficient is sampled uniformly at random.
+    #[allow(dead_code)]
     fn rand<R: Rng>(d: usize, rng: &mut R) -> Self {
         let mut random_coeffs = Vec::new();
         for _ in 0..=d {
@@ -91,6 +90,7 @@ where
     }
 
     /// Returns the total degree of the polynomial
+    #[allow(dead_code)]
     pub fn degree(&self) -> usize {
         if self.is_zero() {
             0

--- a/primitives/src/pcs/poly.rs
+++ b/primitives/src/pcs/poly.rs
@@ -1,0 +1,263 @@
+// Copyright (c) 2023 Espresso Systems (espressosys.com)
+// This file is part of the Jellyfish library.
+
+// You should have received a copy of the MIT License
+// along with the Jellyfish library. If not, see <https://mit-license.org/>.
+
+//! Generalized DensePolynomial, allowing coefficients to be group elements, not
+//! just field elemnts.
+//! Inspired by and natural extension of arkwork's `ark-poly` code.
+
+// FIXME: remove this
+#![allow(dead_code)]
+use ark_ff::{Field, Zero};
+use ark_std::{
+    fmt,
+    marker::PhantomData,
+    ops::{Add, MulAssign},
+    rand::Rng,
+    vec::Vec,
+    UniformRand,
+};
+use itertools::{
+    EitherOrBoth::{Both, Left, Right},
+    Itertools,
+};
+
+// TODO: (alex) change to trait alias once stablized in Rust:
+// `https://doc.rust-lang.org/unstable-book/language-features/trait-alias.html`
+/// A trait bound alias for generalized coefficient type used in
+/// `GeneralDensePolynomial`. Concrete instantiations can be both field or
+/// group elements.
+pub trait GeneralCoeff<F: Field>:
+    Clone + fmt::Debug + Copy + Add<Self, Output = Self> + MulAssign<F> + Zero + UniformRand + Sized
+{
+}
+
+impl<T, F: Field> GeneralCoeff<F> for T where
+    T: Clone
+        + fmt::Debug
+        + Copy
+        + Add<Self, Output = Self>
+        + MulAssign<F>
+        + Zero
+        + UniformRand
+        + Sized
+{
+}
+
+/// Stores a polynomial in the coefficient form.
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct GeneralDensePolynomial<T: GeneralCoeff<F>, F: Field> {
+    /// The coefficient of `x^i` is stored at location `i` in `self.coeffs`.
+    pub coeffs: Vec<T>,
+    _phantom: PhantomData<F>,
+}
+
+// TODO: (alex) we didn't implement `trait Polynomial<F>` in arkwork for our
+// struct because that trait assume the coeffs are field elements. Therefore, we
+// need to generalize that trait first which is left for future work or even
+// upstream PR.
+impl<T, F> GeneralDensePolynomial<T, F>
+where
+    T: GeneralCoeff<F>,
+    F: Field,
+{
+    /// Constructs a new polynomial from a list of coefficients
+    pub fn from_coeff_slice(coeffs: &[T]) -> Self {
+        Self::from_coeff_vec(coeffs.to_vec())
+    }
+
+    /// Constructs a new polynomial from a list of coefficients
+    pub fn from_coeff_vec(coeffs: Vec<T>) -> Self {
+        let mut result = Self {
+            coeffs,
+            _phantom: PhantomData,
+        };
+        result.truncate_leading_zeros();
+        assert!(result.coeffs.last().map_or(true, |coeff| !coeff.is_zero()));
+        result
+    }
+
+    /// Outputs a univariate polynomial of degree `d` where
+    /// each coefficient is sampled uniformly at random.
+    fn rand<R: Rng>(d: usize, rng: &mut R) -> Self {
+        let mut random_coeffs = Vec::new();
+        for _ in 0..=d {
+            random_coeffs.push(T::rand(rng));
+        }
+        Self::from_coeff_vec(random_coeffs)
+    }
+
+    /// Returns the total degree of the polynomial
+    pub fn degree(&self) -> usize {
+        if self.is_zero() {
+            0
+        } else {
+            assert!(self.coeffs.last().map_or(false, |coeff| !coeff.is_zero()));
+            self.coeffs.len() - 1
+        }
+    }
+
+    /// Evaluate `self` at a given `point`
+    pub fn evaluate(&self, point: &F) -> T {
+        if self.is_zero() {
+            return T::zero();
+        } else if point.is_zero() {
+            return self.coeffs[0];
+        }
+        self.horner_evaluate(point)
+    }
+}
+
+impl<T, F> GeneralDensePolynomial<T, F>
+where
+    T: GeneralCoeff<F>,
+    F: Field,
+{
+    fn truncate_leading_zeros(&mut self) {
+        while self.coeffs.last().map_or(false, |c| c.is_zero()) {
+            self.coeffs.pop();
+        }
+    }
+
+    // Horner's method for polynomial evaluation with cost O(n).
+    fn horner_evaluate(&self, point: &F) -> T {
+        self.coeffs
+            .iter()
+            .rfold(T::zero(), move |mut result, coeff| {
+                result *= *point;
+                result + *coeff
+            })
+    }
+}
+
+impl<T, F> Zero for GeneralDensePolynomial<T, F>
+where
+    T: GeneralCoeff<F>,
+    F: Field,
+{
+    /// returns the zero polynomial
+    fn zero() -> Self {
+        Self {
+            coeffs: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// checks if the given polynomial is zero
+    fn is_zero(&self) -> bool {
+        self.coeffs.is_empty() || self.coeffs.iter().all(|coeff| coeff.is_zero())
+    }
+}
+
+impl<T, F> Add<Self> for GeneralDensePolynomial<T, F>
+where
+    T: GeneralCoeff<F>,
+    F: Field,
+{
+    type Output = Self;
+
+    // TODO: (alex) add `Add<'a Self, Output=Self>` and internally use that instead.
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut res = if self.is_zero() {
+            rhs
+        } else if rhs.is_zero() {
+            self
+        } else {
+            let coeffs = self
+                .coeffs
+                .into_iter()
+                .zip_longest(rhs.coeffs.into_iter())
+                .map(|pair| match pair {
+                    Both(x, y) => x + y,
+                    Left(x) | Right(x) => x,
+                })
+                .collect();
+            Self::from_coeff_vec(coeffs)
+        };
+
+        res.truncate_leading_zeros();
+        res
+    }
+}
+
+impl<T, F> fmt::Debug for GeneralDensePolynomial<T, F>
+where
+    T: GeneralCoeff<F>,
+    F: Field,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        for (i, coeff) in self.coeffs.iter().enumerate().filter(|(_, c)| !c.is_zero()) {
+            if i == 0 {
+                write!(f, "\n{:?}", coeff)?;
+            } else if i == 1 {
+                write!(f, " + \n{:?} * x", coeff)?;
+            } else {
+                write!(f, " + \n{:?} * x^{}", coeff, i)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bls12_381::{Fr, G1Projective};
+    use ark_ec::{short_weierstrass::SWCurveConfig, CurveGroup};
+    use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Polynomial};
+    use ark_std::iter::successors;
+    use jf_utils::test_rng;
+
+    #[test]
+    fn test_poly_eval_single_point() {
+        let mut rng = test_rng();
+        for _ in 0..5 {
+            let degree = rng.gen_range(5..40);
+            let f = GeneralDensePolynomial::<Fr, Fr>::rand(degree, &mut rng);
+            let g = GeneralDensePolynomial::<G1Projective, Fr>::rand(degree, &mut rng);
+            let point = Fr::rand(&mut rng);
+
+            let f_x = f.evaluate(&point);
+            let expected_f_x: Fr =
+                DensePolynomial::from_coefficients_slice(&f.coeffs).evaluate(&point);
+            assert_eq!(f_x, expected_f_x);
+
+            let g_x = g.evaluate(&point);
+            // g(X) = G0 + G1 * X + G2 * X^2 + G3 * X^3 + ...
+            // turn into an MSM between [G0, G1, G2, ...] and [1, x, x^2, x^3, ...]
+            let scalars: Vec<Fr> = successors(Some(Fr::from(1u32)), |&prev| Some(prev * point))
+                .take((g.degree() + 1) as usize)
+                .collect();
+            let expected_g_x =
+                SWCurveConfig::msm(&CurveGroup::normalize_batch(&g.coeffs), &scalars).unwrap();
+            assert_eq!(g_x, expected_g_x);
+        }
+    }
+
+    #[test]
+    fn test_poly_add() {
+        let mut rng = test_rng();
+        for _ in 0..5 {
+            let degree = rng.gen_range(5..40);
+            let f_1 = GeneralDensePolynomial::<Fr, Fr>::rand(degree, &mut rng);
+            let f_2 = GeneralDensePolynomial::<Fr, Fr>::rand(degree, &mut rng);
+            let expected_f_3 = DensePolynomial::from_coefficients_slice(&f_1.coeffs)
+                + DensePolynomial::from_coefficients_slice(&f_2.coeffs);
+            let f_3 = f_1 + f_2;
+            assert_eq!(f_3.coeffs, expected_f_3.coeffs);
+
+            let g_1 = GeneralDensePolynomial::<G1Projective, Fr>::rand(degree, &mut rng);
+            let g_2 = GeneralDensePolynomial::<G1Projective, Fr>::rand(degree, &mut rng);
+            let expected_g_3: Vec<G1Projective> = g_1
+                .coeffs
+                .iter()
+                .zip(g_2.coeffs.iter())
+                .map(|(a, b)| a + b)
+                .collect();
+            let g_3 = g_1 + g_2;
+            assert_eq!(g_3.coeffs, expected_g_3);
+        }
+    }
+}

--- a/primitives/src/pcs/poly.rs
+++ b/primitives/src/pcs/poly.rs
@@ -290,22 +290,32 @@ pub(crate) mod tests {
         for _ in 0..5 {
             let degree = rng.gen_range(5..40);
             let f_1 = GeneralDensePolynomial::<Fr, Fr>::rand(degree, &mut rng);
-            let f_2 = GeneralDensePolynomial::<Fr, Fr>::rand(degree, &mut rng);
+            let mut f_2 = GeneralDensePolynomial::<Fr, Fr>::rand(degree, &mut rng);
             let expected_f_3 = DensePolynomial::from_coefficients_slice(&f_1.coeffs)
                 + DensePolynomial::from_coefficients_slice(&f_2.coeffs);
-            let f_3 = f_1 + f_2;
+            let f_3 = f_1.clone() + f_2.clone();
             assert_eq!(f_3.coeffs, expected_f_3.coeffs);
 
+            f_2.coeffs[degree] = -f_1.coeffs[degree];
+            let f_4 = f_1 + f_2;
+            assert_eq!(f_4.degree(), degree - 1,);
+
             let g_1 = GeneralDensePolynomial::<G1Projective, Fr>::rand(degree, &mut rng);
-            let g_2 = GeneralDensePolynomial::<G1Projective, Fr>::rand(degree, &mut rng);
+            let mut g_2 = GeneralDensePolynomial::<G1Projective, Fr>::rand(degree, &mut rng);
             let expected_g_3: Vec<G1Projective> = g_1
                 .coeffs
                 .iter()
                 .zip(g_2.coeffs.iter())
                 .map(|(a, b)| a + b)
                 .collect();
-            let g_3 = g_1 + g_2;
+            let g_3 = g_1.clone() + g_2.clone();
             assert_eq!(g_3.coeffs, expected_g_3);
+
+            g_2.coeffs[degree] = -g_1.coeffs[degree];
+            g_2.coeffs[degree - 1] = -g_1.coeffs[degree - 1];
+            g_2.coeffs[degree - 2] = -g_1.coeffs[degree - 2];
+            let g_4 = g_1 + g_2;
+            assert_eq!(g_4.degree(), degree - 3);
         }
     }
 

--- a/primitives/src/pcs/poly.rs
+++ b/primitives/src/pcs/poly.rs
@@ -28,12 +28,12 @@ use itertools::{
 /// A trait bound alias for generalized coefficient type used in
 /// `GeneralDensePolynomial`. Concrete instantiations can be both field or
 /// group elements.
-pub trait GeneralCoeff<F: Field>:
+pub trait GroupCoeff<F: Field>:
     Clone + fmt::Debug + Copy + Add<Self, Output = Self> + MulAssign<F> + Zero + UniformRand + Sized
 {
 }
 
-impl<T, F: Field> GeneralCoeff<F> for T where
+impl<T, F: Field> GroupCoeff<F> for T where
     T: Clone
         + fmt::Debug
         + Copy
@@ -47,7 +47,7 @@ impl<T, F: Field> GeneralCoeff<F> for T where
 
 /// Stores a polynomial in the coefficient form.
 #[derive(Clone, PartialEq, Eq, Default)]
-pub struct GeneralDensePolynomial<T: GeneralCoeff<F>, F: Field> {
+pub struct GeneralDensePolynomial<T: GroupCoeff<F>, F: Field> {
     /// The coefficient of `x^i` is stored at location `i` in `self.coeffs`.
     pub coeffs: Vec<T>,
     _phantom: PhantomData<F>,
@@ -59,7 +59,7 @@ pub struct GeneralDensePolynomial<T: GeneralCoeff<F>, F: Field> {
 // upstream PR.
 impl<T, F> GeneralDensePolynomial<T, F>
 where
-    T: GeneralCoeff<F>,
+    T: GroupCoeff<F>,
     F: Field,
 {
     /// Constructs a new polynomial from a list of coefficients
@@ -124,7 +124,7 @@ pub enum BatchEvalPoints<'a, F: Field> {
 
 impl<T, F> GeneralDensePolynomial<T, F>
 where
-    T: GeneralCoeff<F> + DomainCoeff<F> + for<'a> Mul<&'a F, Output = T>,
+    T: GroupCoeff<F> + DomainCoeff<F> + for<'a> Mul<&'a F, Output = T>,
     F: FftField,
 {
     /// Evaluate `self` at a list of `points`.
@@ -164,7 +164,7 @@ where
 
 impl<T, F> GeneralDensePolynomial<T, F>
 where
-    T: GeneralCoeff<F>,
+    T: GroupCoeff<F>,
     F: Field,
 {
     fn truncate_leading_zeros(&mut self) {
@@ -186,7 +186,7 @@ where
 
 impl<T, F> Zero for GeneralDensePolynomial<T, F>
 where
-    T: GeneralCoeff<F>,
+    T: GroupCoeff<F>,
     F: Field,
 {
     /// returns the zero polynomial
@@ -205,7 +205,7 @@ where
 
 impl<T, F> Add<Self> for GeneralDensePolynomial<T, F>
 where
-    T: GeneralCoeff<F>,
+    T: GroupCoeff<F>,
     F: Field,
 {
     type Output = Self;
@@ -236,7 +236,7 @@ where
 
 impl<T, F> fmt::Debug for GeneralDensePolynomial<T, F>
 where
-    T: GeneralCoeff<F>,
+    T: GroupCoeff<F>,
     F: Field,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {

--- a/primitives/src/pcs/prelude.rs
+++ b/primitives/src/pcs/prelude.rs
@@ -9,7 +9,7 @@ pub use crate::pcs::{
     errors::PCSError,
     multilinear_kzg::{
         srs::{MultilinearProverParam, MultilinearUniversalParams, MultilinearVerifierParam},
-        util::{compute_qx_degree, get_batched_nv, merge_polynomials},
+        util::{get_batched_nv, merge_polynomials},
         MultilinearKzgBatchProof, MultilinearKzgPCS, MultilinearKzgProof,
     },
     structs::Commitment,

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -300,7 +300,7 @@ where
     /// Fast computation of batch opening for a single polynomial at multiple
     /// points. Details see Sec 2.1~2.3 of [FK23](https://eprint.iacr.org/2023/033.pdf).
     ///
-    /// Only accept `polynomial` with power-of-two degree, no constrain on the
+    /// Only accept `polynomial` with power-of-two degree, no constraint on the
     /// size of `points`
     #[allow(clippy::type_complexity)]
     pub fn batch_open_fk23(
@@ -367,7 +367,6 @@ where
             .collect();
 
         // Evaluate at all points
-        ark_std::println!("!! during eval:");
         let evals =
             GeneralDensePolynomial::from_coeff_slice(&polynomial.coeffs).batch_evaluate(points);
 

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -67,19 +67,6 @@ impl<E: Pairing> PolynomialCommitmentScheme for UnivariateKzgPCS<E> {
     type Proof = UnivariateKzgProof<E>;
     type BatchProof = UnivariateKzgBatchProof<E>;
 
-    /// Build SRS for testing.
-    ///
-    /// - For univariate polynomials, `supported_size` is the maximum degree.
-    ///
-    /// WARNING: THIS FUNCTION IS FOR TESTING PURPOSE ONLY.
-    /// THE OUTPUT SRS SHOULD NOT BE USED IN PRODUCTION.
-    fn setup_for_testing<R: RngCore + CryptoRng>(
-        rng: &mut R,
-        supported_size: usize,
-    ) -> Result<Self::SRS, PCSError> {
-        Self::SRS::gen_srs_for_testing(rng, supported_size)
-    }
-
     /// Trim the universal parameters to specialize the public parameters.
     /// Input `max_degree` for univariate.
     /// `supported_num_vars` must be None or an error is returned.
@@ -412,7 +399,7 @@ mod tests {
             while degree <= 1 {
                 degree = usize::rand(rng) % 20;
             }
-            let pp = UnivariateKzgPCS::<E>::setup_for_testing(rng, degree)?;
+            let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(rng, degree)?;
             let (ck, vk) = pp.trim(degree)?;
             let p = <DensePolynomial<E::ScalarField> as DenseUVPolynomial<E::ScalarField>>::rand(
                 degree, rng,
@@ -438,7 +425,7 @@ mod tests {
         for _ in 0..100 {
             let degree = 50;
 
-            let pp = UnivariateKzgPCS::<E>::setup_for_testing(rng, degree)?;
+            let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(rng, degree)?;
             let (ck, vk) = pp.trim(degree)?;
             let p = <DensePolynomial<E::ScalarField> as DenseUVPolynomial<E::ScalarField>>::rand(
                 degree, rng,
@@ -466,7 +453,7 @@ mod tests {
             while degree <= 1 {
                 degree = usize::rand(rng) % 20;
             }
-            let pp = UnivariateKzgPCS::<E>::setup_for_testing(rng, degree)?;
+            let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(rng, degree)?;
             let (ck, vk) = UnivariateKzgPCS::<E>::trim(&pp, degree, None)?;
             let mut comms = Vec::new();
             let mut values = Vec::new();
@@ -517,7 +504,7 @@ mod tests {
 
         let mut rng = test_rng();
         let max_degree = 32;
-        let pp = UnivariateKzgPCS::<E>::setup_for_testing(&mut rng, max_degree)?;
+        let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(&mut rng, max_degree)?;
 
         for _ in 0..1 {
             let degree = 32; // has to be power-of-two

--- a/primitives/src/pcs/univariate_kzg/srs.rs
+++ b/primitives/src/pcs/univariate_kzg/srs.rs
@@ -7,7 +7,7 @@
 //! Implementing Structured Reference Strings for univariate polynomial KZG
 
 use crate::pcs::{PCSError, StructuredReferenceString};
-use ark_ec::{pairing::Pairing, scalar_mul::fixed_base::FixedBase, AffineRepr, CurveGroup};
+use ark_ec::{pairing::Pairing, scalar_mul::fixed_base::FixedBase, CurveGroup};
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
@@ -41,9 +41,9 @@ impl<E: Pairing> UnivariateUniversalParams<E> {
 
 /// `UnivariateProverParam` is used to generate a proof
 #[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug, Eq, PartialEq, Default)]
-pub struct UnivariateProverParam<C: AffineRepr> {
+pub struct UnivariateProverParam<E: Pairing> {
     /// Config
-    pub powers_of_g: Vec<C>,
+    pub powers_of_g: Vec<E::G1Affine>,
 }
 
 /// `UnivariateVerifierParam` is used to check evaluation proofs for a given
@@ -67,7 +67,7 @@ pub struct UnivariateVerifierParam<E: Pairing> {
 }
 
 impl<E: Pairing> StructuredReferenceString for UnivariateUniversalParams<E> {
-    type ProverParam = UnivariateProverParam<E::G1Affine>;
+    type ProverParam = UnivariateProverParam<E>;
     type VerifierParam = UnivariateVerifierParam<E>;
 
     /// Extract the prover parameters from the public parameters.

--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -327,7 +327,7 @@ mod tests {
     };
     use ark_ff::vec;
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-    use jf_utils::Vec;
+    use ark_std::vec::Vec;
 
     #[test]
     fn test_bls_signature_internals() {

--- a/primitives/src/toeplitz.rs
+++ b/primitives/src/toeplitz.rs
@@ -10,7 +10,7 @@
 use crate::errors::PrimitivesError;
 use ark_ff::FftField;
 use ark_poly::{domain::DomainCoeff, EvaluationDomain, GeneralEvaluationDomain};
-use ark_std::{ops::Mul, string::ToString, vec::Vec};
+use ark_std::{format, ops::Mul, string::ToString, vec::Vec};
 use jf_utils::hadamard_product;
 
 /// An `NxN` [Circulant Matrix](https://en.wikipedia.org/wiki/Circulant_matrix)
@@ -80,18 +80,20 @@ pub struct ToeplitzMatrix<F: FftField> {
 }
 
 impl<F: FftField> ToeplitzMatrix<F> {
-    /// constructor for a new Toeplitz matrice.
+    /// constructor for a new Toeplitz matrix.
     pub fn new(col: Vec<F>, row: Vec<F>) -> Result<Self, PrimitivesError> {
         if col.is_empty() || col.len() != row.len() {
-            return Err(PrimitivesError::ParameterError(
-                "2-Dimension should be positive and equal".to_string(),
-            ));
+            return Err(PrimitivesError::ParameterError(format!(
+                "row: {}, col: {} should be both positive and equal",
+                row.len(),
+                col.len()
+            )));
         }
         if col[0] != row[0] {
-            return Err(PrimitivesError::ParameterError(
-                "1st value in 1st column and 1st row of Toeplitz matrix should be the same"
-                    .to_string(),
-            ));
+            return Err(PrimitivesError::ParameterError(format!(
+                "1st value in 1st col: {:?} should be the same as that in 1st row: {:?}",
+                col[0], row[0]
+            )));
         }
 
         Ok(Self { col, row })

--- a/primitives/src/toeplitz.rs
+++ b/primitives/src/toeplitz.rs
@@ -5,12 +5,14 @@
 // along with the Jellyfish library. If not, see <https://mit-license.org/>.
 
 //! Toeplitz matrices and Circulant matrices operations
-//! References: https://eprint.iacr.org/2020/1516.pdf
+//! References: `https://eprint.iacr.org/2020/1516.pdf`
 
 use crate::errors::PrimitivesError;
-use ark_ff::Field;
-use ark_std::string::ToString;
-// use ark_std::ops::Mul;
+use ark_ec::short_weierstrass::{Projective, SWCurveConfig};
+use ark_ff::{FftField, Zero};
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
+use ark_std::{ops::Mul, string::ToString};
+use jf_utils::hadamard_product;
 
 /// An `NxN` [Circulant Matrix](https://en.wikipedia.org/wiki/Circulant_matrix)
 /// is unambiguously represented by its first column, and has the form:
@@ -22,16 +24,39 @@ use ark_std::string::ToString;
 /// [c_N-1 c_N-2 c_N-3 ... c_0]
 ///
 /// It is a special case of [`ToeplitzMatrix`].
-// TODO: (alex) remove this clippy exception
-#[allow(dead_code)]
-pub struct CirculantMatrix<F: Field, const N: usize> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CirculantMatrix<F: FftField, const N: usize> {
     col: [F; N],
 }
 
-// TODO: (alex) need FFT over group elements first.
-// impl<F: Field> Mul<>
+// NOTE: (alex) currently clearer, less error-prone API at the cost of a few
+// (unnecessary?) copying from Vec to array.
+// TODO: (alex) think of ways to extend to arbitrary length vector (simply
+// truncate doesn't work).
+impl<F, const N: usize, C> Mul<[Projective<C>; N]> for CirculantMatrix<F, N>
+where
+    F: FftField,
+    C: SWCurveConfig<ScalarField = F>,
+{
+    type Output = [Projective<C>; N];
+    fn mul(self, rhs: [Projective<C>; N]) -> Self::Output {
+        assert!(
+            N.is_power_of_two(),
+            "Fast Circulant Matrix mul only supports vector size of power of two."
+        );
+        let domain: GeneralEvaluationDomain<F> =
+            GeneralEvaluationDomain::new(N).expect("Should init an evaluation domain");
 
-// impl<F: Field> Mul<>
+        let rhs_evals = domain.fft(&rhs); // DFT(m)
+        let col_evals = domain.fft(&self.col); // DFT(c_N)
+        let eval_prod = // DFT(c_N) * DFT(m)
+            hadamard_product(&col_evals, &rhs_evals).expect("Hadmard product should succeed");
+        let mut res = [Projective::zero(); N]; // iDFT(DFT(c_N) * DFT(m))
+        res.copy_from_slice(&domain.ifft(&eval_prod)[..N]);
+
+        res
+    }
+}
 
 /// An `NxN` [Toeplitz Matrix](https://en.wikipedia.org/wiki/Toeplitz_matrix) is
 /// unambiguously represented by its first column and first row, and has the
@@ -42,14 +67,13 @@ pub struct CirculantMatrix<F: Field, const N: usize> {
 /// [a_2   a_1   a_0   ...  a_-(N-3)]
 /// [..    ..    ..    ...    ..    ]
 /// [a_N-1 a_N-2 ..    ...  a_0     ]
-// TODO: (alex) remove this clippy exception
-#[allow(dead_code)]
-pub struct ToeplitzMatrix<F: Field, const N: usize> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToeplitzMatrix<F: FftField, const N: usize> {
     col: [F; N],
     row: [F; N],
 }
 
-impl<F: Field, const N: usize> ToeplitzMatrix<F, N> {
+impl<F: FftField, const N: usize> ToeplitzMatrix<F, N> {
     /// constructor for a new Toeplitz matrice.
     pub fn new(col: [F; N], row: [F; N]) -> Result<Self, PrimitivesError> {
         if N == 0 {
@@ -90,7 +114,7 @@ impl<F: Field, const N: usize> ToeplitzMatrix<F, N> {
     }
 }
 
-impl<F: Field, const N: usize> From<CirculantMatrix<F, N>> for ToeplitzMatrix<F, N> {
+impl<F: FftField, const N: usize> From<CirculantMatrix<F, N>> for ToeplitzMatrix<F, N> {
     fn from(c: CirculantMatrix<F, N>) -> Self {
         let mut row = [c.col[0]; N];
         for (i, v) in c.col.iter().enumerate().skip(1) {
@@ -100,7 +124,7 @@ impl<F: Field, const N: usize> From<CirculantMatrix<F, N>> for ToeplitzMatrix<F,
     }
 }
 
-impl<F: Field, const N: usize> TryFrom<ToeplitzMatrix<F, N>> for CirculantMatrix<F, N> {
+impl<F: FftField, const N: usize> TryFrom<ToeplitzMatrix<F, N>> for CirculantMatrix<F, N> {
     type Error = PrimitivesError;
 
     fn try_from(t: ToeplitzMatrix<F, N>) -> Result<Self, Self::Error> {
@@ -110,5 +134,103 @@ impl<F: Field, const N: usize> TryFrom<ToeplitzMatrix<F, N>> for CirculantMatrix
             ));
         }
         Ok(Self { col: t.col })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bls12_381::{Fr, G1Projective};
+    use ark_ff::Field;
+    use ark_std::{convert::Into, ops::AddAssign, UniformRand};
+    use jf_utils::test_rng;
+
+    // a MxN matrix, M rows, N cols.
+    struct Matrix<T, const M: usize, const N: usize>([[T; N]; M]);
+    struct Vector<T, const N: usize>([T; N]);
+
+    impl<T: Copy, const M: usize, const N: usize> Matrix<T, M, N> {
+        fn transpose(self) -> Matrix<T, N, M> {
+            let mut transposed = [[self.0[0][0]; M]; N];
+            for i in 0..M {
+                for j in 0..N {
+                    transposed[j][i] = self.0[i][j];
+                }
+            }
+            Matrix(transposed)
+        }
+    }
+
+    impl<T: Copy, const N: usize> From<Matrix<T, 1, N>> for Vector<T, N> {
+        fn from(m: Matrix<T, 1, N>) -> Self {
+            let mut v = [m.0[0][0]; N];
+            v.copy_from_slice(&m.0[0]);
+            Vector(v)
+        }
+    }
+
+    impl<F: FftField, const N: usize> CirculantMatrix<F, N> {
+        fn full_matrix(self) -> Matrix<F, N, N> {
+            let t: ToeplitzMatrix<F, N> = self.into();
+            let mut row_vecs = [t.row; N];
+            let mut cur_row = t.row;
+
+            for i in 1..N {
+                cur_row.rotate_right(1);
+                row_vecs[i] = cur_row;
+            }
+            // some arbitrary sanity check
+            assert_eq!(row_vecs[N - 1][0], row_vecs[0][1]);
+            assert_eq!(row_vecs[1][0], row_vecs[0][N - 1]);
+            assert_eq!(row_vecs[N - 1][N - 1], row_vecs[0][0]);
+
+            Matrix(row_vecs)
+        }
+    }
+
+    fn naive_matrix_mul<F, T, const M: usize, const N: usize, const K: usize>(
+        a: Matrix<F, M, N>,
+        b: Matrix<T, N, K>,
+    ) -> Matrix<T, M, K>
+    where
+        F: Field,
+        T: for<'a> Mul<&'a F, Output = T> + AddAssign<T> + Copy + Default,
+    {
+        let mut c = [[T::default(); K]; M];
+
+        for i in 0..M {
+            for j in 0..K {
+                for k in 0..N {
+                    c[i][j] += b.0[k][j] * &a.0[i][k];
+                }
+            }
+        }
+        Matrix(c)
+    }
+
+    #[test]
+    fn test_circulant_mul() -> Result<(), PrimitivesError> {
+        let mut rng = test_rng();
+        const N: usize = 16;
+
+        let mut cir_col = [Fr::default(); N];
+        for f in cir_col.iter_mut() {
+            *f = Fr::rand(&mut rng);
+        }
+        let cir_matrix = CirculantMatrix { col: cir_col };
+
+        let mut msgs = [G1Projective::default(); N];
+        for m in msgs.iter_mut() {
+            *m = G1Projective::rand(&mut rng);
+        }
+        let msg_matrix = Matrix([msgs]);
+
+        let expected: Vector<G1Projective, N> =
+            naive_matrix_mul(cir_matrix.clone().full_matrix(), msg_matrix.transpose())
+                .transpose()
+                .into();
+        let got: [G1Projective; N] = cir_matrix * msgs;
+        assert_eq!(expected.0, got, "Fast Circulant Matrix mul is incorrect.");
+        Ok(())
     }
 }

--- a/primitives/src/toeplitz.rs
+++ b/primitives/src/toeplitz.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2023 Espresso Systems (espressosys.com)
+// This file is part of the Jellyfish library.
+
+// You should have received a copy of the MIT License
+// along with the Jellyfish library. If not, see <https://mit-license.org/>.
+
+//! Toeplitz matrices and Circulant matrices operations
+//! References: https://eprint.iacr.org/2020/1516.pdf
+
+use crate::errors::PrimitivesError;
+use ark_ff::Field;
+use ark_std::string::ToString;
+// use ark_std::ops::Mul;
+
+/// An `NxN` [Circulant Matrix](https://en.wikipedia.org/wiki/Circulant_matrix)
+/// is unambiguously represented by its first column, and has the form:
+///
+/// [c_0   c_N-1 c_N-2 ... c_1]
+/// [c_1   c_0   c_N-1 ... c_2]
+/// [c_2   c_1   c_0   ... c_3]
+/// [..    ..    ..    ... .. ]
+/// [c_N-1 c_N-2 c_N-3 ... c_0]
+///
+/// It is a special case of [`ToeplitzMatrix`].
+// TODO: (alex) remove this clippy exception
+#[allow(dead_code)]
+pub struct CirculantMatrix<F: Field, const N: usize> {
+    col: [F; N],
+}
+
+// TODO: (alex) need FFT over group elements first.
+// impl<F: Field> Mul<>
+
+// impl<F: Field> Mul<>
+
+/// An `NxN` [Toeplitz Matrix](https://en.wikipedia.org/wiki/Toeplitz_matrix) is
+/// unambiguously represented by its first column and first row, and has the
+/// form:
+///
+/// [a_0   a_-1  a_-2  ...  a_-(N-1)]
+/// [a_1   a_0   a_-1  ...  a_-(N-2)]
+/// [a_2   a_1   a_0   ...  a_-(N-3)]
+/// [..    ..    ..    ...    ..    ]
+/// [a_N-1 a_N-2 ..    ...  a_0     ]
+// TODO: (alex) remove this clippy exception
+#[allow(dead_code)]
+pub struct ToeplitzMatrix<F: Field, const N: usize> {
+    col: [F; N],
+    row: [F; N],
+}
+
+impl<F: Field, const N: usize> ToeplitzMatrix<F, N> {
+    /// constructor for a new Toeplitz matrice.
+    pub fn new(col: [F; N], row: [F; N]) -> Result<Self, PrimitivesError> {
+        if N == 0 {
+            return Err(PrimitivesError::ParameterError(
+                "Matrix dimension should be positive".to_string(),
+            ));
+        }
+        if col[0] != row[0] {
+            return Err(PrimitivesError::ParameterError(
+                "1st value in 1st column and 1st row of Toeplitz matrix should be the same"
+                    .to_string(),
+            ));
+        }
+
+        Ok(Self { col, row })
+    }
+
+    /// Embeds a Toeplitz matrix of size N to a Circulant matrix of size 2N.
+    ///
+    /// Details see Section 2.3.1 of [Tomescu20](https://eprint.iacr.org/2020/1516.pdf).
+    // TODO: (alex) turn this into concurrent code after: https://github.com/EspressoSystems/jellyfish/issues/111
+    pub fn circulant_embedding<const M: usize>(
+        &self,
+    ) -> Result<CirculantMatrix<F, M>, PrimitivesError> {
+        if M != 2 * N {
+            return Err(PrimitivesError::ParameterError(
+                "Circulant embedding should be twice the size".to_string(),
+            ));
+        }
+        let mut extended_col = [self.col[0]; M];
+        extended_col[..N].copy_from_slice(&self.col);
+        extended_col[N] = self.col[0];
+        for (i, v) in self.row.iter().enumerate().skip(1) {
+            extended_col[2 * N - i] = *v;
+        }
+
+        Ok(CirculantMatrix { col: extended_col })
+    }
+}
+
+impl<F: Field, const N: usize> From<CirculantMatrix<F, N>> for ToeplitzMatrix<F, N> {
+    fn from(c: CirculantMatrix<F, N>) -> Self {
+        let mut row = [c.col[0]; N];
+        for (i, v) in c.col.iter().enumerate().skip(1) {
+            row[N - i] = *v;
+        }
+        Self { col: c.col, row }
+    }
+}
+
+impl<F: Field, const N: usize> TryFrom<ToeplitzMatrix<F, N>> for CirculantMatrix<F, N> {
+    type Error = PrimitivesError;
+
+    fn try_from(t: ToeplitzMatrix<F, N>) -> Result<Self, Self::Error> {
+        if (1..N).any(|i| t.row[i] != t.col[N - i]) {
+            return Err(PrimitivesError::ParameterError(
+                "Not a Circulant Matrix".to_string(),
+            ));
+        }
+        Ok(Self { col: t.col })
+    }
+}

--- a/primitives/src/toeplitz.rs
+++ b/primitives/src/toeplitz.rs
@@ -58,7 +58,7 @@ impl<F: FftField> CirculantMatrix<F> {
         let m_evals = domain.fft(m); // DFT(m)
         let col_evals = domain.fft(&self.col); // DFT(c_N)
         let eval_prod = // DFT(c_N) * DFT(m)
-            hadamard_product(col_evals, m_evals).expect("Hadmard product should succeed");
+            hadamard_product(col_evals, m_evals).expect("Hadamard product should succeed");
         let res = domain.ifft(&eval_prod); // iDFT(DFT(c_N) * DFT(m))
         Ok(res)
     }

--- a/primitives/src/toeplitz.rs
+++ b/primitives/src/toeplitz.rs
@@ -48,7 +48,7 @@ impl<F: FftField, const N: usize> CirculantMatrix<F, N> {
         let m_evals = domain.fft(&m); // DFT(m)
         let col_evals = domain.fft(&self.col); // DFT(c_N)
         let eval_prod = // DFT(c_N) * DFT(m)
-            hadamard_product(&col_evals, &m_evals).expect("Hadmard product should succeed");
+            hadamard_product(col_evals, m_evals).expect("Hadmard product should succeed");
         let mut res = [T::default(); N]; // iDFT(DFT(c_N) * DFT(m))
         res.copy_from_slice(&domain.ifft(&eval_prod)[..N]);
         Ok(res)

--- a/primitives/src/toeplitz.rs
+++ b/primitives/src/toeplitz.rs
@@ -40,7 +40,7 @@ impl<F: FftField> CirculantMatrix<F> {
     // truncate doesn't work).
     pub fn fast_vec_mul<T>(&self, m: &[T]) -> Result<Vec<T>, PrimitivesError>
     where
-        T: for<'a> Mul<&'a F, Output = T> + DomainCoeff<F> + Default,
+        T: for<'a> Mul<&'a F, Output = T> + DomainCoeff<F>,
     {
         if !m.len().is_power_of_two() {
             return Err(PrimitivesError::ParameterError(
@@ -117,7 +117,7 @@ impl<F: FftField> ToeplitzMatrix<F> {
     /// Details see Section 2.3.1 of [Tomescu20](https://eprint.iacr.org/2020/1516.pdf).
     pub fn fast_vec_mul<T>(&self, v: &[T]) -> Result<Vec<T>, PrimitivesError>
     where
-        T: for<'a> Mul<&'a F, Output = T> + DomainCoeff<F> + Default,
+        T: for<'a> Mul<&'a F, Output = T> + DomainCoeff<F>,
     {
         if !v.len().is_power_of_two() {
             return Err(PrimitivesError::ParameterError(
@@ -132,7 +132,7 @@ impl<F: FftField> ToeplitzMatrix<F> {
 
         let cir_repr = self.circulant_embedding()?;
         let mut padded_v = Vec::from(v);
-        padded_v.resize_with(2 * v.len(), T::default);
+        padded_v.resize(2 * v.len(), T::zero());
 
         let mut res = cir_repr.fast_vec_mul(&padded_v)?;
         res.truncate(v.len());

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,6 +5,6 @@ set -e
 export RUSTFLAGS="-C overflow-checks=on"
 
 cargo test --release -p jf-utils -- -Zunstable-options --report-time
-cargo test --release -p jf-plonk -- -Zunstable-options --report-time
+cargo test --release -p jf-plonk --lib --bins -- -Zunstable-options --report-time
 cargo test --release -p jf-primitives -- -Zunstable-options --report-time
 cargo test --release -p jf-relation -- -Zunstable-options --report-time


### PR DESCRIPTION
## Description

Partially completes: #118 

Major changes include:
- add trait bound to associated type of the PCS trait: `PolynomialCommitmentScheme::SRS: StructuredReferenceString`.
- define Toeplitz and Circulant matrix, impl conversion between them. 
- Implement fast mul with a vector for circulant matrix
- implement fast mul with a vector for toeplitz by expanding into a 2N circulant matrix and use above subroutine
- add correctness test for matrix multiplications.
- Define a `GeneralDensePolynomial` that allows its coeffs to be either field or group, and implement `batch_evaluate`
- FK23 methods using all above, with unit tests.

More important changes when addressing comments:
- hide `gen_srs_for_testing` under `test-srs` feature flag (and also available for test) so that downstream and bench code can still use it, but won't be in the default or production-ready binary.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
