### PR TITLE
feat: new trait method VidScheme::get_num_storage_nodes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700204040,
-        "narHash": "sha256-xSVcS5HBYnD3LTer7Y2K8ZQCDCXMa3QUD1MzRjHzuhI=",
+        "lastModified": 1705677747,
+        "narHash": "sha256-eyM3okYtMgYDgmYukoUzrmuoY4xl4FUujnsv/P6I/zI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c757e9bd77b16ca2e03c89bf8bc9ecb28e0c06ad",
+        "rev": "bbe7d8f876fbbe7c959c90ba2ae2852220573261",
         "type": "github"
       },
       "original": {
@@ -125,16 +125,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1685801374,
-        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700064067,
-        "narHash": "sha256-1ZWNDzhu8UlVCK7+DUN9dVQfiHX1bv6OQP9VxstY/gs=",
+        "lastModified": 1705757126,
+        "narHash": "sha256-Eksr+n4Q8EYZKAN0Scef5JK4H6FcHc+TKNHb95CWm+c=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e558068cba67b23b4fbc5537173dbb43748a17e8",
+        "rev": "f56597d53fd174f796b5a7d3ee0b494f9e2285cc",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1700273673,
-        "narHash": "sha256-0XD4JvrQiZ9BDFdH3VTwqZVXTYzOfS7DVblvqHBnWgE=",
+        "lastModified": 1705716951,
+        "narHash": "sha256-Yp4EkRWoXX57a7hDyx6xJDTtl0h1WRFdRlp9SejPPOQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "616074a1b2a71bbe44da4cc29a64255aecb8d541",
+        "rev": "612b6a974cb921fe7aa4cafd54f4f5f899b19173",
         "type": "github"
       },
       "original": {

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -74,6 +74,9 @@ pub trait VidScheme {
 
     /// Extract the payload byte length data from a [`VidScheme::Common`].
     fn get_payload_byte_len(common: &Self::Common) -> usize;
+
+    /// Extract the number of storage nodes from a [`VidScheme::Common`].
+    fn get_num_storage_nodes(common: &Self::Common) -> usize;
 }
 
 /// Convenience struct to aggregate disperse data.

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -384,7 +384,8 @@ where
                 common.poly_commits.len()
             )));
         }
-        if common.num_storage_nodes != self.num_storage_nodes.try_into().map_err(vid)? {
+        let num_storage_nodes: u32 = self.num_storage_nodes.try_into().map_err(vid)?; // pacify cargo check --target wasm32-unknown-unknown --no-default-features
+        if common.num_storage_nodes != num_storage_nodes {
             return Err(VidError::Argument(format!(
                 "common num_storage_nodes differs from self ({},{})",
                 common.num_storage_nodes, self.num_storage_nodes
@@ -448,7 +449,8 @@ where
                 self.payload_chunk_size
             )));
         }
-        if common.num_storage_nodes != self.num_storage_nodes.try_into().map_err(vid)? {
+        let num_storage_nodes: u32 = self.num_storage_nodes.try_into().map_err(vid)?; // pacify cargo check --target wasm32-unknown-unknown --no-default-features
+        if common.num_storage_nodes != num_storage_nodes {
             return Err(VidError::Argument(format!(
                 "common num_storage_nodes differs from self ({},{})",
                 common.num_storage_nodes, self.num_storage_nodes

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -370,6 +370,12 @@ where
                 common.poly_commits.len()
             )));
         }
+        if common.num_storage_nodes != self.num_storage_nodes {
+            return Err(VidError::Argument(format!(
+                "common num_storage_nodes differs from self ({},{})",
+                common.num_storage_nodes, self.num_storage_nodes
+            )));
+        }
         if share.index >= self.num_storage_nodes {
             return Ok(Err(())); // not an arg error
         }
@@ -426,6 +432,12 @@ where
                 "not enough shares {}, expected at least {}",
                 shares.len(),
                 self.payload_chunk_size
+            )));
+        }
+        if common.num_storage_nodes != self.num_storage_nodes {
+            return Err(VidError::Argument(format!(
+                "common num_storage_nodes differs from self ({},{})",
+                common.num_storage_nodes, self.num_storage_nodes
             )));
         }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -190,7 +190,8 @@ where
     #[serde(with = "canonical")]
     all_evals_digest: KzgEvalsMerkleTreeNode<E, H>,
 
-    bytes_len: usize, // TODO don't use usize in serializable struct?
+    bytes_len: usize,         // TODO don't use usize in serializable struct?
+    num_storage_nodes: usize, // TODO don't use usize in serializable struct?
 }
 
 impl<E, H> VidScheme for Advz<E, H>
@@ -301,6 +302,7 @@ where
             poly_commits: UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?,
             all_evals_digest: all_evals_commit.commitment().digest(),
             bytes_len: payload_len,
+            num_storage_nodes: self.num_storage_nodes,
         };
         end_timer!(common_timer);
 
@@ -482,6 +484,10 @@ where
 
     fn get_payload_byte_len(common: &Self::Common) -> usize {
         common.bytes_len
+    }
+
+    fn get_num_storage_nodes(common: &Self::Common) -> usize {
+        common.num_storage_nodes
     }
 }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -237,7 +237,7 @@ where
         let payload_byte_len = payload.len().try_into().map_err(vid)?;
         let disperse_time = start_timer!(|| format!(
             "VID disperse {} payload bytes to {} nodes",
-            payload_len, self.num_storage_nodes
+            payload_byte_len, self.num_storage_nodes
         ));
 
         // partition payload into polynomial coefficients

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -321,7 +321,10 @@ where
     }
 
     fn check_stmt_consistency(stmt: &Statement<Self>) -> VidResult<()> {
-        check_range_nonempty_and_in_bounds(stmt.common.bytes_len, &stmt.range)?;
+        check_range_nonempty_and_in_bounds(
+            stmt.common.payload_byte_len.try_into().map_err(vid)?,
+            &stmt.range,
+        )?;
         if stmt.payload_subslice.len() != stmt.range.len() {
             return Err(VidError::Argument(format!(
                 "payload_subslice length {} inconsistent with range length {}",

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -39,6 +39,8 @@ pub fn round_trip<V, R>(
             let (mut shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
             assert_eq!(shares.len(), num_storage_nodes);
             assert_eq!(commit, vid.commit_only(&bytes_random).unwrap());
+            assert_eq!(len, V::get_payload_byte_len(&common));
+            assert_eq!(num_storage_nodes, V::get_num_storage_nodes(&common));
 
             for share in shares.iter() {
                 vid.verify_share(share, &common, &commit).unwrap().unwrap();


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #460 

Does what it says on the tin.

# Question

Currently data such as [payload byte length], [number of storage nodes] is stored in `Common` as `usize`. But `Common` is a serializable struct. I'm uneasy about putting `usize` in such a struct because the guarantees you get are less clear and it could waste space. This struct will be sent over the wire and every byte counts. Shall we pick a fixed word size here like `u16`, `u32`? (We could even use 3 bytes.)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
