### PR TITLE
test: Expose more internal functions for test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["plonk", "primitives", "relation", "utilities"]
+resolver = "2"
 
 [workspace.package]
 version = "0.4.0-pre.0"

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -66,7 +66,7 @@ std = [
     "rand_chacha/std",
     "sha3/std",
 ]
-test_apis = [] # exposing apis for testing purpose
+test-apis = [] # exposing apis for testing purpose
 parallel = [
     "ark-ff/parallel",
     "ark-ec/parallel",

--- a/plonk/src/lib.rs
+++ b/plonk/src/lib.rs
@@ -23,5 +23,5 @@ pub mod transcript;
 
 pub use jf_relation::PlonkType;
 
-#[cfg(feature = "test_apis")]
+#[cfg(feature = "test-apis")]
 pub mod testing_apis;

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -60,26 +60,26 @@ pub type OpenKey<E> = UnivariateVerifierParam<E>;
 #[derivative(PartialEq, Hash(bound = "E:Pairing"))]
 pub struct Proof<E: Pairing> {
     /// Wire witness polynomials commitments.
-    pub(crate) wires_poly_comms: Vec<Commitment<E>>,
+    pub wires_poly_comms: Vec<Commitment<E>>,
 
     /// The polynomial commitment for the wire permutation argument.
-    pub(crate) prod_perm_poly_comm: Commitment<E>,
+    pub prod_perm_poly_comm: Commitment<E>,
 
     /// Splitted quotient polynomial commitments.
-    pub(crate) split_quot_poly_comms: Vec<Commitment<E>>,
+    pub split_quot_poly_comms: Vec<Commitment<E>>,
 
     /// (Aggregated) proof of evaluations at challenge point `zeta`.
-    pub(crate) opening_proof: Commitment<E>,
+    pub opening_proof: Commitment<E>,
 
     /// (Aggregated) proof of evaluation at challenge point `zeta * g` where `g`
     /// is the root of unity.
-    pub(crate) shifted_opening_proof: Commitment<E>,
+    pub shifted_opening_proof: Commitment<E>,
 
     /// Polynomial evaluations.
-    pub(crate) poly_evals: ProofEvaluations<E::ScalarField>,
+    pub poly_evals: ProofEvaluations<E::ScalarField>,
 
     /// The partial proof for Plookup argument
-    pub(crate) plookup_proof: Option<PlookupProof<E>>,
+    pub plookup_proof: Option<PlookupProof<E>>,
 }
 
 impl<E, P> TryFrom<Vec<E::BaseField>> for Proof<E>
@@ -402,14 +402,14 @@ impl<E: Pairing> BatchProof<E> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 pub struct ProofEvaluations<F: Field> {
     /// Wire witness polynomials evaluations at point `zeta`.
-    pub(crate) wires_evals: Vec<F>,
+    pub wires_evals: Vec<F>,
 
     /// Extended permutation (sigma) polynomials evaluations at point `zeta`.
     /// We do not include the last sigma polynomial evaluation.
-    pub(crate) wire_sigma_evals: Vec<F>,
+    pub wire_sigma_evals: Vec<F>,
 
     /// Permutation product polynomial evaluation at point `zeta * g`.
-    pub(crate) perm_next_eval: F,
+    pub perm_next_eval: F,
 }
 
 impl<F: Field> TryFrom<Vec<F>> for ProofEvaluations<F> {

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -655,29 +655,29 @@ impl<E: Pairing> ProvingKey<E> {
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifyingKey<E: Pairing> {
     /// The size of the evaluation domain. Should be a power of two.
-    pub(crate) domain_size: usize,
+    pub domain_size: usize,
 
     /// The number of public inputs.
-    pub(crate) num_inputs: usize,
+    pub num_inputs: usize,
 
     /// The permutation polynomial commitments. The commitments are not hiding.
-    pub(crate) sigma_comms: Vec<Commitment<E>>,
+    pub sigma_comms: Vec<Commitment<E>>,
 
     /// The selector polynomial commitments. The commitments are not hiding.
-    pub(crate) selector_comms: Vec<Commitment<E>>,
+    pub selector_comms: Vec<Commitment<E>>,
 
     /// The constants K0, ..., K_num_wire_types that ensure wire subsets are
     /// disjoint.
-    pub(crate) k: Vec<E::ScalarField>,
+    pub k: Vec<E::ScalarField>,
 
     /// KZG PCS opening key.
     pub open_key: OpenKey<E>,
 
     /// A flag indicating whether the key is a merged key.
-    pub(crate) is_merged: bool,
+    pub is_merged: bool,
 
     /// Plookup verifying key, None if not support lookup.
-    pub(crate) plookup_vk: Option<PlookupVerifyingKey<E>>,
+    pub plookup_vk: Option<PlookupVerifyingKey<E>>,
 }
 
 impl<E, F, P1, P2> From<VerifyingKey<E>> for Vec<E::BaseField>

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -816,14 +816,14 @@ where
 
     /// Evaluate vanishing polynomial at point `zeta`
     #[inline]
-    fn evaluate_vanishing_poly(&self, zeta: &E::ScalarField) -> E::ScalarField {
+    pub(crate) fn evaluate_vanishing_poly(&self, zeta: &E::ScalarField) -> E::ScalarField {
         self.domain.evaluate_vanishing_polynomial(*zeta)
     }
 
     /// Evaluate the first and the last lagrange polynomial at point `zeta`
     /// given the vanishing polynomial evaluation `vanish_eval`.
     #[inline]
-    fn evaluate_lagrange_1_and_n(
+    pub(crate) fn evaluate_lagrange_1_and_n(
         &self,
         zeta: &E::ScalarField,
         vanish_eval: &E::ScalarField,
@@ -892,7 +892,7 @@ where
     /// * pub_input[l/2+i]
     ///
     /// TODO: reuse the lagrange values
-    fn evaluate_pi_poly(
+    pub(crate) fn evaluate_pi_poly(
         &self,
         pub_input: &[E::ScalarField],
         z: &E::ScalarField,

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -222,6 +222,24 @@ where
         .into())
     }
 
+    /// Compute some intermediate polynomial evaluations used to further compute
+    /// `PcsInfo`.
+    ///
+    /// Returns:
+    /// `(vanish_eval, lagrange_1_eval, pi_eval)` on challenge point `zeta`.
+    pub fn compute_poly_evals_for_pcs_info(
+        &self,
+        zeta: &E::ScalarField,
+        public_input: &[E::ScalarField],
+    ) -> Result<(E::ScalarField, E::ScalarField, E::ScalarField), PlonkError> {
+        let verifier: verifier::Verifier<E> = (*self).clone().into();
+
+        let vanish_eval = verifier.evaluate_vanishing_poly(zeta);
+        let (lagrange_1_eval, _) = verifier.evaluate_lagrange_1_and_n(zeta, &vanish_eval);
+        let pi_eval = verifier.evaluate_pi_poly(public_input, zeta, &vanish_eval, false)?;
+        Ok((vanish_eval, lagrange_1_eval, pi_eval))
+    }
+
     /// Compute the constant term of the linearization polynomial:
     /// For each instance j:
     ///

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -12,12 +12,13 @@
 #![allow(missing_docs)]
 
 use crate::{
+    constants::KECCAK256_STATE_SIZE,
     errors::PlonkError,
     proof_system::{
         structs::{self, BatchProof, PlookupProof, ProofEvaluations, VerifyingKey},
         verifier,
     },
-    transcript::PlonkTranscript,
+    transcript::{PlonkTranscript, SolidityTranscript},
 };
 use ark_ec::{
     pairing::Pairing,
@@ -363,5 +364,18 @@ where
             plookup_proofs_vec,
             buffer_v_and_uv_basis,
         )
+    }
+}
+
+/// exposing the internal states for testing purposes
+impl SolidityTranscript {
+    /// Create a new transcript from specific internal states.
+    pub fn from_internal(transcript: Vec<u8>, state: [u8; KECCAK256_STATE_SIZE]) -> Self {
+        Self { transcript, state }
+    }
+
+    /// Returns the internal states
+    pub fn internal(&self) -> (Vec<u8>, [u8; KECCAK256_STATE_SIZE]) {
+        (self.transcript.clone(), self.state.clone())
     }
 }

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -151,7 +151,8 @@ impl<E: Pairing> From<verifier::PcsInfo<E>> for PcsInfo<E> {
 /// A wrapper of crate::proof_system::verifier::Verifier
 #[derive(Debug, Clone)]
 pub struct Verifier<E: Pairing> {
-    pub(crate) domain: Radix2EvaluationDomain<E::ScalarField>,
+    /// Evaluation domain
+    pub domain: Radix2EvaluationDomain<E::ScalarField>,
 }
 
 impl<E: Pairing> From<Verifier<E>> for verifier::Verifier<E> {

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -228,18 +228,28 @@ where
     /// `PcsInfo`.
     ///
     /// Returns:
-    /// `(vanish_eval, lagrange_1_eval, pi_eval)` on challenge point `zeta`.
+    /// `(vanish_eval, lagrange_1_eval, lagrange_n_eval, pi_eval)` on challenge
+    /// point `zeta`.
     pub fn compute_poly_evals_for_pcs_info(
         &self,
         zeta: &E::ScalarField,
         public_input: &[E::ScalarField],
-    ) -> Result<(E::ScalarField, E::ScalarField, E::ScalarField), PlonkError> {
+    ) -> Result<
+        (
+            E::ScalarField,
+            E::ScalarField,
+            E::ScalarField,
+            E::ScalarField,
+        ),
+        PlonkError,
+    > {
         let verifier: verifier::Verifier<E> = (*self).clone().into();
 
         let vanish_eval = verifier.evaluate_vanishing_poly(zeta);
-        let (lagrange_1_eval, _) = verifier.evaluate_lagrange_1_and_n(zeta, &vanish_eval);
+        let (lagrange_1_eval, lagrange_n_eval) =
+            verifier.evaluate_lagrange_1_and_n(zeta, &vanish_eval);
         let pi_eval = verifier.evaluate_pi_poly(public_input, zeta, &vanish_eval, false)?;
-        Ok((vanish_eval, lagrange_1_eval, pi_eval))
+        Ok((vanish_eval, lagrange_1_eval, lagrange_n_eval, pi_eval))
     }
 
     /// Compute the constant term of the linearization polynomial:

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -5,7 +5,7 @@
 // along with the Jellyfish library. If not, see <https://mit-license.org/>.
 
 //! This file implements various wrappers of internal functions and structs.
-//! It exposes those APIs under `test_apis` feature.
+//! It exposes those APIs under `test-apis` feature.
 //! The functions and structs in this file should not be used for other
 //! purposes.
 

--- a/plonk/src/transcript/solidity.rs
+++ b/plonk/src/transcript/solidity.rs
@@ -29,8 +29,8 @@ use sha3::{Digest, Keccak256};
 /// 2. challenge = state\[0\]
 /// 3. transcript = vec!\[challenge\]
 pub struct SolidityTranscript {
-    transcript: Vec<u8>,
-    state: [u8; KECCAK256_STATE_SIZE], // 64 bytes state size
+    pub(crate) transcript: Vec<u8>,
+    pub(crate) state: [u8; KECCAK256_STATE_SIZE], // 64 bytes state size
 }
 
 impl<F> PlonkTranscript<F> for SolidityTranscript {


### PR DESCRIPTION
These are the changes I made during writing tests for https://github.com/EspressoSystems/espresso-sequencer/pull/722, Most changes are under `test-api`, so should be safe