### PR TITLE
Parallel optimizations for FK23 and multi-openings

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -123,9 +123,6 @@ print-trace = ["ark-std/print-trace"]
 kzg-print-trace = [
         "print-trace",
 ] # leave disabled to reduce pollution in downstream users of KZG (such as VID)
-naive-kzg-multi-open = [
-        "parallel",
-] # enable to use an alternate (parallel) impl of multi_open_rou_proofs()
 parallel = [
         "ark-ff/parallel",
         "ark-ec/parallel",
@@ -134,3 +131,4 @@ parallel = [
         "rayon",
 ]
 test-srs = []
+seq-fk-23 = [] # FK23 without parallelism


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #431 

**Two optimizations:**
1. Use the naive O(n^2) algorithm to compute h_poly, but with parallelism.
2. Parallelize the opening proofs generations: if `|poly_deg|=n` and the number of opening points is `k > n`, then we split them into `k/n` parallel parts, each with size `n`. This is only useful when the polynomial degree much less than the number of validators. 

**Performance:** (Note optimization 1 has small effect in the below experiment, because k/n = 2 only)

With parallelization:
```
Start:   KZG10::Setup with prover degree 256 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................2.456ms
End:     KZG10::Setup with prover degree 256 and verifier degree 1 .................4.544ms
Start:   VID disperse 1048576 payload bytes to 512 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................30.513ms
··Start:   compute all storage node evals for 133 polynomials of degree 256
··End:     compute all storage node evals for 133 polynomials of degree 256 ........37.066ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................7.542ms
··Start:   compute 133 KZG commitments
··End:     compute 133 KZG commitments .............................................171.822ms
··Start:   compute aggregate proofs for 512 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................123.122ms
····Start:   gen eval proofs with parallel_factor 2 and num_points 512
····End:     gen eval proofs with parallel_factor 2 and num_points 512 .............81.611ms
··End:     compute aggregate proofs for 512 storage nodes ..........................208.781ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................754.000µs
End:     VID disperse 1048576 payload bytes to 512 nodes ...........................457.420ms
```

No parallelization:
```
Start:   KZG10::Setup with prover degree 256 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................2.412ms
End:     KZG10::Setup with prover degree 256 and verifier degree 1 .................4.735ms
Start:   VID disperse 1048576 payload bytes to 512 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................44.808ms
··Start:   compute all storage node evals for 133 polynomials of degree 256
··End:     compute all storage node evals for 133 polynomials of degree 256 ........47.912ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................7.796ms
··Start:   compute 133 KZG commitments
··End:     compute 133 KZG commitments .............................................150.323ms
··Start:   compute aggregate proofs for 512 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................274.174ms
····Start:   gen eval proofs
····End:     gen eval proofs .......................................................95.086ms
··End:     compute aggregate proofs for 512 storage nodes ..........................369.306ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................884.125µs
End:     VID disperse 1048576 payload bytes to 512 nodes ...........................622.037ms
```

---

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
