### PR TITLE
refactor: add some trait bounds to SignatureSchemes traits

### DIFF
--- a/primitives/src/signatures/bls_over_bls12381.rs
+++ b/primitives/src/signatures/bls_over_bls12381.rs
@@ -323,6 +323,7 @@ impl Valid for BLSSignature {
 
 /// BLS signature scheme. Wrapping around structs from the `blst` crate.
 /// See [module-level documentation](self) for example usage.
+#[derive(Clone, Debug)]
 pub struct BLSSignatureScheme;
 
 impl SignatureScheme for BLSSignatureScheme {

--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -68,7 +68,7 @@ use tagged_base64::tagged;
 use zeroize::Zeroize;
 
 /// BLS signature scheme.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct BLSOverBN254CurveSignatureScheme;
 
 impl SignatureScheme for BLSOverBN254CurveSignatureScheme {

--- a/primitives/src/signatures/mod.rs
+++ b/primitives/src/signatures/mod.rs
@@ -16,7 +16,7 @@ use zeroize::Zeroize;
 // A signature scheme is associated with a hash function H that is
 // to be used for challenge generation.
 // FIXME: update H bound once hash-api is merged.
-pub trait SignatureScheme {
+pub trait SignatureScheme: Clone + Send + Sync + 'static {
     /// Ciphersuite Identifier
     const CS_ID: &'static str;
 
@@ -92,8 +92,10 @@ pub trait SignatureScheme {
 
 /// Trait for aggregatable signatures.
 /// TODO: generic over hash functions
+// NOTE: we +Debug here instead of on `SignatureSchemes` because `schnorr <P:
+// CurveConfig>` doesn't impl Debug
 pub trait AggregateableSignatureSchemes:
-    SignatureScheme + Serialize + for<'a> Deserialize<'a>
+    SignatureScheme + Serialize + for<'a> Deserialize<'a> + Debug
 {
     /// Aggregate multiple signatures into a single signature
     /// The list of public keys is also in the input as some aggregate signature

--- a/primitives/src/signatures/schnorr.rs
+++ b/primitives/src/signatures/schnorr.rs
@@ -35,6 +35,7 @@ use tagged_base64::tagged;
 use zeroize::Zeroize;
 
 /// Schnorr signature scheme.
+#[derive(Debug, PartialEq, Clone)]
 pub struct SchnorrSignatureScheme<P> {
     curve_param: PhantomData<P>,
 }
@@ -42,7 +43,7 @@ pub struct SchnorrSignatureScheme<P> {
 impl<F, P> SignatureScheme for SchnorrSignatureScheme<P>
 where
     F: RescueParameter,
-    P: Config<BaseField = F>,
+    P: Config<BaseField = F> + Clone,
 {
     const CS_ID: &'static str = CS_ID_SCHNORR;
 


### PR DESCRIPTION
## Description

These trait bounds are needed in some downstream libraries [here](https://github.com/EspressoSystems/hotshot-qc-prover/blob/main/src/circuit/vars.rs#L16-L27). 

Even though the downstream usage might be changed later, I don't find it unreasonable to add these trait bounds anyway. 