### PR TITLE
chore: Merkle tree index trait bound `From<u64>` -> `TryFrom<u64>`

### DIFF
--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -6,8 +6,6 @@
 
 //! Implementation of a typical append only merkle tree
 
-use core::ops::AddAssign;
-
 use super::{
     internal::{build_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment},
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
@@ -18,7 +16,8 @@ use crate::{
     impl_forgetable_merkle_tree_scheme, impl_merkle_tree_scheme,
 };
 use ark_std::{
-    borrow::Borrow, boxed::Box, fmt::Debug, marker::PhantomData, string::ToString, vec, vec::Vec,
+    borrow::Borrow, boxed::Box, fmt::Debug, format, marker::PhantomData, ops::AddAssign,
+    string::ToString, vec, vec::Vec,
 };
 use num_bigint::BigUint;
 use num_traits::pow::pow;
@@ -32,7 +31,7 @@ impl<E, H, I, Arity, T> AppendableMerkleTreeScheme for MerkleTree<E, H, I, Arity
 where
     E: Element,
     H: DigestAlgorithm<E, I, T>,
-    I: Index + From<u64> + AddAssign + ToTraversalPath<Arity>,
+    I: Index + TryFrom<u64> + AddAssign + ToTraversalPath<Arity>,
     Arity: Unsigned,
     T: NodeValue,
 {
@@ -45,11 +44,17 @@ where
         elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
     ) -> Result<(), PrimitivesError> {
         let mut iter = elems.into_iter().peekable();
+        let num_leaves = I::try_from(self.num_leaves).map_err(|_| {
+            PrimitivesError::InternalError(format!(
+                "failure to convert num_leaves {} to u64",
+                self.num_leaves
+            ))
+        })?;
 
-        let traversal_path = I::from(self.num_leaves).to_traversal_path(self.height);
+        let traversal_path = num_leaves.to_traversal_path(self.height);
         self.num_leaves += self.root.extend_internal::<H, Arity>(
             self.height,
-            &I::from(self.num_leaves),
+            &num_leaves,
             &traversal_path,
             true,
             &mut iter,

--- a/primitives/src/merkle_tree/hasher.rs
+++ b/primitives/src/merkle_tree/hasher.rs
@@ -42,7 +42,9 @@ use serde::{Deserialize, Serialize};
 use typenum::U3;
 
 /// Merkle tree generic over [`Digest`] hasher.
-pub type HasherMerkleTree<H, E> = MerkleTree<E, HasherDigestAlgorithm, u64, U3, HasherNode<H>>;
+pub type HasherMerkleTree<H, E> = MerkleTree<E, HasherDigestAlgorithm, usize, U3, HasherNode<H>>;
+// pub type HasherMerkleTree<H, E> = MerkleTree<E, HasherDigestAlgorithm, u64,
+// U3, HasherNode<H>>;
 
 /// A struct that impls [`DigestAlgorithm`] for use with [`MerkleTree`].
 pub struct HasherDigestAlgorithm;

--- a/primitives/src/merkle_tree/hasher.rs
+++ b/primitives/src/merkle_tree/hasher.rs
@@ -13,7 +13,10 @@
 //!
 //! # fn main() -> Result<(), PrimitivesError> {
 //! let my_data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+//!
+//! // payload type is `usize`, hash function is `Sha256`.
 //! let mt = HasherMerkleTree::<Sha256, usize>::from_elems(2, &my_data)?;
+//!
 //! let root = mt.commitment().digest();
 //! let (val, proof) = mt.lookup(2).expect_ok()?;
 //! assert_eq!(val, 3);
@@ -28,6 +31,9 @@
 //! [dependencies]
 //! sha2 = "0.10"
 //! ```
+//!
+//! Use [`GenericHasherMerkleTree`] if you prefer to specify your own `Arity`
+//! and node [`Index`] types.
 
 use super::{append_only::MerkleTree, DigestAlgorithm, Element, Index};
 use ark_serialize::{
@@ -41,10 +47,23 @@ use digest::{
 use serde::{Deserialize, Serialize};
 use typenum::U3;
 
-/// Merkle tree generic over [`Digest`] hasher.
-pub type HasherMerkleTree<H, E> = MerkleTree<E, HasherDigestAlgorithm, usize, U3, HasherNode<H>>;
-// pub type HasherMerkleTree<H, E> = MerkleTree<E, HasherDigestAlgorithm, u64,
-// U3, HasherNode<H>>;
+/// Merkle tree generic over [`Digest`] hasher `H`.
+///
+/// It's a trinary ([`U3`]) tree whose nodes are indexed by [`usize`].
+/// - `H` is a [RustCrypto-compatible](https://github.com/RustCrypto/hashes)
+///   hash function.
+/// - `E` is a [`Element`] payload data type for the Merkle tree.
+pub type HasherMerkleTree<H, E> = GenericHasherMerkleTree<H, E, usize, U3>;
+
+/// Like [`HasherMerkleTree`] except with additional parameters.
+///
+/// Additional parameters beyond [`HasherMerkleTree`]:
+/// - `I` is a [`Index`] data type that impls [`TryFrom<u64>`]. (eg. [`usize`],
+///   [`u64`], [`Field`](ark_ff::Field), etc.)
+/// - `Arity` is a [`Unsigned`](typenum::Unsigned). (eg. [`U2`](typenum::U2) for
+///   a binary tree, [`U3`] for a trinary tree, etc.)
+pub type GenericHasherMerkleTree<H, E, I, Arity> =
+    MerkleTree<E, HasherDigestAlgorithm, I, Arity, HasherNode<H>>;
 
 /// A struct that impls [`DigestAlgorithm`] for use with [`MerkleTree`].
 pub struct HasherDigestAlgorithm;
@@ -74,7 +93,7 @@ where
     }
 }
 
-/// Newtype wrapper for hash output that impls `NodeValue`.
+/// Newtype wrapper for hash output that impls [`NodeValue`](super::NodeValue).
 #[derive(Derivative, Deserialize, Serialize)]
 #[serde(bound = "Output<H>: Serialize + for<'a> Deserialize<'a>")]
 #[derivative(
@@ -112,7 +131,7 @@ where
     }
 }
 
-// Manual impls of some subtraits of `NodeValue`
+// Manual impls of some subtraits of [`NodeValue`](super::NodeValue).
 impl<H> CanonicalSerialize for HasherNode<H>
 where
     H: Digest,

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -36,7 +36,7 @@ macro_rules! impl_merkle_tree_scheme {
         where
             E: Element,
             H: DigestAlgorithm<E, I, T>,
-            I: Index + From<u64> + ToTraversalPath<Arity>,
+            I: Index + TryFrom<u64> + ToTraversalPath<Arity>,
             Arity: Unsigned,
             T: NodeValue,
         {
@@ -113,7 +113,7 @@ macro_rules! impl_forgetable_merkle_tree_scheme {
         where
             E: Element,
             H: DigestAlgorithm<E, I, T>,
-            I: Index + From<u64> + ToTraversalPath<Arity>,
+            I: Index + TryFrom<u64> + ToTraversalPath<Arity>,
             Arity: Unsigned,
             T: NodeValue,
         {

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -31,7 +31,7 @@ impl<E, H, I, Arity, T> UniversalMerkleTreeScheme for UniversalMerkleTree<E, H, 
 where
     E: Element,
     H: DigestAlgorithm<E, I, T>,
-    I: Index + From<u64> + ToTraversalPath<Arity>,
+    I: Index + TryFrom<u64> + ToTraversalPath<Arity>,
     Arity: Unsigned,
     T: NodeValue,
 {
@@ -110,7 +110,7 @@ impl<E, H, I, Arity, T> ForgetableUniversalMerkleTreeScheme
 where
     E: Element,
     H: DigestAlgorithm<E, I, T>,
-    I: Index + From<u64> + ToTraversalPath<Arity>,
+    I: Index + TryFrom<u64> + ToTraversalPath<Arity>,
     Arity: Unsigned,
     T: NodeValue,
 {
@@ -260,7 +260,7 @@ mod mt_tests {
 
     fn test_update_and_lookup_helper<I, F>()
     where
-        I: Index + ToTraversalPath<U3> + From<u64>,
+        I: Index + ToTraversalPath<U3> + TryFrom<u64>,
         F: RescueParameter + ToTraversalPath<U3>,
         RescueHash<F>: DigestAlgorithm<F, I, F>,
     {

--- a/primitives/tests/merkle_tree_hasher.rs
+++ b/primitives/tests/merkle_tree_hasher.rs
@@ -7,7 +7,10 @@ use sha2::Sha256;
 #[test]
 fn doctest_example() -> Result<(), PrimitivesError> {
     let my_data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    // payload type is `usize`, hash function is `Sha256`.
     let mt = HasherMerkleTree::<Sha256, usize>::from_elems(2, &my_data)?;
+
     let root = mt.commitment().digest();
     let (val, proof) = mt.lookup(2).expect_ok()?;
     assert_eq!(val, 3);


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #279
blocked by: #276 

I had to insert lots of `map_err` everywhere to convert `TryFrom` errors into `PrimitivesError`. In the future this cruft could be removed by switching to `anyhow` but that's a major clean-up task that's outside the scope of this PR.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (pending merge of #276 )
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
