### PR TITLE
make `bytes_from_field_elements` infallible with paranoid checks for overflow

### DIFF
--- a/primitives/src/pcs/errors.rs
+++ b/primitives/src/pcs/errors.rs
@@ -28,6 +28,8 @@ pub enum PCSError {
     TranscriptError(TranscriptError),
 }
 
+impl ark_std::error::Error for PCSError {}
+
 impl From<SerializationError> for PCSError {
     fn from(e: ark_serialize::SerializationError) -> Self {
         Self::SerializationError(e)

--- a/relation/src/gadgets/ecc/glv.rs
+++ b/relation/src/gadgets/ecc/glv.rs
@@ -94,7 +94,8 @@ where
         self.check_var_bound(scalar)?;
         self.check_point_var_bound(base)?;
 
-        let (s1_var, s2_var, s2_sign_var) = scalar_decomposition_gate::<_, P, _>(self, &scalar)?;
+        let (s1_var, s2_var, s2_sign_var) =
+            scalar_decomposition_gate::<P::BaseField, P::ScalarField>(self, &scalar)?;
 
         let endo_base_var = endomorphism_circuit::<_, P>(self, base)?;
         multi_scalar_mul_circuit::<_, P>(self, base, s1_var, &endo_base_var, s2_var, s2_sign_var)
@@ -264,13 +265,13 @@ macro_rules! int_to_fq {
 // Return the variables for k1 and k2
 // and sign bit for k2.
 #[allow(clippy::type_complexity)]
-fn scalar_decomposition_gate<F, P, S>(
+fn scalar_decomposition_gate<F, S>(
     circuit: &mut PlonkCircuit<F>,
     s_var: &Variable,
 ) -> Result<(Variable, Variable, BoolVar), CircuitError>
 where
     F: PrimeField,
-    P: TECurveConfig<BaseField = F, ScalarField = S>,
+    // P: TECurveConfig<BaseField = F, ScalarField = S>,
     S: PrimeField,
 {
     // the order of scalar field
@@ -572,7 +573,10 @@ fn get_bits(a: &[bool]) -> u16 {
 mod tests {
     use super::*;
     use crate::{errors::CircuitError, gadgets::ecc::Point, Circuit, PlonkCircuit};
-    use ark_ec::twisted_edwards::{Affine, TECurveConfig as Config};
+    use ark_ec::{
+        twisted_edwards::{Affine, TECurveConfig as Config},
+        CurveConfig,
+    };
     use ark_ed_on_bls12_381_bandersnatch::{EdwardsAffine, EdwardsConfig, Fq, Fr};
     use ark_ff::{BigInteger, MontFp, One, PrimeField, UniformRand};
     use jf_utils::{field_switching, fr_to_fq, test_rng};
@@ -697,9 +701,11 @@ mod tests {
 
             let mut circuit: PlonkCircuit<Fq> = PlonkCircuit::new_ultra_plonk(16);
             let scalar_var = circuit.create_variable(field_switching(&scalar)).unwrap();
-            let (k1_var, k2_var, k2_sign_var) =
-                scalar_decomposition_gate::<_, EdwardsConfig, _>(&mut circuit, &scalar_var)
-                    .unwrap();
+            let (k1_var, k2_var, k2_sign_var) = scalar_decomposition_gate::<
+                <EdwardsConfig as CurveConfig>::BaseField,
+                <EdwardsConfig as CurveConfig>::ScalarField,
+            >(&mut circuit, &scalar_var)
+            .unwrap();
 
             let k1_rec = circuit.witness(k1_var).unwrap();
             assert_eq!(field_switching::<_, Fq>(&k1), k1_rec);

--- a/relation/src/gadgets/ecc/glv.rs
+++ b/relation/src/gadgets/ecc/glv.rs
@@ -271,7 +271,6 @@ fn scalar_decomposition_gate<F, S>(
 ) -> Result<(Variable, Variable, BoolVar), CircuitError>
 where
     F: PrimeField,
-    // P: TECurveConfig<BaseField = F, ScalarField = S>,
     S: PrimeField,
 {
     // the order of scalar field

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+anyhow = "1.0"
 ark-ec = { version = "0.4.0", default-features = false }
 ark-ff = { version = "0.4.0", default-features = false, features = [ "asm" ] }
 ark-serialize = { version = "0.4.0", default-features = false }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -8,7 +8,6 @@ license = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
 ark-ec = { version = "0.4.0", default-features = false }
 ark-ff = { version = "0.4.0", default-features = false, features = [ "asm" ] }
 ark-serialize = { version = "0.4.0", default-features = false }

--- a/utilities/src/conversion.rs
+++ b/utilities/src/conversion.rs
@@ -138,7 +138,11 @@ where
                 primefield_elems.push(F::BasePrimeField::ZERO);
             }
         }
-        result.push(F::from_base_prime_field_elems(&primefield_elems).unwrap_or_else(|| panic!("from_base_prime_field_elems should return Some, elems len {} should equal extension degree {}", primefield_elems.len(), extension_degree)));
+        assert_eq!(primefield_elems.len(), extension_degree);
+        result.push(
+            F::from_base_prime_field_elems(&primefield_elems)
+                .expect("from_base_prime_field_elems should return Some"),
+        );
     }
     assert_eq!(result.len(), result_len);
     result


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- `bytes_from_field_elements` error type is `String`, which does not implement the `Error` trait. Instead, make it infallible. Because it's infallible we need paranoid checks for overflow.
- Improve tests for `bytes_[to|from]_field_elements`.
- Minor quality-of-life improvement for downstream error handling: `PCSError` does not implement the `Error` trait -> implement it
- Appease clippy way over in `glv.rs`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
