### PR TITLE
feat: ADVZ PayloadProver support requests that span multiple polynomial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and follow [semantic versioning](https://semver.org/) for our releases.
 - [#381](https://github.com/EspressoSystems/jellyfish/pull/381) VID take iterator instead of slice
 - [#389](https://github.com/EspressoSystems/jellyfish/pull/389) Hello-world namespace support for ADVZ VID scheme
 - [#406](https://github.com/EspressoSystems/jellyfish/pull/406) Implement KZG multiproof
+- [#438](https://github.com/EspressoSystems/jellyfish/pull/438) ADVZ PayloadProver support requests that span multiple polynomial
 
 ### Changed
 

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -89,6 +89,8 @@ where
         let range_elem_byte = self.range_elem_to_byte_clamped(&range_elem, payload.len());
         let range_poly_byte = self.range_poly_to_byte_clamped(&range_poly, payload.len());
         let offset_elem = self.offset_poly_to_elem(range_poly.start, range_elem.start);
+        let final_points_range_end =
+            self.final_poly_points_range_end(range_elem.len(), offset_elem);
 
         // prepare list of input points
         // perf: we might not need all these points
@@ -107,7 +109,7 @@ where
                 start: if i == 0 { offset_elem } else { 0 },
                 // final polynomial? stop at the end of the proof range
                 end: if i == range_poly.len() - 1 {
-                    (range_elem.len() + offset_elem - 1) % points.len() + 1
+                    final_points_range_end
                 } else {
                     points.len()
                 },
@@ -158,6 +160,8 @@ where
         let range_elem = self.range_byte_to_elem(&proof.chunk_range);
         let range_poly = self.range_elem_to_poly(&range_elem);
         let offset_elem = self.offset_poly_to_elem(range_poly.start, range_elem.start);
+        let final_points_range_end =
+            self.final_poly_points_range_end(range_elem.len(), offset_elem);
 
         // prepare list of input points
         // perf: we might not need all these points
@@ -174,7 +178,7 @@ where
                 start: if i == 0 { offset_elem } else { 0 },
                 // final polynomial? stop at the end of the proof range
                 end: if i == range_poly.len() - 1 {
-                    (range_elem.len() + offset_elem - 1) % points.len() + 1
+                    final_points_range_end
                 } else {
                     points.len()
                 },
@@ -319,6 +323,9 @@ where
             self.payload_chunk_size * elem_byte_capacity::<KzgEval<E>>(),
         );
         range_elem_start - index_coarsen(start_poly_byte, elem_byte_capacity::<KzgEval<E>>())
+    }
+    fn final_poly_points_range_end(&self, range_elem_len: usize, offset_elem: usize) -> usize {
+        (range_elem_len + offset_elem - 1) % self.payload_chunk_size + 1
     }
 
     // arg check helpers

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -509,9 +509,32 @@ mod tests {
 
                     let large_range_proof: LargeRangeProof<_> =
                         advz.payload_proof(&payload, range.clone()).unwrap();
-                    advz.payload_verify(stmt, &large_range_proof)
+                    advz.payload_verify(stmt.clone(), &large_range_proof)
                         .unwrap()
                         .unwrap();
+
+                    // test wrong proofs
+                    let stmt_corrupted = Statement {
+                        // corrupt the payload subslice by adding 1 to each byte
+                        payload_subslice: &stmt
+                            .payload_subslice
+                            .iter()
+                            .cloned()
+                            .map(|b| b.wrapping_add(1))
+                            .collect::<Vec<_>>(),
+                        ..stmt
+                    };
+                    advz.payload_verify(stmt_corrupted.clone(), &small_range_proof)
+                        .unwrap()
+                        .unwrap_err();
+                    advz.payload_verify(stmt_corrupted, &large_range_proof)
+                        .unwrap()
+                        .unwrap_err();
+
+                    // TODO more tests for bad proofs, eg:
+                    // - valid proof, different range
+                    // - corrupt proof
+                    // - etc
                 }
             }
         }

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -138,7 +138,6 @@ where
         Self::check_common_commit_consistency(stmt.common, stmt.commit)?;
 
         // prepare list of data elems
-        // TODO don't collect
         let data_elems: Vec<_> = bytes_to_field::<_, KzgEval<E>>(
             proof
                 .prefix_bytes


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #424 

Naive implementation:
- `SmallRangeProof`: concatenate individual KZG proofs from multiple polynomials, do not aggregate
- `LargeRangeProof`: rebuild and verify multiple KZG commitments. There's not much more we could do to improve here. But verification inside a smart contract is now more complex because it might need to compute multiple KZG commitments instead of one.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
