### PR TITLE
Remove function `Signature.get_sig_value()` and make `Signature.sigma` public instead.

### DIFF
--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -277,7 +277,7 @@ pub struct KeyPair {
 #[allow(non_snake_case)]
 pub struct Signature {
     /// The signature is a G1 group element.
-    pub(crate) sigma: G1Projective,
+    pub sigma: G1Projective,
 }
 
 impl Hash for Signature {
@@ -292,12 +292,6 @@ impl PartialEq for Signature {
     }
 }
 
-impl Signature {
-    /// Getter function to obtain the signature value
-    pub fn get_sig_value(self) -> G1Projective {
-        self.sigma
-    }
-}
 // =====================================================
 // end of definitions
 // =====================================================


### PR DESCRIPTION
As discussed in https://github.com/EspressoSystems/jellyfish/pull/242#pullrequestreview-1393076760.