### PR TITLE
chore: VidScheme::Commit assoc type support TaggedBase64 conversion

### DIFF
--- a/primitives/src/merkle_tree/hasher.rs
+++ b/primitives/src/merkle_tree/hasher.rs
@@ -50,7 +50,7 @@ use digest::{
     crypto_common::{generic_array::ArrayLength, Output},
     Digest, OutputSizeUser,
 };
-use serde::{Deserialize, Serialize};
+use tagged_base64::tagged;
 use typenum::U3;
 
 /// Merkle tree generic over [`Digest`] hasher `H`.
@@ -161,8 +161,7 @@ where
 }
 
 /// Newtype wrapper for hash output that impls [`NodeValue`](super::NodeValue).
-#[derive(Derivative, Deserialize, Serialize)]
-#[serde(bound = "Output<H>: Serialize + for<'a> Deserialize<'a>")]
+#[derive(Derivative)]
 #[derivative(
     Clone(bound = ""),
     Copy(bound = "<<H as OutputSizeUser>::OutputSize as ArrayLength<u8>>::ArrayType: Copy"),
@@ -174,6 +173,7 @@ where
     PartialEq(bound = ""),
     PartialOrd(bound = "")
 )]
+#[tagged("HASH")]
 pub struct HasherNode<H>(Output<H>)
 where
     H: Digest;

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -6,14 +6,31 @@
 
 //! Trait and implementation for a Verifiable Information Retrieval (VID).
 /// See <https://arxiv.org/abs/2111.12323> section 1.3--1.4 for intro to VID semantics.
-use ark_std::{error::Error, fmt::Debug, hash::Hash, string::String, vec::Vec};
+use ark_std::{
+    error::Error,
+    fmt::{Debug, Display},
+    hash::Hash,
+    string::String,
+    vec::Vec,
+};
 use displaydoc::Display;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tagged_base64::TaggedBase64;
 
 /// VID: Verifiable Information Dispersal
 pub trait VidScheme {
     /// Payload commitment.
-    type Commit: Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
+    type Commit: Clone
+        + Debug
+        + Display
+        + DeserializeOwned
+        + Eq
+        + PartialEq
+        + Hash
+        + Serialize
+        + Sync
+        + for<'a> TryFrom<&'a TaggedBase64>
+        + Into<TaggedBase64>; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Share-specific data sent to a storage node.
     type Share: Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -12,7 +12,7 @@ use super::{vid, VidDisperse, VidError, VidResult, VidScheme};
 use crate::{
     alloc::string::ToString,
     merkle_tree::{
-        hasher::{HasherDigest, HasherMerkleTree},
+        hasher::{HasherDigest, HasherMerkleTree, HasherNode},
         MerkleCommitment, MerkleTreeScheme,
     },
     pcs::{
@@ -198,7 +198,9 @@ where
     E: Pairing,
     H: HasherDigest,
 {
-    type Commit = Output<H>;
+    // use HasherNode<H> instead of Output<H> to easily meet trait bounds
+    type Commit = HasherNode<H>;
+
     type Share = Share<E, H>;
     type Common = Common<E, H>;
 
@@ -552,7 +554,7 @@ where
                 .serialize_uncompressed(&mut hasher)
                 .map_err(vid)?;
         }
-        Ok(hasher.finalize())
+        Ok(hasher.finalize().into())
     }
 }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -100,6 +100,8 @@ where
         num_storage_nodes: usize,
         srs: impl Borrow<KzgSrs<E>>,
     ) -> VidResult<Self> {
+        // TODO support any degree, give multiple shares to nodes if needed
+        // https://github.com/EspressoSystems/jellyfish/issues/393
         if num_storage_nodes < payload_chunk_size {
             return Err(VidError::Argument(format!(
                 "payload_chunk_size {} exceeds num_storage_nodes {}",


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #455 

- `Advz` implementation of `VidScheme` change `Commit` assoc type from `Output<H>` to `HasherNode<H>`. `HasherNode` was originally intended for use in jellyfish's merkle tree implementation. But it also conveniently doubles as a friendly wrapper for the upstream `Output<H>` that provides many more trait impls.
- `#[tagged]` is magic 😮 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
