### PR TITLE
perf: naive parallel implementation for `multi_open_rou_proofs`

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -123,7 +123,7 @@ print-trace = ["ark-std/print-trace"]
 kzg-print-trace = [
         "print-trace",
 ] # leave disabled to reduce pollution in downstream users of KZG (such as VID)
-no-fk23 = [
+naive-kzg-multi-open = [
         "parallel",
 ] # enable to use an alternate (parallel) impl of multi_open_rou_proofs()
 parallel = [

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -123,6 +123,9 @@ print-trace = ["ark-std/print-trace"]
 kzg-print-trace = [
         "print-trace",
 ] # leave disabled to reduce pollution in downstream users of KZG (such as VID)
+no-fk23 = [
+        "parallel",
+] # enable to use an alternate (parallel) impl of multi_open_rou_proofs()
 parallel = [
         "ark-ff/parallel",
         "ark-ec/parallel",

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -148,12 +148,18 @@ impl<E: Pairing> PolynomialCommitmentScheme for UnivariateKzgPCS<E> {
         polynomial: &Self::Polynomial,
         point: &Self::Point,
     ) -> Result<(Self::Proof, Self::Evaluation), PCSError> {
+        #[cfg(feature = "kzg-print-trace")]
         let open_time =
             start_timer!(|| format!("Opening polynomial of degree {}", polynomial.degree()));
+
         let divisor = Self::Polynomial::from_coefficients_vec(vec![-*point, E::ScalarField::one()]);
 
+        #[cfg(feature = "kzg-print-trace")]
         let witness_time = start_timer!(|| "Computing witness polynomial");
+
         let witness_polynomial = polynomial / &divisor;
+
+        #[cfg(feature = "kzg-print-trace")]
         end_timer!(witness_time);
 
         let (num_leading_zeros, witness_coeffs) =
@@ -169,7 +175,9 @@ impl<E: Pairing> PolynomialCommitmentScheme for UnivariateKzgPCS<E> {
         // https://github.com/EspressoSystems/jellyfish/issues/426
         let eval = polynomial.evaluate(point);
 
+        #[cfg(feature = "kzg-print-trace")]
         end_timer!(open_time);
+
         Ok((Self::Proof { proof }, eval))
     }
 

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -332,7 +332,7 @@ impl<E: Pairing> UnivariatePCS for UnivariateKzgPCS<E> {
         num_points: usize,
         domain: &Radix2EvaluationDomain<Self::Evaluation>,
     ) -> Result<Vec<Self::Proof>, PCSError> {
-        #[cfg(feature = "no-fk23")]
+        #[cfg(feature = "naive-kzg-multi-open")]
         {
             use ark_poly::EvaluationDomain;
             let prover_param = prover_param.borrow(); // needed for Send + Sync
@@ -358,7 +358,7 @@ impl<E: Pairing> UnivariatePCS for UnivariateKzgPCS<E> {
                 .collect()
         }
 
-        #[cfg(not(feature = "no-fk23"))]
+        #[cfg(not(feature = "naive-kzg-multi-open"))]
         {
             let mut h_poly = Self::compute_h_poly_in_fk23(prover_param, &polynomial.coeffs)?;
             let proofs: Vec<_> = h_poly

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -18,8 +18,7 @@ use ark_ec::{
 };
 use ark_ff::{FftField, Field, PrimeField};
 use ark_poly::{
-    univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Polynomial,
-    Radix2EvaluationDomain,
+    univariate::DensePolynomial, DenseUVPolynomial, Polynomial, Radix2EvaluationDomain,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
@@ -335,6 +334,7 @@ impl<E: Pairing> UnivariatePCS for UnivariateKzgPCS<E> {
     ) -> Result<Vec<Self::Proof>, PCSError> {
         #[cfg(feature = "parallel")]
         {
+            use ark_poly::EvaluationDomain;
             let prover_param = prover_param.borrow(); // needed for Send + Sync
 
             // We prefer use `.par_bridge()` instead of

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -332,7 +332,7 @@ impl<E: Pairing> UnivariatePCS for UnivariateKzgPCS<E> {
         num_points: usize,
         domain: &Radix2EvaluationDomain<Self::Evaluation>,
     ) -> Result<Vec<Self::Proof>, PCSError> {
-        #[cfg(feature = "parallel")]
+        #[cfg(feature = "no-fk23")]
         {
             use ark_poly::EvaluationDomain;
             let prover_param = prover_param.borrow(); // needed for Send + Sync
@@ -358,7 +358,7 @@ impl<E: Pairing> UnivariatePCS for UnivariateKzgPCS<E> {
                 .collect()
         }
 
-        #[cfg(not(feature = "parallel"))]
+        #[cfg(not(feature = "no-fk23"))]
         {
             let mut h_poly = Self::compute_h_poly_in_fk23(prover_param, &polynomial.coeffs)?;
             let proofs: Vec<_> = h_poly

--- a/primitives/src/pcs/univariate_kzg/srs.rs
+++ b/primitives/src/pcs/univariate_kzg/srs.rs
@@ -127,7 +127,8 @@ mod tests {
         rng: &mut R,
         max_degree: usize,
     ) -> Result<UnivariateUniversalParams<E>, PCSError> {
-        let setup_time = start_timer!(|| format!("KZG10::Setup with degree {}", max_degree));
+        let setup_time =
+            start_timer!(|| ark_std::format!("KZG10::Setup with degree {}", max_degree));
         let beta = E::ScalarField::rand(rng);
         let g = E::G1::rand(rng);
         let h = E::G2::rand(rng);


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #427 

- New build feature `no-fk23` to enable a naive parallel implementation of `UnivariateKzgPCS::multi_open_rou_proofs()`.
- Tidy: comment link to issues, timer logs, fix build breaks for various feature combos.

# How to run benchmarks

1. Uncomment the `#[test]` attribute for the `disperse_timer` test in `vid/advz.rs`. (This test is commented out so as to save CI.) https://github.com/EspressoSystems/jellyfish/blob/2f004e2abe566f8cfaaca5b25c66fbfe6920db1e/primitives/src/vid/advz.rs#L642-L644
2. Run test in release mode with (and without) `no-fk23` feature:
```bash
cargo test --release --package jf-primitives --lib --features test-srs,print-trace,no-fk23 -- vid::advz::tests::disperse_timer --exact --nocapture
cargo test --release --package jf-primitives --lib --features test-srs,print-trace -- vid::advz::tests::disperse_timer --exact --nocapture
```

# Edit

Do I need to set another flag to use more threads in these tests?

# Results

Sadly, the naive parallel implementation is slower than FK23: 1.429s vs 1.016s on my local laptop.

## Naive parallel (`no-fk23`):

```
cargo test --release --package jf-primitives --lib --features test-srs,print-trace,no-fk23 -- vid::advz::tests::disperse_timer --exact --nocapture

Start:   KZG10::Setup with degree 256
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................3.662ms
End:     KZG10::Setup with degree 256 ..............................................6.087ms
Start:   VID disperse 1048576 payload bytes to 512 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................46.898ms
··Start:   compute all storage node evals for 133 polynomials of degree 256
··End:     compute all storage node evals for 133 polynomials of degree 256 ........44.984ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................14.011ms
··Start:   compute 133 KZG commitments
··End:     compute 133 KZG commitments .............................................326.505ms
··Start:   compute aggregate proofs for 512 storage nodes
··End:     compute aggregate proofs for 512 storage nodes ..........................993.262ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................2.622ms
End:     VID disperse 1048576 payload bytes to 512 nodes ...........................1.429s
``` 

## FK23

```
cargo test --release --package jf-primitives --lib --features test-srs,print-trace -- vid::advz::tests::disperse_timer --exact --nocapture

Start:   KZG10::Setup with degree 256
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................3.911ms
End:     KZG10::Setup with degree 256 ..............................................6.634ms
Start:   VID disperse 1048576 payload bytes to 512 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................49.238ms
··Start:   compute all storage node evals for 133 polynomials of degree 256
··End:     compute all storage node evals for 133 polynomials of degree 256 ........46.323ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................13.339ms
··Start:   compute 133 KZG commitments
··End:     compute 133 KZG commitments .............................................323.645ms
··Start:   compute aggregate proofs for 512 storage nodes
··End:     compute aggregate proofs for 512 storage nodes ..........................579.888ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................1.799ms
End:     VID disperse 1048576 payload bytes to 512 nodes ...........................1.016s
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
