### PR TITLE
Use ~/.cargo-nix as CARGO_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ We recommend the following tools:
 - [`direnv`](https://direnv.net/docs/installation.html)
 
 Run `direnv allow` at the repo root. You should see dependencies (including Rust) being installed.
+Alternatively, enter the nix-shell manually via `nix develop`.
+
+You can check you are in the correct development environment by running `which cargo`, which should print
+something like `/nix/store/2gb31jhahrm59n3lhpv1lw0wfax9cf9v-rust-minimal-1.69.0/bin/cargo`;
+and running `echo $CARGO_HOME` should print `~/.cargo-nix`.
 
 ## Build, run tests and examples
 

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,8 @@
           shellHook = ''
             export RUST_BACKTRACE=full
             export PATH="$PATH:$(pwd)/target/debug:$(pwd)/target/release"
+            # Prevent cargo aliases from using programs in `~/.cargo` to avoid conflicts with local rustup installations.
+            export CARGO_HOME=$HOME/.cargo-nix
 
             # Ensure `cargo fmt` uses `rustfmt` from nightly.
             export RUSTFMT="${nightlyToolchain}/bin/rustfmt"


### PR DESCRIPTION
## Description

Inspired by @sveitser's talk on https://github.com/EspressoSystems/espresso-sequencer/blob/1423d9ecce347a352cf89f0fd053b76c9d4ea52b/flake.nix.

next time you run `cargo check/test` command, it will take a while and download bunch of stuffs in your `~/.cargo-nix/`. 