### PR TITLE
chore: Derive Eq, Hash at a bunch of places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 - [#337](https://github.com/EspressoSystems/jellyfish/pull/337) Port VID from another repo
 - [#341](https://github.com/EspressoSystems/jellyfish/pull/341) Port VDF from another repo
 - [#343](https://github.com/EspressoSystems/jellyfish/pull/343) Rescue parameter for `ark_bn254::Fq`
+- [#362](https://github.com/EspressoSystems/jellyfish/pull/362) Derive Eq, Hash at a bunch of places
 
 ### Changed
 

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -606,7 +606,7 @@ where
             // Compute coefficients for selector polynomial commitments.
             // The order: q_lc, q_mul, q_hash, q_o, q_c, q_ecc
             // TODO(binyi): get the order from a function.
-            let mut q_scalars = vec![E::ScalarField::zero(); 2 * GATE_WIDTH + 5];
+            let mut q_scalars = [E::ScalarField::zero(); 2 * GATE_WIDTH + 5];
             q_scalars[0] = w_evals[0];
             q_scalars[1] = w_evals[1];
             q_scalars[2] = w_evals[2];

--- a/primitives/src/merkle_tree/examples.rs
+++ b/primitives/src/merkle_tree/examples.rs
@@ -22,7 +22,7 @@ use sha3::{Digest, Sha3_256};
 use typenum::U3;
 
 /// Element type for interval merkle tree
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
 pub struct Interval<F: Field>(pub F, pub F);
 // impl<F: Field> Element for Interval<F> {}
 

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -832,27 +832,19 @@ where
                 .to_traversal_path(self.tree_height() - 1)
                 .iter()
                 .zip(self.proof.iter().skip(1))
-                .fold(
-                    Ok(init),
-                    |result, (branch, node)| -> Result<T, PrimitivesError> {
-                        match result {
-                            Ok(val) => match node {
-                                MerkleNode::Branch { value: _, children } => {
-                                    let mut data = children
-                                        .iter()
-                                        .map(|node| node.value())
-                                        .collect::<Vec<_>>();
-                                    data[*branch] = val;
-                                    H::digest(&data)
-                                },
-                                _ => Err(PrimitivesError::ParameterError(
-                                    "Incompatible proof for this merkle tree".to_string(),
-                                )),
-                            },
-                            Err(e) => Err(e),
-                        }
-                    },
-                )?;
+                .try_fold(init, |val, (branch, node)| -> Result<T, PrimitivesError> {
+                    match node {
+                        MerkleNode::Branch { value: _, children } => {
+                            let mut data =
+                                children.iter().map(|node| node.value()).collect::<Vec<_>>();
+                            data[*branch] = val;
+                            H::digest(&data)
+                        },
+                        _ => Err(PrimitivesError::ParameterError(
+                            "Incompatible proof for this merkle tree".to_string(),
+                        )),
+                    }
+                })?;
             if computed_root == *expected_root {
                 Ok(Ok(()))
             } else {
@@ -881,28 +873,20 @@ where
                 .to_traversal_path(self.tree_height() - 1)
                 .iter()
                 .zip(self.proof.iter().skip(1))
-                .fold(
-                    Ok(init),
-                    |result, (branch, node)| -> Result<T, PrimitivesError> {
-                        match result {
-                            Ok(val) => match node {
-                                MerkleNode::Branch { value: _, children } => {
-                                    let mut data = children
-                                        .iter()
-                                        .map(|node| node.value())
-                                        .collect::<Vec<_>>();
-                                    data[*branch] = val;
-                                    H::digest(&data)
-                                },
-                                MerkleNode::Empty => Ok(init),
-                                _ => Err(PrimitivesError::ParameterError(
-                                    "Incompatible proof for this merkle tree".to_string(),
-                                )),
-                            },
-                            Err(e) => Err(e),
-                        }
-                    },
-                )?;
+                .try_fold(init, |val, (branch, node)| -> Result<T, PrimitivesError> {
+                    match node {
+                        MerkleNode::Branch { value: _, children } => {
+                            let mut data =
+                                children.iter().map(|node| node.value()).collect::<Vec<_>>();
+                            data[*branch] = val;
+                            H::digest(&data)
+                        },
+                        MerkleNode::Empty => Ok(init),
+                        _ => Err(PrimitivesError::ParameterError(
+                            "Incompatible proof for this merkle tree".to_string(),
+                        )),
+                    }
+                })?;
             Ok(computed_root == *expected_root)
         } else {
             Err(PrimitivesError::ParameterError(

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -122,7 +122,8 @@ impl<T: NodeValue> MerkleCommitment<T> for MerkleTreeCommitment<T> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Derivative, Debug, Clone, Serialize, Deserialize)]
+#[derivative(Eq, Hash, PartialEq)]
 #[serde(bound = "E: CanonicalSerialize + CanonicalDeserialize,
              I: CanonicalSerialize + CanonicalDeserialize,")]
 pub struct MerkleProof<E, I, T, Arity>

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -85,8 +85,8 @@ impl<F, P, N> LookupResult<F, P, N> {
 }
 
 /// An element of a Merkle tree.
-pub trait Element: Clone + Eq + PartialEq {}
-impl<T: Clone + Eq + PartialEq> Element for T {}
+pub trait Element: Clone + Eq + PartialEq + Hash {}
+impl<T: Clone + Eq + PartialEq + Hash> Element for T {}
 
 /// An index type of a leaf in a Merkle tree.
 pub trait Index: Debug + Eq + PartialEq + Hash + Ord + PartialOrd + Clone {}
@@ -187,7 +187,7 @@ pub trait MerkleTreeScheme: Sized {
     /// Internal and root node value
     type NodeValue: NodeValue;
     /// Merkle proof
-    type MembershipProof: Clone;
+    type MembershipProof: Clone + Eq + Hash;
     /// Batch proof
     type BatchMembershipProof: Clone;
     /// Merkle tree commitment

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -140,13 +140,13 @@ where
         if matches!(&proof.proof[0], MerkleNode::Empty) {
             let empty_value = T::default();
             let mut path_values = vec![empty_value];
-            traversal_path.iter().zip(proof.proof.iter().skip(1)).fold(
-                Ok(empty_value),
-                |result: Result<T, PrimitivesError>,
-                 (branch, node)|
-                 -> Result<T, PrimitivesError> {
-                    match result {
-                        Ok(val) => match node {
+            traversal_path
+                .iter()
+                .zip(proof.proof.iter().skip(1))
+                .try_fold(
+                    empty_value,
+                    |val: T, (branch, node)| -> Result<T, PrimitivesError> {
+                        match node {
                             MerkleNode::Branch { value: _, children } => {
                                 let mut data: Vec<_> =
                                     children.iter().map(|node| node.value()).collect();
@@ -162,11 +162,9 @@ where
                             _ => Err(PrimitivesError::ParameterError(
                                 "Incompatible proof for this merkle tree".to_string(),
                             )),
-                        },
-                        Err(e) => Err(e),
-                    }
-                },
-            )?;
+                        }
+                    },
+                )?;
             self.root.remember_internal::<H, Arity>(
                 self.height,
                 &traversal_path,

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -39,11 +39,17 @@ pub trait PolynomialCommitmentScheme {
     /// Polynomial Evaluation
     type Evaluation: Field;
     /// Commitments
-    type Commitment: Clone + CanonicalSerialize + CanonicalDeserialize + Debug + PartialEq + Eq;
+    type Commitment: Clone
+        + CanonicalSerialize
+        + CanonicalDeserialize
+        + Debug
+        + PartialEq
+        + Eq
+        + Hash;
     /// Batch commitments
     type BatchCommitment: Clone + CanonicalSerialize + CanonicalDeserialize + Debug + PartialEq + Eq;
     /// Proofs
-    type Proof: Clone + CanonicalSerialize + CanonicalDeserialize + Debug + PartialEq + Eq;
+    type Proof: Clone + CanonicalSerialize + CanonicalDeserialize + Debug + PartialEq + Eq + Hash;
     /// Batch proofs
     type BatchProof: Clone + CanonicalSerialize + CanonicalDeserialize + Debug + PartialEq + Eq;
 

--- a/primitives/src/pcs/multilinear_kzg/mod.rs
+++ b/primitives/src/pcs/multilinear_kzg/mod.rs
@@ -51,7 +51,8 @@ pub struct MultilinearKzgPCS<E: Pairing> {
     phantom: PhantomData<E>,
 }
 
-#[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq, Eq)]
+#[derivative(Hash)]
 /// proof of opening
 pub struct MultilinearKzgProof<E: Pairing> {
     /// Evaluation of quotients

--- a/primitives/src/pcs/poly.rs
+++ b/primitives/src/pcs/poly.rs
@@ -213,7 +213,7 @@ where
             let coeffs = self
                 .coeffs
                 .into_iter()
-                .zip_longest(rhs.coeffs.into_iter())
+                .zip_longest(rhs.coeffs)
                 .map(|pair| match pair {
                     Both(x, y) => x + y,
                     Left(x) | Right(x) => x,

--- a/primitives/src/pcs/structs.rs
+++ b/primitives/src/pcs/structs.rs
@@ -8,16 +8,10 @@ use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Default(bound = ""),
-    Hash(bound = ""),
-    Clone(bound = ""),
-    Copy(bound = ""),
-    Debug(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = "")
+#[derive(
+    Derivative, Clone, Copy, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize,
 )]
+#[derivative(Default, Hash)]
 /// A commitment is an Affine point.
 pub struct Commitment<E: Pairing>(
     /// the actual commitment is an affine point.

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -46,7 +46,8 @@ pub struct UnivariateKzgPCS<E: Pairing> {
     phantom: PhantomData<E>,
 }
 
-#[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq, Eq)]
+#[derivative(Hash)]
 /// proof of opening
 pub struct UnivariateKzgProof<E: Pairing> {
     /// Evaluation of quotients

--- a/primitives/src/pcs/univariate_kzg/srs.rs
+++ b/primitives/src/pcs/univariate_kzg/srs.rs
@@ -41,15 +41,8 @@ pub struct UnivariateProverParam<E: Pairing> {
 
 /// `UnivariateVerifierParam` is used to check evaluation proofs for a given
 /// commitment.
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Default(bound = ""),
-    Clone(bound = ""),
-    Copy(bound = ""),
-    Debug(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = "")
-)]
+#[derive(Derivative, Clone, Copy, Debug, Eq, CanonicalSerialize, CanonicalDeserialize, PartialEq)]
+#[derivative(Default)]
 pub struct UnivariateVerifierParam<E: Pairing> {
     /// The generator of G1.
     pub g: E::G1Affine,

--- a/primitives/src/pcs/univariate_kzg/srs.rs
+++ b/primitives/src/pcs/univariate_kzg/srs.rs
@@ -41,7 +41,9 @@ pub struct UnivariateProverParam<E: Pairing> {
 
 /// `UnivariateVerifierParam` is used to check evaluation proofs for a given
 /// commitment.
-#[derive(Derivative, Clone, Copy, Debug, Eq, CanonicalSerialize, CanonicalDeserialize, PartialEq)]
+#[derive(
+    Derivative, Clone, Copy, Debug, Eq, CanonicalSerialize, CanonicalDeserialize, PartialEq,
+)]
 #[derivative(Default)]
 pub struct UnivariateVerifierParam<E: Pairing> {
     /// The generator of G1.

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -112,7 +112,7 @@ where
 #[derive(Derivative, Deserialize, Serialize)]
 // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 // #[derivative(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[derivative(Clone, Debug)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Share<P, V>
 where
     P: PolynomialCommitmentScheme,
@@ -131,7 +131,7 @@ where
 #[derive(CanonicalSerialize, CanonicalDeserialize, Derivative, Deserialize, Serialize)]
 // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 // #[derivative(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[derivative(Clone, Debug, Default, Eq, PartialEq)]
+#[derivative(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Common<P, V>
 where
     P: PolynomialCommitmentScheme,

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -47,7 +47,7 @@ pub trait VidScheme {
     type Commitment: Clone + Debug + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Share-specific data sent to a storage node.
-    type StorageShare: Clone + Debug + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
+    type StorageShare: Clone + Debug + Eq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Common data sent to all storage nodes.
     type StorageCommon: CanonicalSerialize + CanonicalDeserialize + Clone + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

A bunch of structs need `Eq` and `Hash` to enable integration of VID into hotshot. This PR does that. It's not pretty but it gets the job done.

This PR is a good opportunity to remind the reader that we should do a proper clean-up of trait bounds #253 to eliminate the need for PRs such as this.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
