### PR TITLE
fix: Reed-Solomon panic on duplicate input points

### DIFF
--- a/primitives/src/reed_solomon_code/mod.rs
+++ b/primitives/src/reed_solomon_code/mod.rs
@@ -111,14 +111,21 @@ where
     let w = (0..data_size)
         .map(|i| {
             let mut ret = F::one();
-            (0..data_size).for_each(|j| {
+            for j in 0..data_size {
                 if i != j {
-                    ret /= x[i] - x[j];
+                    let denom = x[i] - x[j];
+                    if denom.is_zero() {
+                        return Err(PrimitivesError::ParameterError(format!(
+                            "duplicate input point {} at indices {}, {}",
+                            x[i], i, j
+                        )));
+                    }
+                    ret /= denom;
                 }
-            });
-            ret
+            }
+            Ok(ret)
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     // Calculate f(x) = \sum_i l_i(x)
     let mut f = vec![F::zero(); data_size];
     // for i in 0..shares.len() {


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #311 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
