### PR TITLE
feat: Finish NMT Absence proofs

### DIFF
--- a/primitives/src/merkle_tree/namespaced_merkle_tree.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree.rs
@@ -650,8 +650,8 @@ where
             // namespace at some index i, prove that the
             // target namespace is empty by providing proofs of leaves at index i and
             // i - 1
-            if let Some((namespace, _)) = self.namespace_ranges.range(namespace..).next() {
-                let i = self.namespace_ranges.get(namespace).unwrap().start;
+            if let Some((_, range)) = self.namespace_ranges.range(namespace..).next() {
+                let i = range.start;
                 left_boundary_proof = Some(self.lookup_proof(i - 1));
                 right_boundary_proof = Some(self.lookup_proof(i));
             }

--- a/primitives/src/merkle_tree/namespaced_merkle_tree.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree.rs
@@ -646,20 +646,12 @@ where
             }
         } else {
             proof_type = NamespaceProofType::Absence;
-            let ranges: Vec<&N> = self.namespace_ranges.keys().collect();
-            let closest_ns_idx = ranges
-                .binary_search_by(|leaf_ns| (**leaf_ns).cmp(&namespace))
-                .expect_err("The namespace should not be in the range");
             // If there is a namespace in the tree greater than our target
             // namespace at some index i, prove that the
             // target namespace is empty by providing proofs of leaves at index i and
             // i - 1
-            if closest_ns_idx > 0 && closest_ns_idx < ranges.len() {
-                let i = self
-                    .namespace_ranges
-                    .get(ranges[closest_ns_idx])
-                    .unwrap()
-                    .start;
+            if let Some((namespace, _)) = self.namespace_ranges.range(namespace..).next() {
+                let i = self.namespace_ranges.get(namespace).unwrap().start;
                 left_boundary_proof = Some(self.lookup_proof(i - 1));
                 right_boundary_proof = Some(self.lookup_proof(i));
             }


### PR DESCRIPTION

<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Constructs an absence proof when the target namespace falls within the tree range by providing two adjacent leaves that bound the target namespace. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ x] Targeted PR against correct branch (main)
- [x ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x ] Wrote unit tests
- [x ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
