### PR TITLE
fix: invalid pos is not en error, so return Ok(_) instead of Err(_)

### DIFF
--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -101,9 +101,7 @@ macro_rules! impl_merkle_tree_scheme {
                 proof: impl Borrow<Self::MembershipProof>,
             ) -> Result<VerificationResult, PrimitivesError> {
                 if *pos.borrow() != proof.borrow().pos {
-                    return Err(PrimitivesError::ParameterError(
-                        "Inconsistent proof index".to_string(),
-                    ));
+                    return Ok(Err(())); // invalid proof for the given pos
                 }
                 proof.borrow().verify_membership_proof::<H>(root.borrow())
             }


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

one-line addendum to #286 

`MerkleTreeScheme::verify` should not return `Err(_)` if the `pos` arg is inconsistent with the `proof`. It just means that `proof` is invalid for this `pos`, so verification fails. This matters for downstream users who use `?` to return early from a real internal error before checking whether verification fails.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
