### PR TITLE
feat(api)!: MerkleTreeScheme::verify do not take self, pos

### DIFF
--- a/primitives/benches/merkle_path.rs
+++ b/primitives/benches/merkle_path.rs
@@ -29,7 +29,7 @@ fn twenty_hashes(c: &mut Criterion) {
 
     let num_inputs = 0;
     benchmark_group.bench_with_input(BENCH_NAME, &num_inputs, move |b, &_num_inputs| {
-        b.iter(|| mt.verify(0, &proof).unwrap())
+        b.iter(|| RescueMerkleTree::<Fq381>::verify(0, &proof).unwrap())
     });
     benchmark_group.finish();
 }

--- a/primitives/benches/merkle_path.rs
+++ b/primitives/benches/merkle_path.rs
@@ -10,7 +10,7 @@ extern crate criterion;
 use ark_ed_on_bls12_381::Fq as Fq381;
 use ark_std::rand::Rng;
 use criterion::Criterion;
-use jf_primitives::merkle_tree::{prelude::RescueMerkleTree, MerkleTreeScheme};
+use jf_primitives::merkle_tree::{prelude::RescueMerkleTree, MerkleCommitment, MerkleTreeScheme};
 use std::time::Duration;
 
 const BENCH_NAME: &str = "merkle_path_height_20";
@@ -25,11 +25,12 @@ fn twenty_hashes(c: &mut Criterion) {
     let leaf: Fq381 = rng.gen();
 
     let mt = RescueMerkleTree::<Fq381>::from_elems(20, &[leaf, leaf]).unwrap();
+    let root = mt.commitment().digest();
     let (_, proof) = mt.lookup(0).expect_ok().unwrap();
 
     let num_inputs = 0;
     benchmark_group.bench_with_input(BENCH_NAME, &num_inputs, move |b, &_num_inputs| {
-        b.iter(|| RescueMerkleTree::<Fq381>::verify(&proof).unwrap())
+        b.iter(|| RescueMerkleTree::<Fq381>::verify(&root, &proof).unwrap())
     });
     benchmark_group.finish();
 }

--- a/primitives/benches/merkle_path.rs
+++ b/primitives/benches/merkle_path.rs
@@ -29,7 +29,7 @@ fn twenty_hashes(c: &mut Criterion) {
 
     let num_inputs = 0;
     benchmark_group.bench_with_input(BENCH_NAME, &num_inputs, move |b, &_num_inputs| {
-        b.iter(|| RescueMerkleTree::<Fq381>::verify(0, &proof).unwrap())
+        b.iter(|| RescueMerkleTree::<Fq381>::verify(&proof).unwrap())
     });
     benchmark_group.finish();
 }

--- a/primitives/src/errors.rs
+++ b/primitives/src/errors.rs
@@ -15,10 +15,17 @@ use ark_std::{
 use blst::BLST_ERROR;
 use displaydoc::Display;
 
+/// A glorified [`bool`] that leverages compile lints to encourage the caller to
+/// use the result.
+///
+/// Intended as the return type for verification of proofs, signatures, etc.
+/// Recommended for use in the nested [`Result`] pattern: see <https://sled.rs/errors>.
+pub type VerificationResult = Result<(), ()>;
+
 /// A `enum` specifying the possible failure modes of the primitives.
 #[derive(Debug, Display)]
 pub enum PrimitivesError {
-    /// Unsuccessful verification for proof or signature, {0}
+    /// Verify fail (proof, sig), {0} [DEPRACATED: use [`VerificationResult`]]
     VerificationError(String),
     /// Bad parameter in function call, {0}
     ParameterError(String),

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -122,7 +122,7 @@ mod mt_tests {
         let (elem, proof) = mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueMerkleTree::<F>::verify(0u64, &proof).unwrap());
+        assert!(RescueMerkleTree::<F>::verify(&proof).unwrap());
 
         let mut bad_proof = proof.clone();
         if let MerkleNode::Leaf {
@@ -136,7 +136,7 @@ mod mt_tests {
             unreachable!()
         }
 
-        let result = RescueMerkleTree::<F>::verify(0u64, &bad_proof);
+        let result = RescueMerkleTree::<F>::verify(&bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
@@ -151,7 +151,7 @@ mod mt_tests {
         } else {
             unreachable!()
         }
-        let result = RescueMerkleTree::<F>::verify(2u64, &forge_proof);
+        let result = RescueMerkleTree::<F>::verify(&forge_proof);
         assert!(result.is_ok());
         assert!(!result.unwrap());
     }
@@ -171,8 +171,8 @@ mod mt_tests {
         assert_eq!(lookup_proof, proof);
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueMerkleTree::<F>::verify(0, &lookup_proof).unwrap());
-        assert!(RescueMerkleTree::<F>::verify(0, &proof).unwrap());
+        assert!(RescueMerkleTree::<F>::verify(&lookup_proof).unwrap());
+        assert!(RescueMerkleTree::<F>::verify(&proof).unwrap());
 
         assert!(mt.forget(0).expect_ok().is_err());
         assert!(matches!(mt.lookup(0), LookupResult::NotInMemory));

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -122,7 +122,7 @@ mod mt_tests {
         let (elem, proof) = mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(mt.verify(0u64, &proof).unwrap());
+        assert!(RescueMerkleTree::<F>::verify(0u64, &proof).unwrap());
 
         let mut bad_proof = proof.clone();
         if let MerkleNode::Leaf {
@@ -136,7 +136,7 @@ mod mt_tests {
             unreachable!()
         }
 
-        let result = mt.verify(0u64, &bad_proof);
+        let result = RescueMerkleTree::<F>::verify(0u64, &bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
@@ -151,7 +151,7 @@ mod mt_tests {
         } else {
             unreachable!()
         }
-        let result = mt.verify(2u64, &forge_proof);
+        let result = RescueMerkleTree::<F>::verify(2u64, &forge_proof);
         assert!(result.is_ok());
         assert!(!result.unwrap());
     }
@@ -171,8 +171,8 @@ mod mt_tests {
         assert_eq!(lookup_proof, proof);
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(mt.verify(0, &lookup_proof).unwrap());
-        assert!(mt.verify(0, &proof).unwrap());
+        assert!(RescueMerkleTree::<F>::verify(0, &lookup_proof).unwrap());
+        assert!(RescueMerkleTree::<F>::verify(0, &proof).unwrap());
 
         assert!(mt.forget(0).expect_ok().is_err());
         assert!(matches!(mt.lookup(0), LookupResult::NotInMemory));

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -13,7 +13,10 @@ use super::{
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
     LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
 };
-use crate::{errors::PrimitivesError, impl_forgetable_merkle_tree_scheme, impl_merkle_tree_scheme};
+use crate::{
+    errors::{PrimitivesError, VerificationResult},
+    impl_forgetable_merkle_tree_scheme, impl_merkle_tree_scheme,
+};
 use ark_std::{
     borrow::Borrow, boxed::Box, fmt::Debug, marker::PhantomData, string::ToString, vec, vec::Vec,
 };
@@ -123,7 +126,9 @@ mod mt_tests {
         let (elem, proof) = mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueMerkleTree::<F>::verify(&root, &proof).unwrap());
+        assert!(RescueMerkleTree::<F>::verify(&root, &proof)
+            .unwrap()
+            .is_ok());
 
         let mut bad_proof = proof.clone();
         if let MerkleNode::Leaf {
@@ -138,7 +143,7 @@ mod mt_tests {
         }
 
         let result = RescueMerkleTree::<F>::verify(&root, &bad_proof);
-        assert!(result.is_ok() && !result.unwrap());
+        assert!(result.unwrap().is_err());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof);
         if let MerkleNode::Leaf {
@@ -153,8 +158,7 @@ mod mt_tests {
             unreachable!()
         }
         let result = RescueMerkleTree::<F>::verify(&root, &forge_proof);
-        assert!(result.is_ok());
-        assert!(!result.unwrap());
+        assert!(result.unwrap().is_err());
     }
 
     #[test]
@@ -173,8 +177,12 @@ mod mt_tests {
         assert_eq!(lookup_proof, proof);
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueMerkleTree::<F>::verify(&root, &lookup_proof).unwrap());
-        assert!(RescueMerkleTree::<F>::verify(&root, &proof).unwrap());
+        assert!(RescueMerkleTree::<F>::verify(&root, &lookup_proof)
+            .unwrap()
+            .is_ok());
+        assert!(RescueMerkleTree::<F>::verify(&root, &proof)
+            .unwrap()
+            .is_ok());
 
         assert!(mt.forget(0).expect_ok().is_err());
         assert!(matches!(mt.lookup(0), LookupResult::NotInMemory));

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -140,7 +140,7 @@ mod mt_tests {
         let result = RescueMerkleTree::<F>::verify(&root, &bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
-        let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
+        let mut forge_proof = MerkleProof::new(2, proof.proof);
         if let MerkleNode::Leaf {
             value: _,
             pos,
@@ -194,7 +194,7 @@ mod mt_tests {
         let result = mt.remember(0u64, elem, &bad_proof);
         assert!(result.is_err());
 
-        let mut forge_proof = MerkleProof::new(2, proof.proof.clone(), mt.root.value());
+        let mut forge_proof = MerkleProof::new(2, proof.proof.clone());
         if let MerkleNode::Leaf {
             value: _,
             pos,

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -139,7 +139,7 @@ mod mt_tests {
         let result = mt.verify(0u64, &bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
-        let mut forge_proof = MerkleProof::new(2, proof.proof);
+        let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
         if let MerkleNode::Leaf {
             value: _,
             pos,
@@ -192,7 +192,7 @@ mod mt_tests {
         let result = mt.remember(0u64, elem, &bad_proof);
         assert!(result.is_err());
 
-        let mut forge_proof = MerkleProof::new(2, proof.proof.clone());
+        let mut forge_proof = MerkleProof::new(2, proof.proof.clone(), mt.root.value());
         if let MerkleNode::Leaf {
             value: _,
             pos,

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -137,9 +137,6 @@ where
     pub pos: I,
     /// Nodes of proof path, from root to leaf
     pub proof: MerklePath<E, I, T>,
-    /// Root
-    #[serde(with = "canonical")]
-    pub root: T,
 
     /// Place holder for Arity
     _phantom_arity: PhantomData<Arity>,
@@ -156,11 +153,10 @@ where
         self.proof.len()
     }
 
-    pub fn new(pos: I, proof: MerklePath<E, I, T>, root: T) -> Self {
+    pub fn new(pos: I, proof: MerklePath<E, I, T>) -> Self {
         MerkleProof {
             pos,
             proof,
-            root,
             _phantom_arity: PhantomData,
         }
     }

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -9,7 +9,7 @@ use core::{marker::PhantomData, ops::AddAssign};
 use super::{
     DigestAlgorithm, Element, Index, LookupResult, MerkleCommitment, NodeValue, ToTraversalPath,
 };
-use crate::errors::PrimitivesError;
+use crate::errors::{PrimitivesError, VerificationResult};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
     borrow::Borrow, boxed::Box, format, iter::Peekable, string::ToString, vec, vec::Vec,
@@ -812,7 +812,7 @@ where
     pub(crate) fn verify_membership_proof<H>(
         &self,
         expected_root: &T,
-    ) -> Result<bool, PrimitivesError>
+    ) -> Result<VerificationResult, PrimitivesError>
     where
         H: DigestAlgorithm<E, I, T>,
         Arity: Unsigned,
@@ -848,7 +848,11 @@ where
                         }
                     },
                 )?;
-            Ok(computed_root == *expected_root)
+            if computed_root == *expected_root {
+                Ok(Ok(()))
+            } else {
+                Ok(Err(()))
+            }
         } else {
             Err(PrimitivesError::ParameterError(
                 "Invalid proof type".to_string(),

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -137,6 +137,9 @@ where
     pub pos: I,
     /// Nodes of proof path, from root to leaf
     pub proof: MerklePath<E, I, T>,
+    /// Root
+    #[serde(with = "canonical")]
+    pub root: T,
 
     /// Place holder for Arity
     _phantom_arity: PhantomData<Arity>,
@@ -153,10 +156,11 @@ where
         self.proof.len()
     }
 
-    pub fn new(pos: I, proof: MerklePath<E, I, T>) -> Self {
+    pub fn new(pos: I, proof: MerklePath<E, I, T>, root: T) -> Self {
         MerkleProof {
             pos,
             proof,
+            root,
             _phantom_arity: PhantomData,
         }
     }

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -14,7 +14,10 @@ use super::{
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
     LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
 };
-use crate::{errors::PrimitivesError, impl_forgetable_merkle_tree_scheme, impl_merkle_tree_scheme};
+use crate::{
+    errors::{PrimitivesError, VerificationResult},
+    impl_forgetable_merkle_tree_scheme, impl_merkle_tree_scheme,
+};
 use ark_std::{
     borrow::Borrow, boxed::Box, fmt::Debug, marker::PhantomData, string::ToString, vec, vec::Vec,
 };
@@ -135,7 +138,11 @@ mod mt_tests {
         let (elem, proof) = mock_mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), &proof).unwrap());
+        assert!(
+            RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), &proof)
+                .unwrap()
+                .is_ok()
+        );
 
         let mut bad_proof = proof.clone();
         if let MerkleNode::Leaf {
@@ -150,7 +157,7 @@ mod mt_tests {
         }
 
         let result = RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), &bad_proof);
-        assert!(result.is_ok() && !result.unwrap());
+        assert!(result.unwrap().is_err());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof);
         if let MerkleNode::Leaf {
@@ -165,8 +172,7 @@ mod mt_tests {
             unreachable!()
         }
         let result = RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), &forge_proof);
-        assert!(result.is_ok());
-        assert!(!result.unwrap());
+        assert!(result.unwrap().is_err());
     }
 
     #[test]

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -152,7 +152,7 @@ mod mt_tests {
         let result = mt.verify(0u64, &bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
-        let mut forge_proof = MerkleProof::new(2, proof.proof);
+        let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
         if let MerkleNode::Leaf {
             value: _,
             pos,

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -135,7 +135,7 @@ mod mt_tests {
         let (elem, proof) = mock_mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueLightWeightMerkleTree::<F>::verify(0u64, &proof).unwrap());
+        assert!(RescueLightWeightMerkleTree::<F>::verify(&proof).unwrap());
 
         let mut bad_proof = proof.clone();
         if let MerkleNode::Leaf {
@@ -149,7 +149,7 @@ mod mt_tests {
             unreachable!()
         }
 
-        let result = RescueLightWeightMerkleTree::<F>::verify(0u64, &bad_proof);
+        let result = RescueLightWeightMerkleTree::<F>::verify(&bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
@@ -164,7 +164,7 @@ mod mt_tests {
         } else {
             unreachable!()
         }
-        let result = RescueLightWeightMerkleTree::<F>::verify(2u64, &forge_proof);
+        let result = RescueLightWeightMerkleTree::<F>::verify(&forge_proof);
         assert!(result.is_ok());
         assert!(!result.unwrap());
     }

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -135,7 +135,7 @@ mod mt_tests {
         let (elem, proof) = mock_mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(mt.verify(0u64, &proof).unwrap());
+        assert!(RescueLightWeightMerkleTree::<F>::verify(0u64, &proof).unwrap());
 
         let mut bad_proof = proof.clone();
         if let MerkleNode::Leaf {
@@ -149,7 +149,7 @@ mod mt_tests {
             unreachable!()
         }
 
-        let result = mt.verify(0u64, &bad_proof);
+        let result = RescueLightWeightMerkleTree::<F>::verify(0u64, &bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
@@ -164,7 +164,7 @@ mod mt_tests {
         } else {
             unreachable!()
         }
-        let result = mt.verify(2u64, &forge_proof);
+        let result = RescueLightWeightMerkleTree::<F>::verify(2u64, &forge_proof);
         assert!(result.is_ok());
         assert!(!result.unwrap());
     }

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -152,7 +152,7 @@ mod mt_tests {
         let result = RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), &bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
-        let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
+        let mut forge_proof = MerkleProof::new(2, proof.proof);
         if let MerkleNode::Leaf {
             value: _,
             pos,

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -135,7 +135,7 @@ mod mt_tests {
         let (elem, proof) = mock_mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueLightWeightMerkleTree::<F>::verify(&proof).unwrap());
+        assert!(RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), &proof).unwrap());
 
         let mut bad_proof = proof.clone();
         if let MerkleNode::Leaf {
@@ -149,7 +149,7 @@ mod mt_tests {
             unreachable!()
         }
 
-        let result = RescueLightWeightMerkleTree::<F>::verify(&bad_proof);
+        let result = RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), &bad_proof);
         assert!(result.is_ok() && !result.unwrap());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof, mt.root.value());
@@ -164,7 +164,7 @@ mod mt_tests {
         } else {
             unreachable!()
         }
-        let result = RescueLightWeightMerkleTree::<F>::verify(&forge_proof);
+        let result = RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), &forge_proof);
         assert!(result.is_ok());
         assert!(!result.unwrap());
     }

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -88,7 +88,7 @@ macro_rules! impl_merkle_tree_scheme {
                 let traversal_path = pos.to_traversal_path(self.height);
                 match self.root.lookup_internal(self.height, &traversal_path) {
                     LookupResult::Ok(value, proof) => {
-                        LookupResult::Ok(value, MerkleProof::new(pos.clone(), proof, self.root.value()))
+                        LookupResult::Ok(value, MerkleProof::new(pos.clone(), proof))
                     },
                     LookupResult::NotInMemory => LookupResult::NotInMemory,
                     LookupResult::NotFound(_) => LookupResult::NotFound(()),
@@ -137,7 +137,7 @@ macro_rules! impl_forgetable_merkle_tree_scheme {
                 let traversal_path = pos.to_traversal_path(self.height);
                 match self.root.forget_internal(self.height, &traversal_path) {
                     LookupResult::Ok(elem, proof) => {
-                        LookupResult::Ok(elem, MerkleProof::new(pos, proof, self.root.value()))
+                        LookupResult::Ok(elem, MerkleProof::new(pos, proof))
                     },
                     LookupResult::NotInMemory => LookupResult::NotInMemory,
                     LookupResult::NotFound(_) => LookupResult::NotFound(()),

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -96,23 +96,17 @@ macro_rules! impl_merkle_tree_scheme {
             }
 
             fn verify(
-                &self,
                 pos: impl Borrow<Self::Index>,
                 proof: impl Borrow<Self::MembershipProof>,
             ) -> Result<bool, PrimitivesError> {
                 let pos = pos.borrow();
                 let proof = proof.borrow();
-                if self.height != proof.tree_height() - 1 {
-                    return Err(PrimitivesError::ParameterError(
-                        "Incompatible membership proof for this merkle tree".to_string(),
-                    ));
-                }
                 if *pos != proof.pos {
                     return Err(PrimitivesError::ParameterError(
                         "Inconsistent proof index".to_string(),
                     ));
                 }
-                proof.verify_membership_proof::<H>(&self.root.value())
+                proof.verify_membership_proof::<H>(&proof.root)
             }
         }
     };

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -98,7 +98,7 @@ macro_rules! impl_merkle_tree_scheme {
             fn verify(
                 root: impl Borrow<Self::NodeValue>,
                 proof: impl Borrow<Self::MembershipProof>,
-            ) -> Result<bool, PrimitivesError> {
+            ) -> Result<VerificationResult, PrimitivesError> {
                 proof.borrow().verify_membership_proof::<H>(root.borrow())
             }
         }

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -96,16 +96,9 @@ macro_rules! impl_merkle_tree_scheme {
             }
 
             fn verify(
-                pos: impl Borrow<Self::Index>,
                 proof: impl Borrow<Self::MembershipProof>,
             ) -> Result<bool, PrimitivesError> {
-                let pos = pos.borrow();
                 let proof = proof.borrow();
-                if *pos != proof.pos {
-                    return Err(PrimitivesError::ParameterError(
-                        "Inconsistent proof index".to_string(),
-                    ));
-                }
                 proof.verify_membership_proof::<H>(&proof.root)
             }
         }

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -88,7 +88,7 @@ macro_rules! impl_merkle_tree_scheme {
                 let traversal_path = pos.to_traversal_path(self.height);
                 match self.root.lookup_internal(self.height, &traversal_path) {
                     LookupResult::Ok(value, proof) => {
-                        LookupResult::Ok(value, MerkleProof::new(pos.clone(), proof))
+                        LookupResult::Ok(value, MerkleProof::new(pos.clone(), proof, self.root.value()))
                     },
                     LookupResult::NotInMemory => LookupResult::NotInMemory,
                     LookupResult::NotFound(_) => LookupResult::NotFound(()),
@@ -150,7 +150,7 @@ macro_rules! impl_forgetable_merkle_tree_scheme {
                 let traversal_path = pos.to_traversal_path(self.height);
                 match self.root.forget_internal(self.height, &traversal_path) {
                     LookupResult::Ok(elem, proof) => {
-                        LookupResult::Ok(elem, MerkleProof::new(pos, proof))
+                        LookupResult::Ok(elem, MerkleProof::new(pos, proof, self.root.value()))
                     },
                     LookupResult::NotInMemory => LookupResult::NotInMemory,
                     LookupResult::NotFound(_) => LookupResult::NotFound(()),

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -96,10 +96,10 @@ macro_rules! impl_merkle_tree_scheme {
             }
 
             fn verify(
+                root: impl Borrow<Self::NodeValue>,
                 proof: impl Borrow<Self::MembershipProof>,
             ) -> Result<bool, PrimitivesError> {
-                let proof = proof.borrow();
-                proof.verify_membership_proof::<H>(&proof.root)
+                proof.borrow().verify_membership_proof::<H>(root.borrow())
             }
         }
     };

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -220,14 +220,10 @@ pub trait MerkleTreeScheme: Sized {
     ) -> LookupResult<Self::Element, Self::MembershipProof, ()>;
 
     /// Verify an element is a leaf of a Merkle tree given the proof
-    /// * `pos` - zero-based index of the leaf in the tree
     /// * `proof` - a merkle tree proof
     /// * `returns` - Ok(true) if the proof is accepted, Ok(false) if not. Err()
     ///   if the proof is not well structured, E.g. not for this merkle tree.
-    fn verify(
-        pos: impl Borrow<Self::Index>,
-        proof: impl Borrow<Self::MembershipProof>,
-    ) -> Result<bool, PrimitivesError>;
+    fn verify(proof: impl Borrow<Self::MembershipProof>) -> Result<bool, PrimitivesError>;
 
     // fn batch_lookup(&self, pos: impl Iterator<Item = usize>) -> LookupResult<(),
     // Self::BatchProof>; fn batch_verify(

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -220,10 +220,15 @@ pub trait MerkleTreeScheme: Sized {
     ) -> LookupResult<Self::Element, Self::MembershipProof, ()>;
 
     /// Verify an element is a leaf of a Merkle tree given the proof
+    /// * `root` - a merkle tree root, usually obtained from
+    ///   `Self::commitment().digest()`
     /// * `proof` - a merkle tree proof
     /// * `returns` - Ok(true) if the proof is accepted, Ok(false) if not. Err()
     ///   if the proof is not well structured, E.g. not for this merkle tree.
-    fn verify(proof: impl Borrow<Self::MembershipProof>) -> Result<bool, PrimitivesError>;
+    fn verify(
+        root: impl Borrow<Self::NodeValue>,
+        proof: impl Borrow<Self::MembershipProof>,
+    ) -> Result<bool, PrimitivesError>;
 
     // fn batch_lookup(&self, pos: impl Iterator<Item = usize>) -> LookupResult<(),
     // Self::BatchProof>; fn batch_verify(

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -16,7 +16,8 @@ pub(crate) mod internal;
 pub mod prelude;
 
 use crate::{
-    errors::PrimitivesError, impl_to_traversal_path_biguint, impl_to_traversal_path_primitives,
+    errors::{PrimitivesError, VerificationResult},
+    impl_to_traversal_path_biguint, impl_to_traversal_path_primitives,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{borrow::Borrow, fmt::Debug, hash::Hash, string::ToString, vec, vec::Vec};
@@ -228,7 +229,7 @@ pub trait MerkleTreeScheme: Sized {
     fn verify(
         root: impl Borrow<Self::NodeValue>,
         proof: impl Borrow<Self::MembershipProof>,
-    ) -> Result<bool, PrimitivesError>;
+    ) -> Result<VerificationResult, PrimitivesError>;
 
     // fn batch_lookup(&self, pos: impl Iterator<Item = usize>) -> LookupResult<(),
     // Self::BatchProof>; fn batch_verify(

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -225,7 +225,6 @@ pub trait MerkleTreeScheme: Sized {
     /// * `returns` - Ok(true) if the proof is accepted, Ok(false) if not. Err()
     ///   if the proof is not well structured, E.g. not for this merkle tree.
     fn verify(
-        &self,
         pos: impl Borrow<Self::Index>,
         proof: impl Borrow<Self::MembershipProof>,
     ) -> Result<bool, PrimitivesError>;

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -11,7 +11,10 @@ use super::{
     Index, LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
     UniversalMerkleTreeScheme,
 };
-use crate::{errors::PrimitivesError, impl_forgetable_merkle_tree_scheme, impl_merkle_tree_scheme};
+use crate::{
+    errors::{PrimitivesError, VerificationResult},
+    impl_forgetable_merkle_tree_scheme, impl_merkle_tree_scheme,
+};
 use ark_std::{
     borrow::Borrow, boxed::Box, fmt::Debug, marker::PhantomData, string::ToString, vec, vec::Vec,
 };
@@ -270,7 +273,11 @@ mod mt_tests {
             let (val, proof) = mt.universal_lookup(F::from(i as u64)).expect_ok().unwrap();
             assert_eq!(val, F::from(i as u64));
             assert_eq!(*proof.elem().unwrap(), val);
-            assert!(RescueSparseMerkleTree::<F, F>::verify(&mt.root.value(), &proof).unwrap());
+            assert!(
+                RescueSparseMerkleTree::<F, F>::verify(&mt.root.value(), &proof)
+                    .unwrap()
+                    .is_ok()
+            );
         }
     }
 
@@ -302,8 +309,16 @@ mod mt_tests {
         assert_eq!(lookup_mem_proof, mem_proof);
         assert_eq!(elem, 1u64.into());
         assert_eq!(mem_proof.tree_height(), 11);
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&root, &lookup_mem_proof).unwrap());
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&root, &mem_proof).unwrap());
+        assert!(
+            RescueSparseMerkleTree::<BigUint, F>::verify(&root, &lookup_mem_proof)
+                .unwrap()
+                .is_ok()
+        );
+        assert!(
+            RescueSparseMerkleTree::<BigUint, F>::verify(&root, &mem_proof)
+                .unwrap()
+                .is_ok()
+        );
 
         // Forgetting or looking up an element that is already forgotten should fail.
         assert!(matches!(
@@ -321,7 +336,9 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 3u64.into());
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&root, &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&root, &proof)
+            .unwrap()
+            .is_ok());
 
         // Look up and forget an empty sub-tree.
         let lookup_non_mem_proof = match mt.universal_lookup(BigUint::from(1u64)) {
@@ -362,7 +379,9 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 3u64.into());
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&root, &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&root, &proof)
+            .unwrap()
+            .is_ok());
 
         // Now if we forget the last entry, which is the only thing keeping the root
         // branch in memory, every entry will be forgotten.
@@ -427,7 +446,9 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 1u64.into());
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&root, &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&root, &proof)
+            .unwrap()
+            .is_ok());
 
         match mt.universal_lookup(BigUint::from(1u64)) {
             LookupResult::NotFound(proof) => {

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -274,7 +274,7 @@ mod mt_tests {
             let (val, proof) = mt.universal_lookup(F::from(i as u64)).expect_ok().unwrap();
             assert_eq!(val, F::from(i as u64));
             assert_eq!(*proof.elem().unwrap(), val);
-            assert!(mt.verify(F::from(i as u64), &proof).unwrap());
+            assert!(RescueSparseMerkleTree::<F, F>::verify(F::from(i as u64), &proof).unwrap());
         }
     }
 
@@ -305,8 +305,14 @@ mod mt_tests {
         assert_eq!(lookup_mem_proof, mem_proof);
         assert_eq!(elem, 1u64.into());
         assert_eq!(mem_proof.tree_height(), 11);
-        assert!(mt.verify(BigUint::from(0u64), &lookup_mem_proof).unwrap());
-        assert!(mt.verify(BigUint::from(0u64), &mem_proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(
+            BigUint::from(0u64),
+            &lookup_mem_proof
+        )
+        .unwrap());
+        assert!(
+            RescueSparseMerkleTree::<BigUint, F>::verify(BigUint::from(0u64), &mem_proof).unwrap()
+        );
 
         // Forgetting or looking up an element that is already forgotten should fail.
         assert!(matches!(
@@ -324,7 +330,7 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 3u64.into());
-        assert!(mt.verify(BigUint::from(2u64), &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(BigUint::from(2u64), &proof).unwrap());
 
         // Look up and forget an empty sub-tree.
         let lookup_non_mem_proof = match mt.universal_lookup(BigUint::from(1u64)) {
@@ -365,7 +371,7 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 3u64.into());
-        assert!(mt.verify(BigUint::from(2u64), &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(BigUint::from(2u64), &proof).unwrap());
 
         // Now if we forget the last entry, which is the only thing keeping the root
         // branch in memory, every entry will be forgotten.
@@ -431,7 +437,7 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 1u64.into());
-        assert!(mt.verify(BigUint::from(0u64), &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(BigUint::from(0u64), &proof).unwrap());
 
         match mt.universal_lookup(BigUint::from(1u64)) {
             LookupResult::NotFound(proof) => {

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -91,14 +91,13 @@ where
         let pos = pos.borrow();
         let traversal_path = pos.to_traversal_path(self.height);
         match self.root.lookup_internal(self.height, &traversal_path) {
-            LookupResult::Ok(value, proof) => LookupResult::Ok(
-                value,
-                MerkleProof::new(pos.clone(), proof, self.root.value()),
-            ),
+            LookupResult::Ok(value, proof) => {
+                LookupResult::Ok(value, MerkleProof::new(pos.clone(), proof))
+            },
             LookupResult::NotInMemory => LookupResult::NotInMemory,
-            LookupResult::NotFound(non_membership_proof) => LookupResult::NotFound(
-                MerkleProof::new(pos.clone(), non_membership_proof, self.root.value()),
-            ),
+            LookupResult::NotFound(non_membership_proof) => {
+                LookupResult::NotFound(MerkleProof::new(pos.clone(), non_membership_proof))
+            },
         }
     }
 }
@@ -118,13 +117,9 @@ where
     ) -> LookupResult<Self::Element, Self::MembershipProof, Self::NonMembershipProof> {
         let traversal_path = pos.to_traversal_path(self.height);
         match self.root.forget_internal(self.height, &traversal_path) {
-            LookupResult::Ok(elem, proof) => {
-                LookupResult::Ok(elem, MerkleProof::new(pos, proof, self.root.value()))
-            },
+            LookupResult::Ok(elem, proof) => LookupResult::Ok(elem, MerkleProof::new(pos, proof)),
             LookupResult::NotInMemory => LookupResult::NotInMemory,
-            LookupResult::NotFound(proof) => {
-                LookupResult::NotFound(MerkleProof::new(pos, proof, self.root.value()))
-            },
+            LookupResult::NotFound(proof) => LookupResult::NotFound(MerkleProof::new(pos, proof)),
         }
     }
 
@@ -406,8 +401,7 @@ mod mt_tests {
         mt.non_membership_remember(1u64.into(), &bad_non_mem_proof)
             .unwrap_err();
 
-        let mut forge_mem_proof =
-            MerkleProof::new(1u64.into(), mem_proof.proof.clone(), mt.root.value());
+        let mut forge_mem_proof = MerkleProof::new(1u64.into(), mem_proof.proof.clone());
         if let MerkleNode::Leaf { pos, elem, .. } = &mut forge_mem_proof.proof[0] {
             *pos = 1u64.into();
             *elem = F::from(0u64);

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -274,7 +274,7 @@ mod mt_tests {
             let (val, proof) = mt.universal_lookup(F::from(i as u64)).expect_ok().unwrap();
             assert_eq!(val, F::from(i as u64));
             assert_eq!(*proof.elem().unwrap(), val);
-            assert!(RescueSparseMerkleTree::<F, F>::verify(F::from(i as u64), &proof).unwrap());
+            assert!(RescueSparseMerkleTree::<F, F>::verify(&proof).unwrap());
         }
     }
 
@@ -305,14 +305,8 @@ mod mt_tests {
         assert_eq!(lookup_mem_proof, mem_proof);
         assert_eq!(elem, 1u64.into());
         assert_eq!(mem_proof.tree_height(), 11);
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(
-            BigUint::from(0u64),
-            &lookup_mem_proof
-        )
-        .unwrap());
-        assert!(
-            RescueSparseMerkleTree::<BigUint, F>::verify(BigUint::from(0u64), &mem_proof).unwrap()
-        );
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&lookup_mem_proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&mem_proof).unwrap());
 
         // Forgetting or looking up an element that is already forgotten should fail.
         assert!(matches!(
@@ -330,7 +324,7 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 3u64.into());
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(BigUint::from(2u64), &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&proof).unwrap());
 
         // Look up and forget an empty sub-tree.
         let lookup_non_mem_proof = match mt.universal_lookup(BigUint::from(1u64)) {
@@ -371,7 +365,7 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 3u64.into());
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(BigUint::from(2u64), &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&proof).unwrap());
 
         // Now if we forget the last entry, which is the only thing keeping the root
         // branch in memory, every entry will be forgotten.
@@ -437,7 +431,7 @@ mod mt_tests {
             .expect_ok()
             .unwrap();
         assert_eq!(elem, 1u64.into());
-        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(BigUint::from(0u64), &proof).unwrap());
+        assert!(RescueSparseMerkleTree::<BigUint, F>::verify(&proof).unwrap());
 
         match mt.universal_lookup(BigUint::from(1u64)) {
             LookupResult::NotFound(proof) => {


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #272 

API change:

- Convert `MerkleTreeScheme::verify` from method to associated function. (ie. do not take `self`.)
- `MerkleTreeScheme::verify` do not take `pos`. Why? This argument is redundant. Currently, the only use of `pos` is to compare it against `proof.pos` and throw an error if they don't match. By removing `pos` we do not force the user to know anything about `pos` in order to verify a proof.
- **[EDIT]** `MerkleTreeScheme::verify` take `root` arg as per https://github.com/EspressoSystems/jellyfish/pull/274#discussion_r1206884154
- **[EDIT]** New `VerificationResult` return type, used in `MerkleTreeScheme::verify` as per https://github.com/EspressoSystems/jellyfish/pull/274#discussion_r1206866522
- Core API changes in `mod.rs`, `macros.rs`, `internal.rs`. All other modified files merely reflect these API changes.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (existing unit tests updated to reflect API change) 
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
