### PR TITLE
New `bytes_from_field_elements` util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 ### Fixed
 
 ### Added
+
 - [#233](https://github.com/EspressoSystems/jellyfish/pull/233) BLS aggregation APIs
+- [#234](https://github.com/EspressoSystems/jellyfish/pull/234) New `bytes_from_field_elements` util
+
 ### Changed
 
 ### Removed
@@ -23,6 +26,7 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 ## [v0.3.0](https://github.com/EspressoSystems/jellyfish/compare/0.2.0...0.3.0) - 2023-03-22
 
 ### Breaking Changes
+
 - [#207](https://github.com/EspressoSystems/jellyfish/pull/207) Update arkworks dependency to v0.4.0
 
 ## [v0.2.0](https://github.com/EspressoSystems/jellyfish/compare/0.1.2...0.2.0) - 2023-01-20
@@ -35,54 +39,54 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 - [#96](https://github.com/EspressoSystems/jellyfish/pull/96) (`jf-plonk`) Introduce comparison gates
 - [#107](https://github.com/EspressoSystems/jellyfish/pull/107) (`jf-primitives`) Updated `crypto_box` from `0.7.1` to `0.8.1`
 - [#110](https://github.com/EspressoSystems/jellyfish/pull/110) (workspace) Reorganized codebase structure
-    - Remove `jf-rescue` crate, rescue hash function now resides in `jf-primitives/rescue`.
-    - Plonk constraint system definition and concrete constructions now live in a standalone crate `jf-relation`.
-        - Basic and customized circuit gates are defined in `jf-relation`.
-        - Customized/advanced circuit implementations are located in their own crates.
-            - Plonk verifier related gadgets, `transcript` and `plonk-verifier` are now in `jf-plonk/circuit`.
-            - Primitive gadgets, including `commitment`, `el gamal` etc. remains in `jf-primitives/circuit`.
-            - Circuit for rescue hash function is now in `jf-primitives/circuit/rescue`.
-    - `par-utils` is moved to `jf-utils`.
+  - Remove `jf-rescue` crate, rescue hash function now resides in `jf-primitives/rescue`.
+  - Plonk constraint system definition and concrete constructions now live in a standalone crate `jf-relation`.
+    - Basic and customized circuit gates are defined in `jf-relation`.
+    - Customized/advanced circuit implementations are located in their own crates.
+      - Plonk verifier related gadgets, `transcript` and `plonk-verifier` are now in `jf-plonk/circuit`.
+      - Primitive gadgets, including `commitment`, `el gamal` etc. remains in `jf-primitives/circuit`.
+      - Circuit for rescue hash function is now in `jf-primitives/circuit/rescue`.
+  - `par-utils` is moved to `jf-utils`.
 - [#126](https://github.com/EspressoSystems/jellyfish/pull/126) (nix) Used nix flake
 - [#135](https://github.com/EspressoSystems/jellyfish/pull/135) Major Merkle Tree refactoring, Unification of different variants:
-    - Introduce new traits which define the functionalities.
-        - `MerkleTreeScheme` is the abstraction of a static array accumulator,
-        - `AppendableMerkleTreeScheme` is the abstraction of an appendable vector accumulator.
-        - `UniversalMerkleTreeScheme` is the abstraction of a key-value map accumulator, which also supports non-membership query/proof.
-        - `ForgetableMerkleTreeScheme` allows you to forget/remember some leafs from the memory.
-    - Implementation of new generic merkle tree: `MerkleTree` and `UniversalMerkleTree`
-        - A default rate-3 rescue merkle tree implementation is provided in `prelude` module.
-        - Other example instantiation can be found in `example` module.
+  - Introduce new traits which define the functionalities.
+    - `MerkleTreeScheme` is the abstraction of a static array accumulator,
+    - `AppendableMerkleTreeScheme` is the abstraction of an appendable vector accumulator.
+    - `UniversalMerkleTreeScheme` is the abstraction of a key-value map accumulator, which also supports non-membership query/proof.
+    - `ForgetableMerkleTreeScheme` allows you to forget/remember some leafs from the memory.
+  - Implementation of new generic merkle tree: `MerkleTree` and `UniversalMerkleTree`
+    - A default rate-3 rescue merkle tree implementation is provided in `prelude` module.
+    - Other example instantiation can be found in `example` module.
 - [#137](https://github.com/EspressoSystems/jellyfish/pull/137) (`jf-primitives`) Refactored VRF APIs and traits
 - [#144](https://github.com/EspressoSystems/jellyfish/pull/144) (`jf-primitives`) Updated append-only merkle tree gadget with the latest MT API
 - [#119](https://github.com/EspressoSystems/jellyfish/pull/119) (all) Updated dependencies
   - Upgraded `criterion` from `0.3.1` to `0.4.0`
 - [#146](https://github.com/EspressoSystems/jellyfish/pull/146) (`jf-primitives`) Refactored Rescue sponge API:
-    - Remove all `.*sponge.*` methods from `Permutation`.
-    - Introduce `RescueCRHF` which takes over `sponge_with_padding` and `sponge_no_padding` from `Permutation`.
-    - Introduce `RescuePRF` which takes over `full_state_keyed_sponge_with_padding` and `full_state_keyed_sponge_no_padding` from `Permutation`.
+  - Remove all `.*sponge.*` methods from `Permutation`.
+  - Introduce `RescueCRHF` which takes over `sponge_with_padding` and `sponge_no_padding` from `Permutation`.
+  - Introduce `RescuePRF` which takes over `full_state_keyed_sponge_with_padding` and `full_state_keyed_sponge_no_padding` from `Permutation`.
 - [#148](https://github.com/EspressoSystems/jellyfish/pull/148), [#156](https://github.com/EspressoSystems/jellyfish/pull/156) (`jf-primitives`) Refactored BLS Signature implementation
   - #148 Added trait bounds on associated types of `trait SignatureScheme`
   - #156 Improved BLS correctness and API compliance with IRTF standard with better doc
 - [#150](https://github.com/EspressoSystems/jellyfish/pull/150) (`jf-primitives`) Refactor `RescueGadget`
-    - Introduce `SpongeStateVar` to abstract over `RescueStateVar` and `RescueNonNativeStateVar` structs.
-    - Unify `RescueGadget` and `RescueNonNativeGadget` traits into `RescueGadget`.
+  - Introduce `SpongeStateVar` to abstract over `RescueStateVar` and `RescueNonNativeStateVar` structs.
+  - Unify `RescueGadget` and `RescueNonNativeGadget` traits into `RescueGadget`.
 - [#158](https://github.com/EspressoSystems/jellyfish/pull/158) (`jf-primitives`) Refactored `MerkleTreeGadget` API:
-    - Generic only over `MerkleTreeScheme`.
-    - New methods for allocating variables: `create_leaf_variable`, `create_membership_proof_variable`, `create_root_variable`.
-    - New methods for enforcing constraints: `is_member` and `enforce_merkle_proof`.
-    - Move the remaining methods to the internals of circuit implementation for `RescueMerkleTree`.
-    - Implement `MerkleTreeGadget` for `RescueMerkleTree`.
+  - Generic only over `MerkleTreeScheme`.
+  - New methods for allocating variables: `create_leaf_variable`, `create_membership_proof_variable`, `create_root_variable`.
+  - New methods for enforcing constraints: `is_member` and `enforce_merkle_proof`.
+  - Move the remaining methods to the internals of circuit implementation for `RescueMerkleTree`.
+  - Implement `MerkleTreeGadget` for `RescueMerkleTree`.
 - [#169](https://github.com/EspressoSystems/jellyfish/pull/169) (`jf-primitives`) Stabilize API effort
-    - Introduced `trait CRHF` and moved current implementations under `struct FixedLengthRescueCRHF, VariableLengthRescueCRHF`.
-    - Introduced `trait CommitmentScheme` and moved current implementations under `struct FixedLengthRescueCommitment`.
+  - Introduced `trait CRHF` and moved current implementations under `struct FixedLengthRescueCRHF, VariableLengthRescueCRHF`.
+  - Introduced `trait CommitmentScheme` and moved current implementations under `struct FixedLengthRescueCommitment`.
 - [#194](https://github.com/EspressoSystems/jellyfish/pull/194) (all) Set MSVR of all crates to 1.64.
 - (`jf-primitives`) `zeroize` from `1.3` to `^1.5`
 
 ### Fixed
 
 - [#76](https://github.com/EspressoSystems/jellyfish/pull/76) (`jf-plonk`) Splitting polynomials are masked to ensure zero-knowledge of Plonk
-    - Now `PlonkKzgSnark` use our own KZG10 implementation.
+  - Now `PlonkKzgSnark` use our own KZG10 implementation.
 - [#115](https://github.com/EspressoSystems/jellyfish/pull/115) (`jf-relation`) Fix a bug in `logic_or` gate
 
 ### Added
@@ -113,11 +117,11 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 ### Breaking Changes
 
 - [#107](https://github.com/EspressoSystems/jellyfish/pull/110) (`jf-primitives`) Updated `crypto_box` from `0.7.1` to `0.8.1`
-- [#149](https://github.com/EspressoSystems/jellyfish/pull/149) (`jf-primitives`, nix) 
-    - Updated dependencies
-        - `crypto_box` from `0.7.1` to `0.8.1`
-        - `zeroize` from `1.3` to `^1.5`
-    - Used nix flake instead, bumped rust version to `1.65`
+- [#149](https://github.com/EspressoSystems/jellyfish/pull/149) (`jf-primitives`, nix)
+  - Updated dependencies
+    - `crypto_box` from `0.7.1` to `0.8.1`
+    - `zeroize` from `1.3` to `^1.5`
+  - Used nix flake instead, bumped rust version to `1.65`
 
 ## [v0.1.2](https://github.com/EspressoSystems/jellyfish/compare/0.1.1...0.1.2) - 2022-06-22
 

--- a/plonk/src/transcript/rescue.rs
+++ b/plonk/src/transcript/rescue.rs
@@ -99,7 +99,7 @@ where
     fn append_message(&mut self, _label: &'static [u8], msg: &[u8]) -> Result<(), PlonkError> {
         // We remove the labels for better efficiency
 
-        let mut f = bytes_to_field_elements(&msg);
+        let mut f = bytes_to_field_elements(msg);
         self.transcript.append(&mut f);
         Ok(())
     }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -13,6 +13,7 @@ ark-ff = { version = "0.4.0", default-features = false, features = [ "asm" ] }
 ark-serialize = { version = "0.4.0", default-features = false }
 ark-std = { version = "0.4.0", default-features = false }
 digest = { version = "0.10.1", default-features = false }
+displaydoc = { version = "0.2.3", default-features = false }
 rayon = { version = "1.5.0", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10.1", default-features = false }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -13,7 +13,6 @@ ark-ff = { version = "0.4.0", default-features = false, features = [ "asm" ] }
 ark-serialize = { version = "0.4.0", default-features = false }
 ark-std = { version = "0.4.0", default-features = false }
 digest = { version = "0.10.1", default-features = false }
-displaydoc = { version = "0.2.3", default-features = false }
 rayon = { version = "1.5.0", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10.1", default-features = false }

--- a/utilities/src/conversion.rs
+++ b/utilities/src/conversion.rs
@@ -222,6 +222,12 @@ mod tests {
             let result = bytes_from_field_elements(elems).unwrap();
             assert_eq!(result, random_bytes);
         }
+
+        // trailing zeros
+        let bytes = [5, 4, 3, 2, 1, 0];
+        let elems: Vec<F> = bytes_to_field_elements(&bytes);
+        let result = bytes_from_field_elements(&elems).unwrap();
+        assert_eq!(result, bytes);
     }
 
     #[test]

--- a/utilities/src/conversion.rs
+++ b/utilities/src/conversion.rs
@@ -104,9 +104,10 @@ where
 {
     // - partition bytes into chunks of length one fewer than the base prime field
     //   modulus byte length
-    // - convert each chunk into F via F::from_le_bytes_mod_order
+    // - convert each chunk into PrimeField via from_le_bytes_mod_order
     // - modular reduction is guaranteed not to occur because chunk byte length is
     //   sufficiently small
+    // - collect PrimeField elements into Field elements and append to result
     let primefield_chunk_len = ((F::BasePrimeField::MODULUS_BIT_SIZE - 1) / 8) as usize;
     let extension_degree = F::extension_degree() as usize;
     let field_chunk_len = primefield_chunk_len * extension_degree;
@@ -179,7 +180,7 @@ where
     // for each base prime field element:
     // - convert to bytes
     // - drop the trailing byte, which must be zero
-    // collect prime field elements into field elements and append to result
+    // - append bytes to result
     let mut result = Vec::with_capacity(result_capacity);
     for elem in elems {
         for primefield_elem in elem.to_base_prime_field_elements() {

--- a/utilities/src/conversion.rs
+++ b/utilities/src/conversion.rs
@@ -102,6 +102,12 @@ where
     B: AsRef<[u8]>,
     F: Field,
 {
+    // Need to ensure that F::characteristic is large enough to hold a u64.
+    // This should be possible at compile time but I don't know how.
+    // Example: could use <https://docs.rs/static_assertions> but then you hit
+    // <https://users.rust-lang.org/t/error-e0401-cant-use-generic-parameters-from-outer-function/84512>
+    assert!(F::BasePrimeField::MODULUS_BIT_SIZE > 64);
+
     // - partition bytes into chunks of length one fewer than the base prime field
     //   modulus byte length
     // - convert each chunk into PrimeField via from_le_bytes_mod_order
@@ -146,6 +152,12 @@ where
     T: AsRef<[F]>,
     F: Field,
 {
+    // Need to ensure that F::characteristic is large enough to hold a u64.
+    // This should be possible at compile time but I don't know how.
+    // Example: could use <https://docs.rs/static_assertions> but then you hit
+    // <https://users.rust-lang.org/t/error-e0401-cant-use-generic-parameters-from-outer-function/84512>
+    assert!(F::BasePrimeField::MODULUS_BIT_SIZE > 64);
+
     let (first_elem, elems) = elems.as_ref().split_first().ok_or("empty elems")?;
 
     // the first element encodes the number of bytes to return

--- a/utilities/src/conversion.rs
+++ b/utilities/src/conversion.rs
@@ -99,7 +99,7 @@ where
 /// field elements.
 pub fn bytes_to_field_elements<B, F>(bytes: B) -> Vec<F>
 where
-    B: AsRef<[u8]> + Clone,
+    B: AsRef<[u8]>,
     F: PrimeField,
 {
     // partition bytes into chunks of length one fewer than the modulus byte length

--- a/utilities/src/conversion.rs
+++ b/utilities/src/conversion.rs
@@ -284,6 +284,7 @@ mod tests {
 
     #[test]
     fn test_bytes_field_elems() {
-        bytes_field_elems::<Fr381>()
+        bytes_field_elems::<Fr381>();
+        bytes_field_elems::<Fr254>();
     }
 }


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #227 

- add `bytes_from_field_elements()` to invert `bytes_to_field_elements()`
- modify `bytes_to_field_elements()` to encode bytes length in the first field element for use in inversion
- remove unneeded bytes copy in `bytes_to_field_elements` and other tidying
- generalize both functions from `PrimeField` to `Field`
- TODO: used `String` as error type for `bytes_from_field_elements`---should we do something else instead?
- minimal tests only

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
