### PR TITLE
fix: light weight merkle tree didn't forget previously inserted elements

### DIFF
--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -735,7 +735,7 @@ where
                                 value: children[frontier - 1].value(),
                             });
                     }
-                    let increment = children[frontier].extend_internal::<H, Arity>(
+                    let increment = children[frontier].extend_and_forget_internal::<H, Arity>(
                         height - 1,
                         &cur_pos,
                         traversal_path,
@@ -775,7 +775,7 @@ where
                                     value: children[frontier - 1].value(),
                                 });
                         }
-                        let increment = children[frontier].extend_internal::<H, Arity>(
+                        let increment = children[frontier].extend_and_forget_internal::<H, Arity>(
                             height - 1,
                             &cur_pos,
                             traversal_path,

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -114,14 +114,7 @@ mod mt_tests {
         assert!(mt.extend(&[F::from(1u64)]).is_err());
 
         // Checks that the prior elements are all forgotten
-        assert!(mt.lookup(0).expect_not_in_memory().is_ok());
-        assert!(mt.lookup(1).expect_not_in_memory().is_ok());
-        assert!(mt.lookup(2).expect_not_in_memory().is_ok());
-        assert!(mt.lookup(3).expect_not_in_memory().is_ok());
-        assert!(mt.lookup(4).expect_not_in_memory().is_ok());
-        assert!(mt.lookup(5).expect_not_in_memory().is_ok());
-        assert!(mt.lookup(6).expect_not_in_memory().is_ok());
-        assert!(mt.lookup(7).expect_not_in_memory().is_ok());
+        (0..8).for_each(|i| assert!(mt.lookup(i).expect_not_in_memory().is_ok()));
         assert!(mt.lookup(8).expect_ok().is_ok());
     }
 

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -112,6 +112,17 @@ mod mt_tests {
         assert!(mt.push(F::from(0u64)).is_err());
         assert!(mt.extend(&[]).is_ok());
         assert!(mt.extend(&[F::from(1u64)]).is_err());
+
+        // Checks that the prior elements are all forgotten
+        assert!(mt.lookup(0).expect_not_in_memory().is_ok());
+        assert!(mt.lookup(1).expect_not_in_memory().is_ok());
+        assert!(mt.lookup(2).expect_not_in_memory().is_ok());
+        assert!(mt.lookup(3).expect_not_in_memory().is_ok());
+        assert!(mt.lookup(4).expect_not_in_memory().is_ok());
+        assert!(mt.lookup(5).expect_not_in_memory().is_ok());
+        assert!(mt.lookup(6).expect_not_in_memory().is_ok());
+        assert!(mt.lookup(7).expect_not_in_memory().is_ok());
+        assert!(mt.lookup(8).expect_ok().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

Now the light weight merkle tree correctly forget the previously inserted elements, and we have a test for that.
Thanks for @Ayiga who spotted it.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
