### PR TITLE
feat: Implement `extend` + `push` for NMT

### DIFF
--- a/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
@@ -9,7 +9,7 @@ use alloc::collections::{btree_map::Entry, BTreeMap};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
 use core::{borrow::Borrow, fmt::Debug, hash::Hash, marker::PhantomData, ops::Range};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use typenum::Unsigned;
 
@@ -104,7 +104,7 @@ pub trait Namespace:
     + Hash
     + Ord
     + Serialize
-    + for<'a> Deserialize<'a>
+    + DeserializeOwned
 {
     /// Returns the minimum possible namespace
     fn min() -> Self;
@@ -226,9 +226,7 @@ where
         &mut self,
         elem: impl core::borrow::Borrow<Self::Element>,
     ) -> Result<(), PrimitivesError> {
-        let cloned = elem.borrow().clone();
-        NMT::<E, H, Arity, N, T>::update_namespace_metadata(&mut self.namespace_ranges, [elem])?;
-        self.inner.push(cloned)
+        self.extend([elem])
     }
 }
 

--- a/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
@@ -9,6 +9,8 @@ use alloc::collections::{btree_map::Entry, BTreeMap};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
 use core::{borrow::Borrow, fmt::Debug, hash::Hash, marker::PhantomData, ops::Range};
+use serde::{Deserialize, Serialize};
+
 use typenum::Unsigned;
 
 use crate::errors::{PrimitivesError, VerificationResult};
@@ -93,7 +95,16 @@ where
 
 /// Trait indiciating that a struct can act as an orderable namespace
 pub trait Namespace:
-    Debug + Clone + CanonicalDeserialize + CanonicalSerialize + Default + Copy + Hash + Ord
+    Debug
+    + Clone
+    + CanonicalDeserialize
+    + CanonicalSerialize
+    + Default
+    + Copy
+    + Hash
+    + Ord
+    + Serialize
+    + for<'a> Deserialize<'a>
 {
     /// Returns the minimum possible namespace
     fn min() -> Self;
@@ -113,7 +124,11 @@ impl Namespace for u64 {
 type InnerTree<E, H, T, N, Arity> =
     MerkleTree<E, NamespacedHasher<H, E, u64, T, N>, u64, Arity, NamespacedHash<T, N>>;
 
-#[derive(Debug, Clone)]
+type NamespaceRanges<N> = BTreeMap<N, Range<u64>>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound = "E: CanonicalSerialize + CanonicalDeserialize,
+                 T: CanonicalSerialize + CanonicalDeserialize")]
 /// NMT
 pub struct NMT<E, H, Arity, N, T>
 where
@@ -123,7 +138,7 @@ where
     N: Namespace,
     Arity: Unsigned,
 {
-    namespace_ranges: BTreeMap<N, Range<u64>>,
+    namespace_ranges: NamespaceRanges<N>,
     inner: InnerTree<E, H, T, N, Arity>,
 }
 
@@ -149,27 +164,8 @@ where
         elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
     ) -> Result<Self, PrimitivesError> {
         let mut namespace_ranges: BTreeMap<N, Range<u64>> = BTreeMap::new();
-        let mut max_namespace = <N as Namespace>::min();
-        let mut leaves = Vec::new();
-        for (idx, elem) in elems.into_iter().enumerate() {
-            let ns = elem.borrow().get_namespace();
-            let idx = idx as u64;
-            if ns < max_namespace {
-                return Err(PrimitivesError::InconsistentStructureError(
-                    "Namespace leaves must be pushed in sorted order".into(),
-                ));
-            }
-            match namespace_ranges.entry(ns) {
-                Entry::Occupied(entry) => {
-                    entry.into_mut().end = idx + 1;
-                },
-                Entry::Vacant(entry) => {
-                    entry.insert(idx..idx + 1);
-                },
-            }
-            max_namespace = ns;
-            leaves.push(elem);
-        }
+        let leaves =
+            NMT::<E, H, Arity, N, T>::update_namespace_metadata(&mut namespace_ranges, elems)?;
         let inner = <InnerTree<E, H, T, N, Arity> as MerkleTreeScheme>::from_elems(height, leaves)?;
         Ok(NMT {
             inner,
@@ -221,22 +217,24 @@ where
         &mut self,
         elems: impl IntoIterator<Item = impl core::borrow::Borrow<Self::Element>>,
     ) -> Result<(), PrimitivesError> {
-        // TODO(#314): update namespace metadata
-        self.inner.extend(elems)
+        let leaves =
+            NMT::<E, H, Arity, N, T>::update_namespace_metadata(&mut self.namespace_ranges, elems)?;
+        self.inner.extend(leaves)
     }
 
     fn push(
         &mut self,
         elem: impl core::borrow::Borrow<Self::Element>,
     ) -> Result<(), PrimitivesError> {
-        // TODO(#314): update namespace metadata
-        self.inner.push(elem)
+        let cloned = elem.borrow().clone();
+        NMT::<E, H, Arity, N, T>::update_namespace_metadata(&mut self.namespace_ranges, [elem])?;
+        self.inner.push(cloned)
     }
 }
 
 impl<E, H, Arity, N, T> NMT<E, H, Arity, N, T>
 where
-    H: DigestAlgorithm<E, u64, T> + BindNamespace<E, u64, T, N> + Clone,
+    H: DigestAlgorithm<E, u64, T> + BindNamespace<E, u64, T, N>,
     E: Element + Namespaced<Namespace = N>,
     T: NodeValue,
     N: Namespace,
@@ -251,6 +249,40 @@ where
             // The NMT is malformed, we cannot recover
             panic!()
         }
+    }
+
+    // Helper function to keep namespace metadata in sync with new leaves,
+    // Returns cached leaf references so that the inner merkle tree can append them
+    fn update_namespace_metadata(
+        namespace_ranges: &mut NamespaceRanges<N>,
+        elems: impl IntoIterator<Item = impl Borrow<E>>,
+    ) -> Result<Vec<impl Borrow<E>>, PrimitivesError> {
+        let (mut max_namespace, start_idx) = namespace_ranges
+            .iter()
+            .next_back()
+            .map(|(n, range)| (*n, range.end))
+            .unwrap_or((<N as Namespace>::min(), 0));
+        let mut leaves = Vec::new();
+        for (idx, elem) in elems.into_iter().enumerate() {
+            let ns = elem.borrow().get_namespace();
+            let idx = start_idx + idx as u64;
+            if ns < max_namespace {
+                return Err(PrimitivesError::InconsistentStructureError(
+                    "Namespace leaves must be pushed in sorted order".into(),
+                ));
+            }
+            match namespace_ranges.entry(ns) {
+                Entry::Occupied(entry) => {
+                    entry.into_mut().end = idx + 1;
+                },
+                Entry::Vacant(entry) => {
+                    entry.insert(idx..idx + 1);
+                },
+            }
+            max_namespace = ns;
+            leaves.push(elem);
+        }
+        Ok(leaves)
     }
 }
 
@@ -421,14 +453,40 @@ mod nmt_tests {
         assert!(Hasher::digest(&hashes).is_err());
     }
 
+    enum BuildType {
+        FromElems,
+        Push,
+        Extend,
+    }
+
     #[test]
     fn test_nmt() {
+        test_nmt_with_build_type(BuildType::Extend);
+        test_nmt_with_build_type(BuildType::FromElems);
+        test_nmt_with_build_type(BuildType::Push);
+    }
+
+    fn test_nmt_with_build_type(build_type: BuildType) {
         let namespaces = [1, 2, 2, 2, 4, 4, 4, 5];
         let first_ns = namespaces[0];
         let last_ns = namespaces[namespaces.len() - 1];
         let internal_ns = namespaces[1];
         let leaves: Vec<Leaf> = namespaces.iter().map(|i| Leaf::new(*i)).collect();
-        let tree = TestNMT::from_elems(3, leaves.clone()).unwrap();
+        let tree = match build_type {
+            BuildType::FromElems => TestNMT::from_elems(3, leaves.clone()).unwrap(),
+            BuildType::Extend => {
+                let mut nmt = TestNMT::from_elems(3, &[]).unwrap();
+                nmt.extend(leaves.clone()).unwrap();
+                nmt
+            },
+            BuildType::Push => {
+                let mut nmt = TestNMT::from_elems(3, &[]).unwrap();
+                for leaf in leaves.clone() {
+                    nmt.push(leaf).unwrap();
+                }
+                nmt
+            },
+        };
         let left_proof = tree.get_namespace_proof(first_ns);
         let right_proof = tree.get_namespace_proof(last_ns);
         let mut internal_proof = tree.get_namespace_proof(internal_ns);


### PR DESCRIPTION
…ng namespace data

<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Refactor logic that handles namespace metadata into a helper function that can be used for `from_elems`, `push`, and `extend`. 

closes: #314 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ x] Targeted PR against correct branch (main)
- [ x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ x] Wrote unit tests
- [ x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
