### PR TITLE
feat: Reed-Solomon decoder accept FFT domain

### DIFF
--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -584,7 +584,7 @@ mod tests {
                 .zip(evals.into_iter())
                 .for_each(|((point, proof), eval)| {
                     assert_eq!(
-                        UnivariateKzgPCS::<E>::open(&ck, &poly, point).unwrap(),
+                        UnivariateKzgPCS::<E>::open(&ck, &poly, &point).unwrap(),
                         (proof, eval)
                     );
                 });

--- a/primitives/src/reed_solomon_code/mod.rs
+++ b/primitives/src/reed_solomon_code/mod.rs
@@ -34,7 +34,7 @@ use core::borrow::Borrow;
 /// let output = reed_solomon_erasure_decode(eval_points.iter().zip(result).take(2), 2).unwrap();
 /// assert_eq!(input, output);
 /// ```
-pub fn reed_solomon_encode<F, D>(
+pub fn reed_solomon_erasure_encode<F, D>(
     data: D,
     parity_size: usize,
 ) -> Result<impl Iterator<Item = F>, PrimitivesError>
@@ -170,7 +170,7 @@ mod test {
     use ark_std::{vec, vec::Vec};
 
     use crate::reed_solomon_code::{
-        reed_solomon_encode, reed_solomon_erasure_decode, reed_solomon_erasure_decode_rou,
+        reed_solomon_erasure_decode, reed_solomon_erasure_decode_rou, reed_solomon_erasure_encode,
     };
 
     fn test_rs_code_helper<F: Field>() {
@@ -178,7 +178,9 @@ mod test {
         let data = vec![F::from(1u64), F::from(2u64)];
         // Evaluation of the above polynomial on (1, 2, 3) is (3, 5, 7)
         let expected = vec![F::from(3u64), F::from(5u64), F::from(7u64)];
-        let code: Vec<F> = reed_solomon_encode(data.iter(), 1).unwrap().collect();
+        let code: Vec<F> = reed_solomon_erasure_encode(data.iter(), 1)
+            .unwrap()
+            .collect();
         assert_eq!(code, expected);
 
         for to_be_removed in 0..code.len() {


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

close: #261 

- Builds upon #256. Merge target is [`rs-code-fft`](https://github.com/EspressoSystems/jellyfish/tree/rs-code-fft) instead of `main` so you can see the stuff I added to #256. If desired we could change the merge target to `main` and close #256.
- House cleaning: change `reed_solomon_encode` into an iterator adaptor. (ie. It now returns an iterator.) It's not obvious/easy to do the same for `reed_solomon_decode` so I didn't do that.

# Warning

Naive implementation of `reed_solomon_erasure_decode_rou` computes each eval point in linear time. Ideally we would like constant-time random access to domain points without allocating and populating a vec for all the points. How best to achieve that?

https://github.com/EspressoSystems/jellyfish/blob/8baf5e0098088eab3c7fda2d60bb2b69b9aeb90e/primitives/src/reed_solomon_code/mod.rs#L157-L158

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
