### PR TITLE
feat: Make `IOPTranscript` publicly accessible

### DIFF
--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -10,7 +10,7 @@ mod multilinear_kzg;
 mod poly;
 pub mod prelude;
 mod structs;
-mod transcript;
+pub mod transcript;
 mod univariate_kzg;
 
 use ark_ff::{FftField, Field};

--- a/primitives/src/pcs/transcript.rs
+++ b/primitives/src/pcs/transcript.rs
@@ -26,7 +26,7 @@ mod errors {
     }
 }
 
-pub(crate) use errors::TranscriptError;
+pub use errors::TranscriptError;
 
 use ark_ff::PrimeField;
 use ark_serialize::CanonicalSerialize;
@@ -44,7 +44,7 @@ use merlin::Transcript;
 /// the verifier, in which case the prover should start its phase by receiving a
 /// `non-empty` transcript.
 #[derive(Clone)]
-pub(crate) struct IOPTranscript<F: PrimeField> {
+pub struct IOPTranscript<F: PrimeField> {
     transcript: Transcript,
     is_empty: bool,
     #[doc(hidden)]
@@ -63,7 +63,7 @@ impl<F: PrimeField> IOPTranscript<F> {
     }
 
     /// Append the message to the transcript.
-    pub(crate) fn append_message(
+    pub fn append_message(
         &mut self,
         label: &'static [u8],
         msg: &[u8],
@@ -74,7 +74,7 @@ impl<F: PrimeField> IOPTranscript<F> {
     }
 
     /// Append the message to the transcript.
-    pub(crate) fn append_serializable_element<S: CanonicalSerialize>(
+    pub fn append_serializable_element<S: CanonicalSerialize>(
         &mut self,
         label: &'static [u8],
         group_elem: &S,
@@ -87,10 +87,7 @@ impl<F: PrimeField> IOPTranscript<F> {
     ///
     /// The output field element is statistical uniform as long
     /// as the field has a size less than 2^384.
-    pub(crate) fn get_and_append_challenge(
-        &mut self,
-        label: &'static [u8],
-    ) -> Result<F, TranscriptError> {
+    pub fn get_and_append_challenge(&mut self, label: &'static [u8]) -> Result<F, TranscriptError> {
         //  we need to reject when transcript is empty
         if self.is_empty {
             return Err(TranscriptError::InvalidTranscript(

--- a/primitives/src/pcs/transcript.rs
+++ b/primitives/src/pcs/transcript.rs
@@ -101,4 +101,26 @@ impl<F: PrimeField> IOPTranscript<F> {
         self.append_serializable_element(label, &challenge)?;
         Ok(challenge)
     }
+
+    /// Generate the challenge from the current transcript
+    /// and append it to the transcript.
+    ///
+    /// Without exposing the internal field `transcript`,
+    /// this is a wrapper around getting bytes as opposed to field elements.
+    pub fn get_and_append_byte_challenge(
+        &mut self,
+        label: &'static [u8],
+        dest: &mut [u8],
+    ) -> Result<(), TranscriptError> {
+        //  we need to reject when transcript is empty
+        if self.is_empty {
+            return Err(TranscriptError::InvalidTranscript(
+                "transcript is empty".to_string(),
+            ));
+        }
+
+        self.transcript.challenge_bytes(label, dest);
+        self.append_message(label, dest)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description


The jellyfish `IOPTranscript` has very ergonomic wrappers around merlin, why not expose it publicly.
Also I added an extra convenience method for getting challenge bytes instead of field elements.
Not sure whether this is a good approach - instead one could make the `transcript` field of the struct public and allow users to call more methods directly from merlin.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
