### PR TITLE
remove crypto_box and support choosing curve25519 backend using rustflags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check no_std support and WASM compilation
         env:
-          RUSTFLAGS: '-C target-cpu=generic --cfg curve25519_dalek_backend="u32_backend"'
+          RUSTFLAGS: '-C target-cpu=generic --cfg curve25519_dalek_backend="u32"'
         run: |
           cargo check --no-default-features
           cargo build --target wasm32-unknown-unknown --no-default-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check no_std support and WASM compilation
         env:
-          RUSTFLAGS: -C target-cpu=generic
+          RUSTFLAGS: '-C target-cpu=generic --cfg curve25519_dalek_backend="u32_backend"'
         run: |
           cargo check --no-default-features
           cargo build --target wasm32-unknown-unknown --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 
 ### Breaking Changes
 
+- [#270](https://github.com/EspressoSystems/jellyfish/pull/270) (`jf-primitives`) Major refactoring on AEAD internals.
+  - Switch from `crypto_box` to `chacha20poly1305` (with `crypto_kx` to establish shared secret) for AEAD.
+  - Supports `--cfg curve25519_dalek_backend="u32_backend"` RUSTFLAGS to select Curve25519 backend.
+  - Remove `Canonical(De)Serialize` on AEAD-related structs, and directly expose `serde::(De)Serialize` instead.
+
 ### Fixed
 
 - [#243](https://github.com/EspressoSystems/jellyfish/pull/243) fixes bug in MerkleTreeGadget implementation for SparseRescueMerkleTree.
@@ -26,7 +31,6 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 
 - [#238](https://github.com/EspressoSystems/jellyfish/pull/238) add public keys into signature aggregation APIs
 - [#251](https://github.com/EspressoSystems/jellyfish/pull/251) add sign_key_ref api for BLSKeyPair
-
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ Jellyfish is `no_std` compliant and compilable to WASM target environment, just 
 ./scripts/build_wasm.sh
 ```
 
+### Backends
+
+To choose different backends for arithemtics of `curve25519-dalek`, which is currently
+used by `jf-primitives/aead`, set the environment variable:
+
+```
+RUSTFLAGS='--cfg curve25519_dalek_backend="BACKEND"'
+```
+
+See the full list of backend options [here](https://github.com/dalek-cryptography/curve25519-dalek#backends).
+
+You could further configure the word size for the backend by setting (see [here](https://github.com/dalek-cryptography/curve25519-dalek#word-size-for-serial-backends)):
+
+```
+RUSTFLAGS='--cfg curve25519_dalek_bits="SIZE"'
+```
+
 ### Tests
 
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
             export CFLAGS="-mcpu=generic"
 
             # by default choose u64_backend
-            export RUSTFLAGS='--cfg curve25519_dalek_backend="u64_backend"'
+            export RUSTFLAGS='--cfg curve25519_dalek_backend="u64"'
           ''
           # install pre-commit hooks
           + self.check.${system}.pre-commit-check.shellHook;

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,9 @@
             export CC="${clang-tools_15.clang}/bin/clang"
             export AR="${llvm_15}/bin/llvm-ar"
             export CFLAGS="-mcpu=generic"
+
+            # by default choose u64_backend
+            export RUSTFLAGS='--cfg curve25519_dalek_backend="u64_backend"'
           ''
           # install pre-commit hooks
           + self.check.${system}.pre-commit-check.shellHook;

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,8 @@ ark-poly = "0.4.0"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }
 blst = { git = "https://github.com/EspressoSystems/blst.git", branch = "no-std", default-features = false } # TODO: pin to a tag or commit
-crypto_box = { version = "=0.9.0-rc.0", default-features = false, features = ["alloc", "chacha20", "rand_core"] }
+chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["alloc", "rand_core"] }
+crypto_kx = { version = "=0.2.0-pre.0", features = ["serde"] }
 derivative = { version = "2", features = ["use_core"] }
 digest = { version = "0.10.1", default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
@@ -35,7 +36,6 @@ merlin = { version = "3.0.0", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
-rand_core = "0.6.4" # pin to this version where `trait CryptoRngCore` is available which crypto_box depends on
 rayon = { version = "1.5.0", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10.1", default-features = false }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ ark-poly = "0.4.0"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }
 blst = { git = "https://github.com/EspressoSystems/blst.git", branch = "no-std", default-features = false } # TODO: pin to a tag or commit
-crypto_box = { version = "0.8.1", default-features = false, features = ["alloc", "u32_backend"] }
+crypto_box = { version = "=0.9.0-rc.0", default-features = false, features = ["alloc", "chacha20", "rand_core"] }
 derivative = { version = "2", features = ["use_core"] }
 digest = { version = "0.10.1", default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
@@ -35,6 +35,7 @@ merlin = { version = "3.0.0", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
+rand_core = "0.6.4" # pin to this version where `trait CryptoRngCore` is available which crypto_box depends on
 rayon = { version = "1.5.0", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10.1", default-features = false }

--- a/primitives/src/aead.rs
+++ b/primitives/src/aead.rs
@@ -144,7 +144,7 @@ impl From<[u8; 32]> for DecKey {
 }
 impl From<DecKey> for [u8; 32] {
     fn from(dec_key: DecKey) -> Self {
-        *dec_key.0.as_bytes()
+        dec_key.0.to_bytes()
     }
 }
 
@@ -159,7 +159,7 @@ impl CanonicalSerialize for DecKey {
     where
         W: Write,
     {
-        CanonicalSerialize::serialize_compressed(self.0.as_bytes().as_ref(), w)
+        CanonicalSerialize::serialize_compressed(self.0.to_bytes().as_ref(), w)
     }
     fn serialized_size(&self, _compress: Compress) -> usize {
         crypto_box::KEY_SIZE
@@ -416,7 +416,7 @@ mod test {
             .serialize_compressed(&mut dec_key_bytes)
             .unwrap();
         let dec_key_de = DecKey::deserialize_compressed(&dec_key_bytes[..]).unwrap();
-        assert_eq!(dec_key_de.0.as_bytes(), keypair.dec_key.0.as_bytes());
+        assert_eq!(dec_key_de.0.to_bytes(), keypair.dec_key.0.to_bytes());
         // wrong byte length
         assert!(DecKey::deserialize_compressed(&dec_key_bytes[1..]).is_err());
 

--- a/primitives/src/aead.rs
+++ b/primitives/src/aead.rs
@@ -4,98 +4,58 @@
 // You should have received a copy of the MIT License
 // along with the Jellyfish library. If not, see <https://mit-license.org/>.
 
-//! Wraps crypto_box's AEAD encryption scheme.
+//! Use `crypto_kx` to derive shared session secrets and use symmetric AEAD
+//! (`xchacha20poly1305`) for authenticated encryption with associated data.
+//!
+//! We only provide an ultra-thin wrapper for stable APIs for jellyfish users,
+//! independent of RustCrypto's upstream changes.
 
 use crate::errors::PrimitivesError;
-use ark_serialize::{
-    CanonicalDeserialize, CanonicalSerialize, Compress, Read, SerializationError, Valid, Validate,
-    Write,
-};
 use ark_std::{
-    format,
+    fmt, format,
+    ops::{Deref, DerefMut},
     rand::{CryptoRng, RngCore},
-    vec,
     vec::Vec,
 };
-use crypto_box::{
-    aead::{Aead, AeadCore, Nonce, Payload},
-    ChaChaBox,
+use chacha20poly1305::{
+    aead::{Aead, AeadCore, Payload},
+    KeyInit, XChaCha20Poly1305, XNonce,
 };
-use generic_array::{typenum::U24, GenericArray};
+use serde::{Deserialize, Deserializer, Serialize};
 
-#[derive(Clone, Debug, Eq, Derivative)]
+#[derive(Clone, Eq, Derivative, Serialize, Deserialize)]
 #[derivative(PartialEq, Hash)]
 /// Public/encryption key for AEAD
-pub struct EncKey(crypto_box::PublicKey);
+pub struct EncKey(crypto_kx::PublicKey);
 
 impl From<[u8; 32]> for EncKey {
     fn from(bytes: [u8; 32]) -> Self {
-        Self(crypto_box::PublicKey::from(bytes))
+        Self(crypto_kx::PublicKey::from(bytes))
     }
 }
 impl From<EncKey> for [u8; 32] {
     fn from(enc_key: EncKey) -> Self {
-        *enc_key.0.as_bytes()
+        *enc_key.0.as_ref()
     }
 }
-impl From<&DecKey> for EncKey {
-    fn from(dec_key: &DecKey) -> Self {
-        let enc_key = crypto_box::PublicKey::from(&dec_key.0);
+impl From<DecKey> for EncKey {
+    fn from(dec_key: DecKey) -> Self {
+        let enc_key = *crypto_kx::Keypair::from(dec_key.0).public();
         Self(enc_key)
     }
 }
 impl Default for EncKey {
     fn default() -> Self {
-        Self(crypto_box::PublicKey::from([0u8; crypto_box::KEY_SIZE]))
+        Self(crypto_kx::PublicKey::from(
+            [0u8; crypto_kx::PublicKey::BYTES],
+        ))
     }
 }
-
-impl CanonicalSerialize for EncKey {
-    /// Serializes the public key. Only compressed form is supported.
-    /// TODO (tessico): should we fail if user asks for uncompressed form?
-    fn serialize_with_mode<W>(&self, w: W, _compress: Compress) -> Result<(), SerializationError>
-    where
-        W: Write,
-    {
-        CanonicalSerialize::serialize_compressed(self.0.as_ref(), w)
-    }
-    fn serialized_size(&self, _compress: Compress) -> usize {
-        crypto_box::KEY_SIZE
-    }
-}
-
-impl CanonicalDeserialize for EncKey {
-    /// Currently no checking is done on the public key. This is unimplemented
-    /// upstream, see <https://github.com/RustCrypto/nacl-compat/blob/b57fb37eb558132546131d1ca2b59615d8aa3c72/crypto_box/src/lib.rs#L338>
-    fn deserialize_with_mode<R>(
-        mut reader: R,
-        _compress: Compress,
-        validate: Validate,
-    ) -> Result<Self, SerializationError>
-    where
-        R: Read,
-    {
-        let len = u64::deserialize_compressed_unchecked(&mut reader)?;
-        if len != crypto_box::KEY_SIZE as u64 {
-            return Err(SerializationError::InvalidData);
-        }
-
-        let mut key = [0u8; crypto_box::KEY_SIZE];
-        reader.read_exact(&mut key)?;
-        let enc_key = Self(crypto_box::PublicKey::from(key));
-        if validate == Validate::Yes {
-            // TODO (tessico): Currently this is a no-op. Should we fail if user asks to
-            // validate?
-            enc_key.check()?;
-        }
-
-        Ok(enc_key)
-    }
-}
-
-impl Valid for EncKey {
-    fn check(&self) -> Result<(), SerializationError> {
-        Ok(())
+impl fmt::Debug for EncKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("aead::EncKey")
+            .field(self.0.as_ref())
+            .finish()
     }
 }
 
@@ -112,34 +72,36 @@ impl EncKey {
         message: &[u8],
         aad: &[u8],
     ) -> Result<Ciphertext, PrimitivesError> {
-        let nonce = ChaChaBox::generate_nonce(&mut rng);
-
         // generate an ephemeral key pair as the virtual sender to derive the crypto box
-        let ephemeral_sk = crypto_box::SecretKey::generate(&mut rng);
-        let ephemeral_pk = EncKey(crypto_box::PublicKey::from(&ephemeral_sk));
-        let my_box = ChaChaBox::new(&self.0, &ephemeral_sk);
+        let ephemeral_keypair = crypto_kx::Keypair::generate(&mut rng);
+        // `crypto_kx` generates a pair of shared secrets, see <https://libsodium.gitbook.io/doc/key_exchange>
+        // we use the transimission key of the ephemeral sender (equals to the receiving
+        // key of the server) as the shared secret.
+        let shared_secret = ephemeral_keypair.session_keys_to(&self.0).tx;
+        let cipher = XChaCha20Poly1305::new(shared_secret.as_ref().into());
+        let nonce = XChaCha20Poly1305::generate_nonce(&mut rng);
 
         // encrypt the message and associated data using crypto box
-        let ct = my_box
+        let ct = cipher
             .encrypt(&nonce, Payload { msg: message, aad })
             .map_err(|e| PrimitivesError::InternalError(format!("{e:?}")))?;
 
         Ok(Ciphertext {
-            nonce,
+            nonce: Nonce(nonce),
             ct,
-            ephemeral_pk,
+            ephemeral_pk: EncKey(*ephemeral_keypair.public()),
         })
     }
 }
 
 /// Private/decryption key for AEAD
 // look into zeroization logic from aead lib
-#[derive(Clone, Debug)]
-struct DecKey(crypto_box::SecretKey);
+#[derive(Clone, Serialize, Deserialize)]
+struct DecKey(crypto_kx::SecretKey);
 
 impl From<[u8; 32]> for DecKey {
     fn from(bytes: [u8; 32]) -> Self {
-        Self(crypto_box::SecretKey::from(bytes))
+        Self(crypto_kx::SecretKey::from(bytes))
     }
 }
 impl From<DecKey> for [u8; 32] {
@@ -150,57 +112,19 @@ impl From<DecKey> for [u8; 32] {
 
 impl Default for DecKey {
     fn default() -> Self {
-        Self(crypto_box::SecretKey::from([0; crypto_box::KEY_SIZE]))
+        Self(crypto_kx::SecretKey::from([0; crypto_kx::SecretKey::BYTES]))
     }
 }
-
-impl CanonicalSerialize for DecKey {
-    fn serialize_with_mode<W>(&self, w: W, _compress: Compress) -> Result<(), SerializationError>
-    where
-        W: Write,
-    {
-        CanonicalSerialize::serialize_compressed(self.0.to_bytes().as_ref(), w)
-    }
-    fn serialized_size(&self, _compress: Compress) -> usize {
-        crypto_box::KEY_SIZE
-    }
-}
-
-impl CanonicalDeserialize for DecKey {
-    fn deserialize_with_mode<R>(
-        mut reader: R,
-        _compress: Compress,
-        validate: Validate,
-    ) -> Result<Self, SerializationError>
-    where
-        R: Read,
-    {
-        let len = u64::deserialize_compressed_unchecked(&mut reader)?;
-        if len != crypto_box::KEY_SIZE as u64 {
-            return Err(SerializationError::InvalidData);
-        }
-        let mut k = [0u8; crypto_box::KEY_SIZE];
-        reader.read_exact(&mut k)?;
-        let dec_key = Self(crypto_box::SecretKey::from(k));
-
-        if validate == Validate::Yes {
-            // TODO (tessico): Currently this is a no-op. Should we fail if user asks to
-            // validate?
-            dec_key.check()?;
-        }
-
-        Ok(dec_key)
-    }
-}
-
-impl Valid for DecKey {
-    fn check(&self) -> Result<(), SerializationError> {
-        Ok(())
+impl fmt::Debug for DecKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("aead::DecKey")
+            .field(&self.0.to_bytes())
+            .finish()
     }
 }
 
 /// Keypair for Authenticated Encryption with Associated Data
-#[derive(Clone, Debug, Default, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct KeyPair {
     enc_key: EncKey,
     dec_key: DecKey,
@@ -215,8 +139,7 @@ impl PartialEq for KeyPair {
 impl KeyPair {
     /// Randomly sample a key pair.
     pub fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        let dec_key = crypto_box::SecretKey::generate(rng);
-        let enc_key = crypto_box::PublicKey::from(&dec_key);
+        let (enc_key, dec_key) = crypto_kx::Keypair::generate(rng).split();
         Self {
             enc_key: EncKey(enc_key),
             dec_key: DecKey(dec_key),
@@ -237,8 +160,11 @@ impl KeyPair {
     /// If the associated data is different that that used during encryption,
     /// then decryption will fail.
     pub fn decrypt(&self, ciphertext: &Ciphertext, aad: &[u8]) -> Result<Vec<u8>, PrimitivesError> {
-        let my_box = ChaChaBox::new(&ciphertext.ephemeral_pk.0, &self.dec_key.0);
-        let plaintext = my_box
+        let shared_secret = crypto_kx::Keypair::from(self.dec_key.0.clone())
+            .session_keys_from(&ciphertext.ephemeral_pk.0)
+            .rx;
+        let cipher = XChaCha20Poly1305::new(shared_secret.as_ref().into());
+        let plaintext = cipher
             .decrypt(
                 &ciphertext.nonce,
                 Payload {
@@ -250,80 +176,75 @@ impl KeyPair {
         Ok(plaintext)
     }
 }
+// newtype for `chacha20poly1305::XNonce` for easier serde support for
+// `Ciphertext`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Nonce(XNonce);
+
+impl Serialize for Nonce {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(self.0.as_slice())
+    }
+}
+
+impl<'de> Deserialize<'de> for Nonce {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct NonceVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for NonceVisitor {
+            type Value = Nonce;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("byte array")
+            }
+
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Nonce(*XNonce::from_slice(&v)))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let bytes: Vec<u8> = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(Nonce(*XNonce::from_slice(&bytes)))
+            }
+        }
+
+        deserializer.deserialize_byte_buf(NonceVisitor)
+    }
+}
+
+// Deref for newtype which acts like a smart pointer
+impl Deref for Nonce {
+    type Target = XNonce;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl DerefMut for Nonce {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 /// The ciphertext produced by AEAD encryption
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Ciphertext {
-    nonce: Nonce<ChaChaBox>,
+    nonce: Nonce,
     ct: Vec<u8>,
     ephemeral_pk: EncKey,
-}
-
-impl CanonicalSerialize for Ciphertext {
-    /// Serialize the ciphertext. `Compress` mode is ignored.
-    fn serialize_with_mode<W>(
-        &self,
-        mut writer: W,
-        _compress: Compress,
-    ) -> Result<(), ark_serialize::SerializationError>
-    where
-        W: ark_serialize::Write,
-    {
-        let len = self.nonce.len() as u64;
-        len.serialize_compressed(&mut writer)?;
-        writer.write_all(self.nonce.as_slice())?;
-
-        let len = self.ct.len() as u64;
-        len.serialize_compressed(&mut writer)?;
-        writer.write_all(&self.ct[..])?;
-
-        self.ephemeral_pk.serialize_compressed(&mut writer)
-    }
-    fn serialized_size(&self, compress: Compress) -> usize {
-        core::mem::size_of::<u64>() * 2
-            + self.nonce.len()
-            + self.ct.len()
-            + self.ephemeral_pk.serialized_size(compress)
-    }
-}
-
-impl CanonicalDeserialize for Ciphertext {
-    fn deserialize_with_mode<R>(
-        mut reader: R,
-        _compress: Compress,
-        validate: Validate,
-    ) -> Result<Self, ark_serialize::SerializationError>
-    where
-        R: ark_serialize::Read,
-    {
-        let len = u64::deserialize_uncompressed_unchecked(&mut reader)?;
-        if len != 24 {
-            return Err(SerializationError::InvalidData);
-        }
-        let mut nonce = [0u8; 24];
-        reader.read_exact(&mut nonce)?;
-        let nonce: Nonce<ChaChaBox> = GenericArray::<u8, U24>::clone_from_slice(&nonce);
-
-        let len = u64::deserialize_uncompressed_unchecked(&mut reader)?;
-        let mut ct = vec![0u8; len as usize];
-        reader.read_exact(&mut ct)?;
-
-        // Note: since EncKey validation check is a no-op, it will propagate here and
-        // validation will also be a no-op. Keeping the validation flag for
-        // potential future use when some EncKey validation is implemented.
-        let ephemeral_pk = EncKey::deserialize_with_mode(&mut reader, Compress::Yes, validate)?;
-        Ok(Self {
-            nonce,
-            ct,
-            ephemeral_pk,
-        })
-    }
-}
-
-impl Valid for Ciphertext {
-    fn check(&self) -> Result<(), SerializationError> {
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -364,25 +285,6 @@ mod test {
     }
 
     #[test]
-    fn test_conversion() {
-        let mut rng = jf_utils::test_rng();
-        let mut rand_bytes = [0u8; 32];
-        rng.fill_bytes(&mut rand_bytes[..]);
-        let enc_key = EncKey::from(rand_bytes);
-        let bytes: [u8; 32] = enc_key.into();
-        assert_eq!(bytes, rand_bytes);
-
-        rng.fill_bytes(&mut rand_bytes[..]);
-        let dec_key = DecKey::from(rand_bytes);
-        let bytes: [u8; 32] = dec_key.into();
-        assert_eq!(bytes, rand_bytes);
-
-        let keypair = KeyPair::generate(&mut rng);
-        let enc_key = EncKey::from(&keypair.dec_key);
-        assert_eq!(enc_key, keypair.enc_key());
-    }
-
-    #[test]
     fn test_serde() {
         let mut rng = jf_utils::test_rng();
         let keypair = KeyPair::generate(&mut rng);
@@ -391,43 +293,33 @@ mod test {
         let ciphertext = keypair.enc_key.encrypt(&mut rng, &msg, &aad).unwrap();
 
         // serde for Keypair
-        let mut keypair_bytes = Vec::new();
-        keypair.serialize_compressed(&mut keypair_bytes).unwrap();
-        let keypair_de = KeyPair::deserialize_compressed(&keypair_bytes[..]).unwrap();
-        assert_eq!(keypair, keypair_de);
+        let bytes = bincode::serialize(&keypair).unwrap();
+        assert_eq!(keypair, bincode::deserialize(&bytes).unwrap());
         // wrong byte length
-        assert!(KeyPair::deserialize_compressed(&keypair_bytes[1..]).is_err());
+        assert!(bincode::deserialize::<KeyPair>(&bytes[1..]).is_err());
 
         // serde for EncKey
-        let mut enc_key_bytes = Vec::new();
-        keypair
-            .enc_key
-            .serialize_compressed(&mut enc_key_bytes)
-            .unwrap();
-        let enc_key_de = EncKey::deserialize_compressed(&enc_key_bytes[..]).unwrap();
-        assert_eq!(enc_key_de, keypair.enc_key);
+        let bytes = bincode::serialize(keypair.enc_key_ref()).unwrap();
+        assert_eq!(
+            keypair.enc_key_ref(),
+            &bincode::deserialize(&bytes).unwrap()
+        );
         // wrong byte length
-        assert!(EncKey::deserialize_compressed(&enc_key_bytes[1..]).is_err());
+        assert!(bincode::deserialize::<EncKey>(&bytes[1..]).is_err());
 
         // serde for DecKey
-        let mut dec_key_bytes = Vec::new();
-        keypair
-            .dec_key
-            .serialize_compressed(&mut dec_key_bytes)
-            .unwrap();
-        let dec_key_de = DecKey::deserialize_compressed(&dec_key_bytes[..]).unwrap();
-        assert_eq!(dec_key_de.0.to_bytes(), keypair.dec_key.0.to_bytes());
+        let bytes = bincode::serialize(&keypair.dec_key).unwrap();
+        assert_eq!(
+            keypair.dec_key.0.to_bytes(),
+            bincode::deserialize::<DecKey>(&bytes).unwrap().0.to_bytes()
+        );
         // wrong byte length
-        assert!(DecKey::deserialize_compressed(&dec_key_bytes[1..]).is_err());
+        assert!(bincode::deserialize::<DecKey>(&bytes[1..]).is_err());
 
         // serde for Ciphertext
-        let mut ciphertext_bytes = Vec::new();
-        ciphertext
-            .serialize_compressed(&mut ciphertext_bytes)
-            .unwrap();
-        let ciphertext_de = Ciphertext::deserialize_compressed(&ciphertext_bytes[..]).unwrap();
-        assert_eq!(ciphertext_de, ciphertext);
+        let bytes = bincode::serialize(&ciphertext).unwrap();
+        assert_eq!(&ciphertext, &bincode::deserialize(&bytes).unwrap());
         // wrong byte length
-        assert!(Ciphertext::deserialize_compressed(&ciphertext_bytes[1..]).is_err());
+        assert!(bincode::deserialize::<Ciphertext>(&bytes[1..]).is_err());
     }
 }

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-RUSTFLAGS='-C target-cpu=generic --cfg curve25519_dalek_backend="u32_backend"' cargo build --target wasm32-unknown-unknown --no-default-features
+RUSTFLAGS='-C target-cpu=generic --cfg curve25519_dalek_backend="u32"' cargo build --target wasm32-unknown-unknown --no-default-features

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-RUSTFLAGS="-C target-cpu=generic" cargo build --target wasm32-unknown-unknown --no-default-features
+RUSTFLAGS='-C target-cpu=generic --cfg curve25519_dalek_backend="u32_backend"' cargo build --target wasm32-unknown-unknown --no-default-features


### PR DESCRIPTION
# Description

closes: #258

(see more discussion in https://github.com/RustCrypto/nacl-compat/issues/124)

Changes include:
- switch the underlying AEAD from `crypto_box` to `crypto_kx` + `chacha20poly1305` without changing Jellyfish's own API
  - the latest `crypto_box` no longer supports associated data since it strive to restore compatibility with libsodium
  - we want the latest `crypto_box` because we want to use `--cfg curve25519_dalek_backend="u32_backend"` to select backend instead of feature flag which is additive, (see the linked issue for details)
  - therefore, I decide to move away from it, and just use `crypto_kx` to establish shared secret, and use symmetric AEAD like `xchacha20poly1305` (with extended nonce), see the RustCrypto issue linked above for more details
- Removed `CanonicalSerde` and directly use `serde::Serde` for our structs. (cuz I don't see any benefits of adding the extra layer of indirection here)
- Remove one unit test named `fn test_conversion()`
  - previously, when using `crypto_box`, any random bytes are guaranteed to be converted back and forth into key structs, but now with `crypto_kx::Keypair` which is essentially `curve25519` key pair, there's some canonical formatting, some potential mod modulus operations etc. Thus there's no point to have that unit test any more. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer

cc @pmikolajczyk41