### PR TITLE
chore: make checked_fft_size public

### DIFF
--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -299,9 +299,9 @@ where
     ) -> Result<Vec<Self::Evaluation>, PCSError>;
 }
 
-// compute the fft size (i.e. `num_coeffs`) given a degree.
+/// compute the fft size (i.e. `num_coeffs`) given a degree.
 #[inline]
-fn checked_fft_size(degree: usize) -> Result<usize, PCSError> {
+pub fn checked_fft_size(degree: usize) -> Result<usize, PCSError> {
     let err = || {
         PCSError::InvalidParameters(ark_std::format!(
             "Next power of two overflows! Got: {}",


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

My life as a downstream user of jellyfish would be so much easier if `checked_fft_size` were public. I use it only in tests, so if you really don't want it public then perhaps we could feature-gate it or something.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
