### PR TITLE
fix: bytes_from_field_elements remove lower bound check on result_len

### DIFF
--- a/utilities/src/conversion.rs
+++ b/utilities/src/conversion.rs
@@ -178,14 +178,15 @@ where
     let field_chunk_len = primefield_chunk_len * extension_degree;
     let result_capacity = elems.len() * field_chunk_len;
 
-    // the original bytes must end somewhere in the final field element
-    // thus, result_len must be within elem_byte_len of result_capacity
-    if result_len > result_capacity || result_len < result_capacity - field_chunk_len {
+    // the original bytes MUST end BEFORE the final field element
+    // thus, result_len <= result_capacity
+    // the original bytes SHOULD end somewhere WITHIN the final field element
+    // however, we allow the user to pad elems with zeros so as to facilitate
+    // use cases such as polynomial interpolation
+    if result_len > result_capacity {
         return Err(format!(
-            "result len {} out of bounds {}..{}",
-            result_len,
-            result_capacity - field_chunk_len,
-            result_capacity
+            "result len {} exceeds elems capacity {}",
+            result_len, result_capacity
         ));
     }
 


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Currently `bytes_from_field_elements` enforces that the result length be within the final field element.

However, some use cases (such as polynomial interpolation) might pad the list of field elements with extra zeros. In this case result length will be below the final field element, so `bytes_from_field_elements` will throw an error.

We could rely on the caller to remember how many field elements it started with and trim appropriately, but that cuts against the purpose of encoding the result length in the field elements. It makes more sense to simply allow the user to pad with extra zeros and then truncate down to the encoded result length at the end.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
