### PR TITLE
chore: Cargo shell script to support +nightly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,8 @@
         cargo-with-nightly = pkgs.writeShellScriptBin "cargo" ''
           if [[ "$1" == "+nightly" ]]; then
             shift
-            exec env PATH=${nightlyToolchain}/bin:$PATH cargo "$@"
+            # Prepend nightly toolchain directory containing cargo, rustc, etc.
+            exec env PATH="${nightlyToolchain}/bin:$PATH" cargo "$@"
           fi
           exec ${stableToolchain}/bin/cargo "$@"
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,10 @@
   inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
   inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, flake-utils, flake-compat, rust-overlay, pre-commit-hooks, ... }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, pre-commit-hooks, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        overlays = [ 
+        overlays = [
           (import rust-overlay)
         ];
         pkgs = import nixpkgs { inherit system overlays; };
@@ -30,8 +30,17 @@
 
         stableToolchain = pkgs.rust-bin.stable.latest.minimal.override {
           extensions = [ "clippy" "llvm-tools-preview" "rust-src" ];
-          targets = ["wasm32-unknown-unknown"];
+          targets = [ "wasm32-unknown-unknown" ];
         };
+        # A script that calls nightly cargo if invoked with `+nightly`
+        # as the first argument, otherwise it calls stable cargo.
+        cargo-with-nightly = pkgs.writeShellScriptBin "cargo" ''
+          if [[ "$1" == "+nightly" ]]; then
+            shift
+            exec env PATH=${nightlyToolchain}/bin:$PATH cargo "$@"
+          fi
+          exec ${stableToolchain}/bin/cargo "$@"
+        '';
       in with pkgs;
       {
         check = {
@@ -73,6 +82,7 @@
             pkg-config
             git
 
+            cargo-with-nightly
             stableToolchain
             nightlyToolchain
             cargo-sort


### PR DESCRIPTION
This might be more convenient than having a separate devShell for
nightly tasks (which still wouldn't support the `+nightly` argument).

It works for me to run `cargo test` and `scripts/run_tests.sh`.

Not familiar with the repo so don't know if other workflows might break.