### PR TITLE
chore: VID disperse also return payload commitment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 - [#299](https://github.com/EspressoSystems/jellyfish/pull/299) For Merkle tree, `DigestAlgorithm` now returns a `Result` type.
 - [#302](https://github.com/EspressoSystems/jellyfish/pull/302) Followup APIs for non-native ECC circuit support.
 - [#323](https://github.com/EspressoSystems/jellyfish/pull/323) Improve performance of range gate in ultra plonk.
+- [#371](https://github.com/EspressoSystems/jellyfish/pull/371) VID disperse also return payload commitment
 
 ### Removed
 

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -78,7 +78,7 @@ where
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
                 |b, _| {
-                    b.iter(|| advz.dispersal_data(&payload_bytes).unwrap());
+                    b.iter(|| advz.disperse(&payload_bytes).unwrap());
                 },
             );
         }
@@ -89,7 +89,7 @@ where
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
             let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
-            let disperse = advz.dispersal_data(&payload_bytes).unwrap();
+            let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common) = (disperse.shares, disperse.common);
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
@@ -107,7 +107,7 @@ where
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
             let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
-            let disperse = advz.dispersal_data(&payload_bytes).unwrap();
+            let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common) = (disperse.shares, disperse.common);
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -63,7 +63,7 @@ where
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
                 |b, _| {
-                    b.iter(|| advz.commitment_only(&payload_bytes).unwrap());
+                    b.iter(|| advz.commit_only(&payload_bytes).unwrap());
                 },
             );
         }

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -89,7 +89,7 @@ where
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
             let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
-            let (shares, common) = advz.dispersal_data(&payload_bytes).unwrap();
+            let (shares, common, _commit) = advz.dispersal_data(&payload_bytes).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -106,7 +106,7 @@ where
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
             let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
-            let (shares, common) = advz.dispersal_data(&payload_bytes).unwrap();
+            let (shares, common, _commit) = advz.dispersal_data(&payload_bytes).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -63,7 +63,7 @@ where
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
                 |b, _| {
-                    b.iter(|| advz.commit(&payload_bytes).unwrap());
+                    b.iter(|| advz.commitment_only(&payload_bytes).unwrap());
                 },
             );
         }

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -89,7 +89,8 @@ where
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
             let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
-            let (shares, common, _commit) = advz.dispersal_data(&payload_bytes).unwrap();
+            let disperse = advz.dispersal_data(&payload_bytes).unwrap();
+            let (shares, common) = (disperse.shares, disperse.common);
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -106,7 +107,8 @@ where
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
             let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
-            let (shares, common, _commit) = advz.dispersal_data(&payload_bytes).unwrap();
+            let disperse = advz.dispersal_data(&payload_bytes).unwrap();
+            let (shares, common) = (disperse.shares, disperse.common);
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -163,7 +163,7 @@ where
     type StorageShare = Share<P, V>;
     type StorageCommon = Common<P, V>;
 
-    fn commit(&self, payload: &[u8]) -> VidResult<Self::Commitment> {
+    fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commitment> {
         let mut hasher = H::new();
 
         // TODO perf: DenseUVPolynomial::from_coefficients_slice copies the slice.

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -181,8 +181,8 @@ where
         Ok(hasher.finalize())
     }
 
-    fn dispersal_data(&self, payload: &[u8]) -> VidResult<VidDisperse<Self>> {
-        self.dispersal_data_from_elems(&bytes_to_field_elements(payload))
+    fn disperse(&self, payload: &[u8]) -> VidResult<VidDisperse<Self>> {
+        self.disperse_from_elems(&bytes_to_field_elements(payload))
     }
 
     fn verify_share(
@@ -274,10 +274,7 @@ where
 {
     /// Same as [`VidScheme::dispersal_data`] except `payload` is a slice of
     /// field elements.
-    pub fn dispersal_data_from_elems(
-        &self,
-        payload: &[P::Evaluation],
-    ) -> VidResult<VidDisperse<Self>> {
+    pub fn disperse_from_elems(&self, payload: &[P::Evaluation]) -> VidResult<VidDisperse<Self>> {
         let num_polys = (payload.len() - 1) / self.payload_chunk_size + 1;
         let domain = P::multi_open_rou_eval_domain(self.payload_chunk_size, self.num_storage_nodes)
             .map_err(vid)?;
@@ -564,7 +561,7 @@ mod tests {
     #[test]
     fn sad_path_verify_share_corrupt_share() {
         let (advz, bytes_random) = avdz_init();
-        let disperse = advz.dispersal_data(&bytes_random).unwrap();
+        let disperse = advz.disperse(&bytes_random).unwrap();
         let (shares, common) = (disperse.shares, disperse.common);
 
         for (i, share) in shares.iter().enumerate() {
@@ -630,7 +627,7 @@ mod tests {
     #[test]
     fn sad_path_verify_share_corrupt_commit() {
         let (advz, bytes_random) = avdz_init();
-        let disperse = advz.dispersal_data(&bytes_random).unwrap();
+        let disperse = advz.disperse(&bytes_random).unwrap();
         let (shares, common) = (disperse.shares, disperse.common);
 
         // missing commit
@@ -675,7 +672,7 @@ mod tests {
     #[test]
     fn sad_path_verify_share_corrupt_share_and_commit() {
         let (advz, bytes_random) = avdz_init();
-        let disperse = advz.dispersal_data(&bytes_random).unwrap();
+        let disperse = advz.disperse(&bytes_random).unwrap();
         let (mut shares, mut common) = (disperse.shares, disperse.common);
 
         common.poly_commits.pop();
@@ -694,7 +691,7 @@ mod tests {
     #[test]
     fn sad_path_recover_payload_corrupt_shares() {
         let (advz, bytes_random) = avdz_init();
-        let disperse = advz.dispersal_data(&bytes_random).unwrap();
+        let disperse = advz.disperse(&bytes_random).unwrap();
         let (shares, common) = (disperse.shares, disperse.common);
 
         {

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -161,7 +161,7 @@ where
 {
     type Commit = Output<H>;
     type Share = Share<P, V>;
-    type StorageCommon = Common<P, V>;
+    type Common = Common<P, V>;
 
     fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commit> {
         let mut hasher = H::new();
@@ -184,14 +184,14 @@ where
     fn dispersal_data(
         &self,
         payload: &[u8],
-    ) -> VidResult<(Vec<Self::Share>, Self::StorageCommon, Self::Commit)> {
+    ) -> VidResult<(Vec<Self::Share>, Self::Common, Self::Commit)> {
         self.dispersal_data_from_elems(&bytes_to_field_elements(payload))
     }
 
     fn verify_share(
         &self,
         share: &Self::Share,
-        common: &Self::StorageCommon,
+        common: &Self::Common,
     ) -> VidResult<Result<(), ()>> {
         // check arguments
         if share.evals.len() != common.poly_commits.len() {
@@ -256,11 +256,7 @@ where
         .ok_or(()))
     }
 
-    fn recover_payload(
-        &self,
-        shares: &[Self::Share],
-        common: &Self::StorageCommon,
-    ) -> VidResult<Vec<u8>> {
+    fn recover_payload(&self, shares: &[Self::Share], common: &Self::Common) -> VidResult<Vec<u8>> {
         Ok(bytes_from_field_elements(
             self.recover_elems(shares, common)?,
         ))
@@ -286,7 +282,7 @@ where
         payload: &[P::Evaluation],
     ) -> VidResult<(
         Vec<<Self as VidScheme>::Share>,
-        <Self as VidScheme>::StorageCommon,
+        <Self as VidScheme>::Common,
         <Self as VidScheme>::Commit,
     )> {
         let num_polys = (payload.len() - 1) / self.payload_chunk_size + 1;
@@ -392,7 +388,7 @@ where
     pub fn recover_elems(
         &self,
         shares: &[<Self as VidScheme>::Share],
-        _common: &<Self as VidScheme>::StorageCommon,
+        _common: &<Self as VidScheme>::Common,
     ) -> VidResult<Vec<P::Evaluation>> {
         if shares.len() < self.payload_chunk_size {
             return Err(VidError::Argument(format!(
@@ -439,9 +435,7 @@ where
         Ok(result)
     }
 
-    fn pseudorandom_scalar(
-        common: &<Self as VidScheme>::StorageCommon,
-    ) -> VidResult<P::Evaluation> {
+    fn pseudorandom_scalar(common: &<Self as VidScheme>::Common) -> VidResult<P::Evaluation> {
         let mut hasher = H::new();
         for poly_commit in common.poly_commits.iter() {
             poly_commit

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -159,11 +159,11 @@ where
     V::MembershipProof: Sync + Debug, /* TODO https://github.com/EspressoSystems/jellyfish/issues/253 */
     V::Index: From<u64>,
 {
-    type Commitment = Output<H>;
+    type Commit = Output<H>;
     type StorageShare = Share<P, V>;
     type StorageCommon = Common<P, V>;
 
-    fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commitment> {
+    fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commit> {
         let mut hasher = H::new();
 
         // TODO perf: DenseUVPolynomial::from_coefficients_slice copies the slice.
@@ -184,11 +184,7 @@ where
     fn dispersal_data(
         &self,
         payload: &[u8],
-    ) -> VidResult<(
-        Vec<Self::StorageShare>,
-        Self::StorageCommon,
-        Self::Commitment,
-    )> {
+    ) -> VidResult<(Vec<Self::StorageShare>, Self::StorageCommon, Self::Commit)> {
         self.dispersal_data_from_elems(&bytes_to_field_elements(payload))
     }
 
@@ -291,7 +287,7 @@ where
     ) -> VidResult<(
         Vec<<Self as VidScheme>::StorageShare>,
         <Self as VidScheme>::StorageCommon,
-        <Self as VidScheme>::Commitment,
+        <Self as VidScheme>::Commit,
     )> {
         let num_polys = (payload.len() - 1) / self.payload_chunk_size + 1;
         let domain = P::multi_open_rou_eval_domain(self.payload_chunk_size, self.num_storage_nodes)

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -108,7 +108,7 @@ where
     }
 }
 
-/// The [`VidScheme::StorageShare`] type for [`Advz`].
+/// The [`VidScheme::Share`] type for [`Advz`].
 #[derive(Derivative, Deserialize, Serialize)]
 // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 // #[derivative(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -127,7 +127,7 @@ where
     evals_proof: V::MembershipProof,
 }
 
-/// The [`VidScheme::StorageCommon`] type for [`Advz`].
+/// The [`VidScheme::Common`] type for [`Advz`].
 #[derive(CanonicalSerialize, CanonicalDeserialize, Derivative, Deserialize, Serialize)]
 // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 // #[derivative(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -272,7 +272,7 @@ where
     V::MembershipProof: Sync + Debug, /* TODO https://github.com/EspressoSystems/jellyfish/issues/253 */
     V::Index: From<u64>,
 {
-    /// Same as [`VidScheme::dispersal_data`] except `payload` is a slice of
+    /// Same as [`VidScheme::disperse`] except `payload` is a slice of
     /// field elements.
     pub fn disperse_from_elems(&self, payload: &[P::Evaluation]) -> VidResult<VidDisperse<Self>> {
         let num_polys = (payload.len() - 1) / self.payload_chunk_size + 1;

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -163,7 +163,7 @@ where
     type Share = Share<P, V>;
     type Common = Common<P, V>;
 
-    fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commit> {
+    fn commit_only(&self, payload: &[u8]) -> VidResult<Self::Commit> {
         let mut hasher = H::new();
 
         // TODO perf: DenseUVPolynomial::from_coefficients_slice copies the slice.

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -160,7 +160,7 @@ where
     V::Index: From<u64>,
 {
     type Commit = Output<H>;
-    type StorageShare = Share<P, V>;
+    type Share = Share<P, V>;
     type StorageCommon = Common<P, V>;
 
     fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commit> {
@@ -184,13 +184,13 @@ where
     fn dispersal_data(
         &self,
         payload: &[u8],
-    ) -> VidResult<(Vec<Self::StorageShare>, Self::StorageCommon, Self::Commit)> {
+    ) -> VidResult<(Vec<Self::Share>, Self::StorageCommon, Self::Commit)> {
         self.dispersal_data_from_elems(&bytes_to_field_elements(payload))
     }
 
     fn verify_share(
         &self,
-        share: &Self::StorageShare,
+        share: &Self::Share,
         common: &Self::StorageCommon,
     ) -> VidResult<Result<(), ()>> {
         // check arguments
@@ -258,7 +258,7 @@ where
 
     fn recover_payload(
         &self,
-        shares: &[Self::StorageShare],
+        shares: &[Self::Share],
         common: &Self::StorageCommon,
     ) -> VidResult<Vec<u8>> {
         Ok(bytes_from_field_elements(
@@ -285,7 +285,7 @@ where
         &self,
         payload: &[P::Evaluation],
     ) -> VidResult<(
-        Vec<<Self as VidScheme>::StorageShare>,
+        Vec<<Self as VidScheme>::Share>,
         <Self as VidScheme>::StorageCommon,
         <Self as VidScheme>::Commit,
     )> {
@@ -391,7 +391,7 @@ where
     /// elements.
     pub fn recover_elems(
         &self,
-        shares: &[<Self as VidScheme>::StorageShare],
+        shares: &[<Self as VidScheme>::Share],
         _common: &<Self as VidScheme>::StorageCommon,
     ) -> VidResult<Vec<P::Evaluation>> {
         if shares.len() < self.payload_chunk_size {

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -56,7 +56,7 @@ pub trait VidScheme {
     fn commit_only(&self, payload: &[u8]) -> VidResult<Self::Commit>;
 
     /// Compute shares to send to the storage nodes
-    fn dispersal_data(&self, payload: &[u8]) -> VidResult<VidDisperse<Self>>;
+    fn disperse(&self, payload: &[u8]) -> VidResult<VidDisperse<Self>>;
 
     /// Verify a share. Used by both storage node and retrieval client.
     /// Why is return type a nested `Result`? See <https://sled.rs/errors>

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -74,7 +74,7 @@ pub trait VidScheme {
 
 /// Convenience struct to aggregate disperse data.
 ///
-/// Return type for [`VidScheme::dispersal_data`].
+/// Return type for [`VidScheme::disperse`].
 ///
 /// # Why the `?Sized` bound?
 /// Rust hates you: <https://stackoverflow.com/a/54465962>

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -53,7 +53,7 @@ pub trait VidScheme {
     type StorageCommon: CanonicalSerialize + CanonicalDeserialize + Clone + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Compute a payload commitment.
-    fn commit(&self, payload: &[u8]) -> VidResult<Self::Commitment>;
+    fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commitment>;
 
     /// Compute shares to send to the storage nodes
     fn dispersal_data(

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -56,10 +56,7 @@ pub trait VidScheme {
     fn commit_only(&self, payload: &[u8]) -> VidResult<Self::Commit>;
 
     /// Compute shares to send to the storage nodes
-    fn dispersal_data(
-        &self,
-        payload: &[u8],
-    ) -> VidResult<(Vec<Self::Share>, Self::Common, Self::Commit)>;
+    fn dispersal_data(&self, payload: &[u8]) -> VidResult<VidDisperse<Self>>;
 
     /// Verify a share. Used by both storage node and retrieval client.
     /// Why is return type a nested `Result`? See <https://sled.rs/errors>
@@ -73,4 +70,19 @@ pub trait VidScheme {
     /// Recover payload from shares.
     /// Do not verify shares or check recovered payload against anything.
     fn recover_payload(&self, shares: &[Self::Share], common: &Self::Common) -> VidResult<Vec<u8>>;
+}
+
+/// Convenience struct to aggregate disperse data.
+///
+/// Return type for [`VidScheme::dispersal_data`].
+///
+/// # Why the `?Sized` bound?
+/// Rust hates you: <https://stackoverflow.com/a/54465962>
+pub struct VidDisperse<V: VidScheme + ?Sized> {
+    /// VID disperse shares to send to the storage nodes.
+    pub shares: Vec<V::Share>,
+    /// VID common data to send to all storage nodes.
+    pub common: V::Common,
+    /// VID payload commitment.
+    pub commit: V::Commit,
 }

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -59,7 +59,11 @@ pub trait VidScheme {
     fn dispersal_data(
         &self,
         payload: &[u8],
-    ) -> VidResult<(Vec<Self::StorageShare>, Self::StorageCommon)>;
+    ) -> VidResult<(
+        Vec<Self::StorageShare>,
+        Self::StorageCommon,
+        Self::Commitment,
+    )>;
 
     /// Verify a share. Used by both storage node and retrieval client.
     /// Why is return type a nested `Result`? See <https://sled.rs/errors>

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -53,7 +53,7 @@ pub trait VidScheme {
     type Common: CanonicalSerialize + CanonicalDeserialize + Clone + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Compute a payload commitment.
-    fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commit>;
+    fn commit_only(&self, payload: &[u8]) -> VidResult<Self::Commit>;
 
     /// Compute shares to send to the storage nodes
     fn dispersal_data(

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -44,7 +44,7 @@ pub type VidResult<T> = Result<T, VidError>;
 /// VID: Verifiable Information Dispersal
 pub trait VidScheme {
     /// Payload commitment.
-    type Commitment: Clone + Debug + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
+    type Commit: Clone + Debug + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Share-specific data sent to a storage node.
     type StorageShare: Clone + Debug + Eq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
@@ -53,17 +53,13 @@ pub trait VidScheme {
     type StorageCommon: CanonicalSerialize + CanonicalDeserialize + Clone + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Compute a payload commitment.
-    fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commitment>;
+    fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commit>;
 
     /// Compute shares to send to the storage nodes
     fn dispersal_data(
         &self,
         payload: &[u8],
-    ) -> VidResult<(
-        Vec<Self::StorageShare>,
-        Self::StorageCommon,
-        Self::Commitment,
-    )>;
+    ) -> VidResult<(Vec<Self::StorageShare>, Self::StorageCommon, Self::Commit)>;
 
     /// Verify a share. Used by both storage node and retrieval client.
     /// Why is return type a nested `Result`? See <https://sled.rs/errors>

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -47,7 +47,7 @@ pub trait VidScheme {
     type Commit: Clone + Debug + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Share-specific data sent to a storage node.
-    type StorageShare: Clone + Debug + Eq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
+    type Share: Clone + Debug + Eq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Common data sent to all storage nodes.
     type StorageCommon: CanonicalSerialize + CanonicalDeserialize + Clone + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
@@ -59,7 +59,7 @@ pub trait VidScheme {
     fn dispersal_data(
         &self,
         payload: &[u8],
-    ) -> VidResult<(Vec<Self::StorageShare>, Self::StorageCommon, Self::Commit)>;
+    ) -> VidResult<(Vec<Self::Share>, Self::StorageCommon, Self::Commit)>;
 
     /// Verify a share. Used by both storage node and retrieval client.
     /// Why is return type a nested `Result`? See <https://sled.rs/errors>
@@ -69,7 +69,7 @@ pub trait VidScheme {
     /// - VidResult::Ok(Result::Ok) if verification succeeds
     fn verify_share(
         &self,
-        share: &Self::StorageShare,
+        share: &Self::Share,
         common: &Self::StorageCommon,
     ) -> VidResult<Result<(), ()>>;
 
@@ -77,7 +77,7 @@ pub trait VidScheme {
     /// Do not verify shares or check recovered payload against anything.
     fn recover_payload(
         &self,
-        shares: &[Self::StorageShare],
+        shares: &[Self::Share],
         common: &Self::StorageCommon,
     ) -> VidResult<Vec<u8>>;
 }

--- a/primitives/src/vid/mod.rs
+++ b/primitives/src/vid/mod.rs
@@ -50,7 +50,7 @@ pub trait VidScheme {
     type Share: Clone + Debug + Eq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Common data sent to all storage nodes.
-    type StorageCommon: CanonicalSerialize + CanonicalDeserialize + Clone + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
+    type Common: CanonicalSerialize + CanonicalDeserialize + Clone + Eq + PartialEq + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Compute a payload commitment.
     fn commitment_only(&self, payload: &[u8]) -> VidResult<Self::Commit>;
@@ -59,7 +59,7 @@ pub trait VidScheme {
     fn dispersal_data(
         &self,
         payload: &[u8],
-    ) -> VidResult<(Vec<Self::Share>, Self::StorageCommon, Self::Commit)>;
+    ) -> VidResult<(Vec<Self::Share>, Self::Common, Self::Commit)>;
 
     /// Verify a share. Used by both storage node and retrieval client.
     /// Why is return type a nested `Result`? See <https://sled.rs/errors>
@@ -67,17 +67,10 @@ pub trait VidScheme {
     /// - VidResult::Err in case of actual error
     /// - VidResult::Ok(Result::Err) if verification fails
     /// - VidResult::Ok(Result::Ok) if verification succeeds
-    fn verify_share(
-        &self,
-        share: &Self::Share,
-        common: &Self::StorageCommon,
-    ) -> VidResult<Result<(), ()>>;
+    fn verify_share(&self, share: &Self::Share, common: &Self::Common)
+        -> VidResult<Result<(), ()>>;
 
     /// Recover payload from shares.
     /// Do not verify shares or check recovered payload against anything.
-    fn recover_payload(
-        &self,
-        shares: &[Self::Share],
-        common: &Self::StorageCommon,
-    ) -> VidResult<Vec<u8>>;
+    fn recover_payload(&self, shares: &[Self::Share], common: &Self::Common) -> VidResult<Vec<u8>>;
 }

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -32,7 +32,7 @@ pub fn round_trip<V, R>(
             let mut bytes_random = vec![0u8; len];
             rng.fill_bytes(&mut bytes_random);
 
-            let disperse = vid.dispersal_data(&bytes_random).unwrap();
+            let disperse = vid.disperse(&bytes_random).unwrap();
             let (mut shares, common) = (disperse.shares, disperse.common);
             assert_eq!(shares.len(), num_storage_nodes);
 

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -32,7 +32,7 @@ pub fn round_trip<V, R>(
             let mut bytes_random = vec![0u8; len];
             rng.fill_bytes(&mut bytes_random);
 
-            let (mut shares, common) = vid.dispersal_data(&bytes_random).unwrap();
+            let (mut shares, common, _commit) = vid.dispersal_data(&bytes_random).unwrap();
             assert_eq!(shares.len(), num_storage_nodes);
 
             for share in shares.iter() {

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -32,7 +32,8 @@ pub fn round_trip<V, R>(
             let mut bytes_random = vec![0u8; len];
             rng.fill_bytes(&mut bytes_random);
 
-            let (mut shares, common, _commit) = vid.dispersal_data(&bytes_random).unwrap();
+            let disperse = vid.dispersal_data(&bytes_random).unwrap();
+            let (mut shares, common) = (disperse.shares, disperse.common);
             assert_eq!(shares.len(), num_storage_nodes);
 
             for share in shares.iter() {

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -33,8 +33,9 @@ pub fn round_trip<V, R>(
             rng.fill_bytes(&mut bytes_random);
 
             let disperse = vid.disperse(&bytes_random).unwrap();
-            let (mut shares, common) = (disperse.shares, disperse.common);
+            let (mut shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
             assert_eq!(shares.len(), num_storage_nodes);
+            assert_eq!(commit, vid.commit_only(&bytes_random).unwrap());
 
             for share in shares.iter() {
                 vid.verify_share(share, &common).unwrap().unwrap();


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #369 

- With this addition of the payload commitment to the return value of `disperse`, the return type would become a 3-tuple. This is unruly and clippy complained about type complexity when I tried it. (See fc4548ca1d0799df5179ee0668d26f0f4d178191.) So instead I created a new struct `VidDisperse` to aggregate these values in a more legibile return type and give them names.
- I took this opportunity to shorten/clarify some names.
- Bizarre behaviour from the compiler forced me to add an unnecessary `as` cast: https://github.com/EspressoSystems/jellyfish/blob/ddea9733fc3739efc99d10c00cb5d25d917edc0a/primitives/src/vid/advz.rs#L341-L346

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
