### PR TITLE
feat: VID API tweaks, plus optimization for ADVZ disperse

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -35,6 +35,9 @@ derivative = { version = "2", features = ["use_core"] }
 digest = { version = "0.10.1", default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2.3", default-features = false }
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.0" }
+generic-array = { version = "0", features = [
+        "serde",
+] } # not a direct dependency, but we need serde
 hashbrown = "0.13.1"
 itertools = { workspace = true, features = ["use_alloc"] }
 jf-relation = { path = "../relation", default-features = false }

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -6,10 +6,9 @@
 
 //! Trait and implementation for a Verifiable Information Retrieval (VID).
 /// See <https://arxiv.org/abs/2111.12323> section 1.3--1.4 for intro to VID semantics.
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{error::Error, fmt::Debug, hash::Hash, string::String, vec::Vec};
 use displaydoc::Display;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// VID: Verifiable Information Dispersal
 pub trait VidScheme {
@@ -20,14 +19,7 @@ pub trait VidScheme {
     type Share: Clone + Debug + Eq + PartialEq + Hash + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Common data sent to all storage nodes.
-    type Common: CanonicalSerialize
-        + CanonicalDeserialize
-        + Clone
-        + Debug
-        + Eq
-        + PartialEq
-        + Hash
-        + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
+    type Common: CommonBounds;
 
     /// Compute a payload commitment
     fn commit_only<B>(&self, payload: B) -> VidResult<Self::Commit>
@@ -90,8 +82,7 @@ pub struct VidDisperse<V: VidScheme + ?Sized> {
 
 /// Trait for [`VidScheme::Common`].
 pub trait CommonBounds:
-    CanonicalSerialize + CanonicalDeserialize + Clone + Debug + Eq + PartialEq + Hash + Sync
-// TODO serde instead of canonical
+    Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync
 {
     /// Get the payload byte length.
     fn payload_byte_len(&self) -> usize;

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -13,10 +13,10 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// VID: Verifiable Information Dispersal
 pub trait VidScheme {
     /// Payload commitment.
-    type Commit: Clone + Debug + Eq + PartialEq + Hash + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
+    type Commit: Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Share-specific data sent to a storage node.
-    type Share: Clone + Debug + Eq + PartialEq + Hash + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
+    type Share: Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Common data sent to all storage nodes.
     type Common: CommonBounds;

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -84,11 +84,21 @@ pub struct VidDisperse<V: VidScheme + ?Sized> {
     pub commit: V::Commit,
 }
 
-/// [`VidScheme::Common`] could impl this trait to allow users to get the block
+/// [`VidScheme::Common`] could impl this trait to allow users to get the
 /// payload byte length.
 pub trait LengthGetter {
     /// Get the payload byte length.
     fn get_payload_byte_len(&self) -> usize;
+}
+
+/// [`VidScheme::Common`] could impl this trait to allow users to check
+/// consistency against a payload commitment.
+pub trait CommitChecker<V>
+where
+    V: VidScheme<Common = Self>,
+{
+    /// Check consistency with a payload commitment.
+    fn is_consistent(&self, commit: &V::Commit) -> VidResult<()>;
 }
 
 pub mod payload_prover;

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -50,6 +50,9 @@ pub trait VidScheme {
 
     /// Check that a [`VidScheme::Common`] is consistent with a
     /// [`VidScheme::Commit`].
+    ///
+    /// TODO conform to nested result pattern like [`VidScheme::verify_share`].
+    /// Unfortunately, `VidResult<()>` is more user-friently.
     fn is_consistent(commit: &Self::Commit, common: &Self::Common) -> VidResult<()>;
 }
 

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -84,6 +84,13 @@ pub struct VidDisperse<V: VidScheme + ?Sized> {
     pub commit: V::Commit,
 }
 
+/// [`VidScheme::Common`] could impl this trait to allow users to get the block
+/// payload byte length.
+pub trait LengthGetter {
+    /// Get the payload byte length.
+    fn get_payload_byte_len(&self) -> usize;
+}
+
 pub mod payload_prover;
 
 pub mod advz; // instantiation of `VidScheme`

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -55,6 +55,10 @@ pub trait VidScheme {
     /// Recover payload from shares.
     /// Do not verify shares or check recovered payload against anything.
     fn recover_payload(&self, shares: &[Self::Share], common: &Self::Common) -> VidResult<Vec<u8>>;
+
+    /// Check that a [`VidScheme::Common`] is consistent with a
+    /// [`VidScheme::Commit`].
+    fn is_consistent(commit: &Self::Commit, common: &Self::Common) -> VidResult<()>;
 }
 
 /// Convenience struct to aggregate disperse data.
@@ -84,21 +88,13 @@ pub struct VidDisperse<V: VidScheme + ?Sized> {
     pub commit: V::Commit,
 }
 
-/// [`VidScheme::Common`] could impl this trait to allow users to get the
-/// payload byte length.
-pub trait LengthGetter {
-    /// Get the payload byte length.
-    fn get_payload_byte_len(&self) -> usize;
-}
-
-/// [`VidScheme::Common`] could impl this trait to allow users to check
-/// consistency against a payload commitment.
-pub trait CommitChecker<V>
-where
-    V: VidScheme<Common = Self>,
+/// Trait for [`VidScheme::Common`].
+pub trait CommonBounds:
+    CanonicalSerialize + CanonicalDeserialize + Clone + Debug + Eq + PartialEq + Hash + Sync
+// TODO serde instead of canonical
 {
-    /// Check consistency with a payload commitment.
-    fn is_consistent(&self, commit: &V::Commit) -> VidResult<()>;
+    /// Get the payload byte length.
+    fn payload_byte_len(&self) -> usize;
 }
 
 pub mod payload_prover;

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -19,7 +19,7 @@ pub trait VidScheme {
     type Share: Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Common data sent to all storage nodes.
-    type Common: CommonBounds;
+    type Common: Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Compute a payload commitment
     fn commit_only<B>(&self, payload: B) -> VidResult<Self::Commit>
@@ -54,6 +54,9 @@ pub trait VidScheme {
     /// TODO conform to nested result pattern like [`VidScheme::verify_share`].
     /// Unfortunately, `VidResult<()>` is more user-friently.
     fn is_consistent(commit: &Self::Commit, common: &Self::Common) -> VidResult<()>;
+
+    /// Extract the payload byte length data from a [`VidScheme::Common`].
+    fn get_payload_byte_len(common: &Self::Common) -> usize;
 }
 
 /// Convenience struct to aggregate disperse data.
@@ -81,14 +84,6 @@ pub struct VidDisperse<V: VidScheme + ?Sized> {
     pub common: V::Common,
     /// VID payload commitment.
     pub commit: V::Commit,
-}
-
-/// Trait for [`VidScheme::Common`].
-pub trait CommonBounds:
-    Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync
-{
-    /// Get the payload byte length.
-    fn payload_byte_len(&self) -> usize;
 }
 
 pub mod payload_prover;

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -8,7 +8,7 @@
 //!
 //! `advz` named for the authors Alhaddad-Duan-Varia-Zhang.
 
-use super::{vid, CommonBounds, VidDisperse, VidError, VidResult, VidScheme};
+use super::{vid, VidDisperse, VidError, VidResult, VidScheme};
 use crate::{
     alloc::string::ToString,
     merkle_tree::{
@@ -189,16 +189,6 @@ where
     all_evals_digest: KzgEvalsMerkleTreeNode<E, H>,
 
     bytes_len: usize, // TODO don't use usize in serializable struct?
-}
-
-impl<E, H> CommonBounds for Common<E, H>
-where
-    E: Pairing,
-    H: HasherDigest,
-{
-    fn payload_byte_len(&self) -> usize {
-        self.bytes_len
-    }
 }
 
 impl<E, H> VidScheme for Advz<E, H>
@@ -484,6 +474,10 @@ where
             ));
         }
         Ok(())
+    }
+
+    fn get_payload_byte_len(common: &Self::Common) -> usize {
+        common.bytes_len
     }
 }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -318,13 +318,8 @@ where
         end_timer!(all_evals_commit_timer);
 
         let common_timer = start_timer!(|| format!("compute {} KZG commitments", polys.len()));
-        // TODO use batch_commit to parallelize commitments!
         let common = Common {
-            poly_commits: polys
-                .iter()
-                .map(|poly| UnivariateKzgPCS::commit(&self.ck, poly))
-                .collect::<Result<_, _>>()
-                .map_err(vid)?,
+            poly_commits: UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?,
             all_evals_digest: all_evals_commit.commitment().digest(),
             bytes_len: payload_len,
         };

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -8,7 +8,7 @@
 //!
 //! `advz` named for the authors Alhaddad-Duan-Varia-Zhang.
 
-use super::{vid, VidDisperse, VidError, VidResult, VidScheme};
+use super::{vid, LengthGetter, VidDisperse, VidError, VidResult, VidScheme};
 use crate::{
     alloc::string::ToString,
     merkle_tree::{
@@ -191,6 +191,16 @@ where
     bytes_len: usize, // TODO don't use usize in serializable struct?
 }
 
+impl<E, H> LengthGetter for Common<E, H>
+where
+    E: Pairing,
+    H: HasherDigest,
+{
+    fn get_payload_byte_len(&self) -> usize {
+        self.bytes_len
+    }
+}
+
 impl<E, H> VidScheme for Advz<E, H>
 where
     E: Pairing,
@@ -293,6 +303,7 @@ where
         end_timer!(all_evals_commit_timer);
 
         let common_timer = start_timer!(|| format!("compute {} KZG commitments", polys.len()));
+        // TODO use batch_commit to parallelize commitments!
         let common = Common {
             poly_commits: polys
                 .iter()

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -24,7 +24,7 @@ use crate::{
     pcs::prelude::UnivariateKzgPCS,
     vid::{
         payload_prover::{PayloadProver, Statement},
-        vid, VidError,
+        vid, CommitChecker, VidError,
     },
 };
 use anyhow::anyhow;
@@ -329,7 +329,7 @@ where
                 stmt.range.len()
             )));
         }
-        Self::check_common_commit_consistency(stmt.common, stmt.commit)
+        stmt.common.is_consistent(stmt.commit)
     }
 }
 

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -24,7 +24,7 @@ use crate::{
     pcs::prelude::UnivariateKzgPCS,
     vid::{
         payload_prover::{PayloadProver, Statement},
-        vid, CommitChecker, VidError,
+        vid, VidError, VidScheme,
     },
 };
 use anyhow::anyhow;
@@ -329,7 +329,7 @@ where
                 stmt.range.len()
             )));
         }
-        stmt.common.is_consistent(stmt.commit)
+        Self::is_consistent(stmt.commit, stmt.common)
     }
 }
 


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #446 

- New trait `LengthGetter` for #446 
- New trait `CommitChecker` for (unposted issue): we need a way for downstream users to check consistency of a `VidScheme::Common` with its corresponding `VidScheme::Commit`. Previously this functionality was not exposed downstream.
- I snuck in more optimisation in `Advz::disperse`: this PR uses `batch_commit` to compute KZG commitments in parallel inside `disperse`, just like what was done in #448 for `Advz::commit_only`. 20% improvement. See below for benches.

## Seeking feedback

This PR adds 2 traits `LengthGetter`, `CommitChecker` intended for optional impl for `VidScheme::Common` assoc type. Is there a cleaner way to achieve this API without forcing all `VidScheme` impls to provide this functionality?

# Benches for parallel commits in VID disperse

1.135s improve to 933.702ms, ~20% improvement.

## Without parallelism

```
Start:   KZG10::Setup with prover degree 256 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................5.501ms
End:     KZG10::Setup with prover degree 256 and verifier degree 1 .................9.966ms
Start:   VID disperse 1048576 payload bytes to 512 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................72.134ms
··Start:   compute all storage node evals for 133 polynomials of degree 256
··End:     compute all storage node evals for 133 polynomials of degree 256 ........67.207ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................17.804ms
··Start:   compute 133 KZG commitments
··End:     compute 133 KZG commitments .............................................403.771ms
··Start:   compute aggregate proofs for 512 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................394.418ms
····Start:   gen eval proofs with parallel_factor 2 and num_points 512
····End:     gen eval proofs with parallel_factor 2 and num_points 512 .............168.222ms
··End:     compute aggregate proofs for 512 storage nodes ..........................569.742ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................2.789ms
End:     VID disperse 1048576 payload bytes to 512 nodes ...........................1.135s
```

## With parallelism

```
Start:   KZG10::Setup with prover degree 256 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................5.602ms
End:     KZG10::Setup with prover degree 256 and verifier degree 1 .................9.228ms
Start:   VID disperse 1048576 payload bytes to 512 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................58.798ms
··Start:   compute all storage node evals for 133 polynomials of degree 256
··End:     compute all storage node evals for 133 polynomials of degree 256 ........59.525ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................14.439ms
··Start:   compute 133 KZG commitments
····Start:   batch commit 133 polynomials
····End:     batch commit 133 polynomials ..........................................299.367ms
··End:     compute 133 KZG commitments .............................................299.414ms
··Start:   compute aggregate proofs for 512 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................335.750ms
····Start:   gen eval proofs with parallel_factor 2 and num_points 512
····End:     gen eval proofs with parallel_factor 2 and num_points 512 .............154.750ms
··End:     compute aggregate proofs for 512 storage nodes ..........................497.390ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................2.371ms
End:     VID disperse 1048576 payload bytes to 512 nodes ...........................933.702ms
```


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
