### PR TITLE
Minor changes to support BLS signature verification inside a smart contract

### DIFF
--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -272,7 +272,8 @@ pub struct KeyPair {
 #[derive(CanonicalSerialize, CanonicalDeserialize, Eq, Clone, Debug)]
 #[allow(non_snake_case)]
 pub struct Signature {
-    pub(crate) sigma: G1Projective,
+    /// The signature is a G1 group element.
+    pub sigma: G1Projective,
 }
 
 impl Hash for Signature {

--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -273,7 +273,7 @@ pub struct KeyPair {
 #[allow(non_snake_case)]
 pub struct Signature {
     /// The signature is a G1 group element.
-    pub sigma: G1Projective,
+    pub(crate) sigma: G1Projective,
 }
 
 impl Hash for Signature {
@@ -285,6 +285,13 @@ impl Hash for Signature {
 impl PartialEq for Signature {
     fn eq(&self, other: &Self) -> bool {
         self.sigma == other.sigma
+    }
+}
+
+impl Signature {
+    /// Getter function to obtain the signature value
+    pub fn get_sig_value(self) -> G1Projective {
+        self.sigma
     }
 }
 // =====================================================

--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -46,7 +46,7 @@ use ark_ec::{
 };
 use ark_ff::{
     field_hashers::{DefaultFieldHasher, HashToField},
-    Field, PrimeField,
+    BigInteger, Field, PrimeField,
 };
 use ark_serialize::*;
 use ark_std::{
@@ -333,8 +333,9 @@ pub fn hash_to_curve<H: Default + DynDigest + Clone>(msg: &[u8]) -> G1Projective
     let mut y = Y.sqrt().unwrap();
 
     // Ensure that y < p/2 where p is the modulus of Fq
-    let y_div_2 = y.into_bigint().const_shr();
-    if y_div_2 > BaseField::MODULUS {
+    let mut y_mul_2 = y.into_bigint();
+    y_mul_2.mul2();
+    if y_mul_2 > BaseField::MODULUS {
         y.neg_in_place();
     }
 

--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -46,7 +46,7 @@ use ark_ec::{
 };
 use ark_ff::{
     field_hashers::{DefaultFieldHasher, HashToField},
-    Field,
+    Field, PrimeField,
 };
 use ark_serialize::*;
 use ark_std::{
@@ -330,7 +330,13 @@ pub fn hash_to_curve<H: Default + DynDigest + Clone>(msg: &[u8]) -> G1Projective
     }
 
     // Safe unwrap as `y` is a quadratic residue
-    let y = Y.sqrt().unwrap();
+    let mut y = Y.sqrt().unwrap();
+
+    // Ensure that y < p/2 where p is the modulus of Fq
+    let y_div_2 = y.into_bigint().const_shr();
+    if y_div_2 > BaseField::MODULUS {
+        y.neg_in_place();
+    }
 
     let g1_affine = G1Affine::new(x, y);
     G1Projective::from(g1_affine)

--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -46,7 +46,7 @@ use ark_ec::{
 };
 use ark_ff::{
     field_hashers::{DefaultFieldHasher, HashToField},
-    Field, MontFp,
+    Field,
 };
 use ark_serialize::*;
 use ark_std::{
@@ -310,7 +310,7 @@ pub fn hash_to_curve<H: Default + DynDigest + Clone>(msg: &[u8]) -> G1Projective
 
     // General equation of the curve: y^2 = x^3 + ax + b
     // For BN254 we have a=0 and b=3 so we only use b
-    let coeff_b: BaseField = MontFp!("3");
+    let coeff_b: BaseField = BaseField::from(3);
 
     let mut x: BaseField = hasher.hash_to_field(msg, 1)[0];
     let mut Y: BaseField = x * x * x + coeff_b;


### PR DESCRIPTION
This PR is related to https://github.com/EspressoSystems/espresso-sequencer/pull/292. The changes are:
* Add a public function to have access to the attribute of the `Signature` struct.
* Change the logic of hash_to_curve  about computing the square root of a field element so that it is consistent with https://github.com/EspressoSystems/cape/blob/77f343849db3d9e721c6e3d0f7108155c178dbee/contracts/contracts/libraries/BN254.sol#L338