### PR TITLE
feat: ergonomics changes for merkle tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and follow [semantic versioning](https://semver.org/) for our releases.
   - Switch from `crypto_box` to `chacha20poly1305` (with `crypto_kx` to establish shared secret) for AEAD.
   - Supports `--cfg curve25519_dalek_backend="u32_backend"` RUSTFLAGS to select Curve25519 backend.
   - Remove `Canonical(De)Serialize` on AEAD-related structs, and directly expose `serde::(De)Serialize` instead.
+- [#475](https://github.com/EspressoSystems/jellyfish/pull/475) (`jf-primitives`) Ergonomics changes for Merkle tree
+  - Remove the unnecessary trait bound `From<u64>` to the merkle tree index
+    - Move the `from_elems` interfaces to `AppendableMerkleTreeScheme`
+    - Add `new()` interfaces for `MerkleTreeScheme`
+  - Add new `update_with()` and `remove()` interface for the universal Merkle tree
+  - Add new `iter()` interface for Merkle tree scheme, allows user to iterate through all elements that are in memory.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ and follow [semantic versioning](https://semver.org/) for our releases.
   - Supports `--cfg curve25519_dalek_backend="u32_backend"` RUSTFLAGS to select Curve25519 backend.
   - Remove `Canonical(De)Serialize` on AEAD-related structs, and directly expose `serde::(De)Serialize` instead.
 - [#475](https://github.com/EspressoSystems/jellyfish/pull/475) (`jf-primitives`) Ergonomics changes for Merkle tree
-  - Remove the unnecessary trait bound `From<u64>` to the merkle tree index
-    - Move the `from_elems` interfaces to `AppendableMerkleTreeScheme`
-    - Add `new()` interfaces for `MerkleTreeScheme`
-  - Add new `update_with()` and `remove()` interface for the universal Merkle tree
+  - Constructors are removed from trait definitions.
+  - Remove the unnecessary trait bounds, for example `I: From<u64>`.
+  - Restricting the index type for `AppendableMerkleTreeScheme` to be `u64`.
+  - Add new `update_with()` and `remove()` interface for the universal Merkle tree.
   - Add new `iter()` interface for Merkle tree scheme, allows user to iterate through all elements that are in memory.
 
 ### Fixed

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -701,7 +701,7 @@ pub mod test {
         for i in a0..(a0 + 4 * m) {
             a.push(cs.create_variable(F::from(i as u64))?);
         }
-        let b = vec![
+        let b = [
             cs.create_public_variable(F::from(m as u64 * 2))?,
             cs.create_public_variable(F::from(a0 as u64 * 2 + m as u64 * 4 - 1))?,
         ];
@@ -1734,7 +1734,7 @@ pub mod test {
         for i in a0..(a0 + 4 * m) {
             a.push(cs.create_variable(F::from(i as u64))?);
         }
-        let b = vec![
+        let b = [
             cs.create_public_variable(F::from(m as u64 * 2))?,
             cs.create_public_variable(F::from(a0 as u64 * 2 + m as u64 * 4 - 1))?,
         ];

--- a/primitives/benches/bls_signature.rs
+++ b/primitives/benches/bls_signature.rs
@@ -53,16 +53,15 @@ fn bench_bls12381(c: &mut Criterion) {
     benchmark_group.sample_size(500);
     benchmark_group.throughput(Throughput::Elements(1u64));
     let rng = &mut test_rng();
-    let pp = BLSSignatureScheme::param_gen(Some(rng)).unwrap();
-    let (sk, vk) = BLSSignatureScheme::key_gen(&pp, rng).unwrap();
+    let (sk, vk) = BLSSignatureScheme::key_gen(&(), rng).unwrap();
     let msg = String::from_utf8(vec![b'X'; 1024]).unwrap();
-    let sig = BLSSignatureScheme::sign(&pp, &sk, &msg, rng).unwrap();
+    let sig = BLSSignatureScheme::sign(&(), &sk, &msg, rng).unwrap();
 
     benchmark_group.bench_function("Sign", |b| {
-        b.iter(|| BLSSignatureScheme::sign(&pp, &sk, &msg, rng).unwrap())
+        b.iter(|| BLSSignatureScheme::sign(&(), &sk, &msg, rng).unwrap())
     });
     benchmark_group.bench_function("Verification", |b| {
-        b.iter(|| BLSSignatureScheme::verify(&pp, &vk, &msg, &sig).unwrap())
+        b.iter(|| BLSSignatureScheme::verify(&(), &vk, &msg, &sig).unwrap())
     });
 
     // TODO: aggregate signature benchmark not implemented
@@ -75,17 +74,16 @@ fn bench_bn254(c: &mut Criterion) {
     benchmark_group.sample_size(100);
     benchmark_group.throughput(Throughput::Elements(1u64));
     let rng = &mut test_rng();
-    let pp = BLSOverBN254CurveSignatureScheme::param_gen(Some(rng)).unwrap();
-    let (sk, vk) = BLSOverBN254CurveSignatureScheme::key_gen(&pp, rng).unwrap();
+    let (sk, vk) = BLSOverBN254CurveSignatureScheme::key_gen(&(), rng).unwrap();
     let msg = vec![12u8; 1000];
     let msgs = vec![msg.as_slice(); 1000];
-    let sig = BLSOverBN254CurveSignatureScheme::sign(&pp, &sk, &msgs[0], rng).unwrap();
+    let sig = BLSOverBN254CurveSignatureScheme::sign(&(), &sk, msgs[0], rng).unwrap();
 
     benchmark_group.bench_function("Sign", |b| {
-        b.iter(|| BLSOverBN254CurveSignatureScheme::sign(&pp, &sk, &msgs[0], rng).unwrap())
+        b.iter(|| BLSOverBN254CurveSignatureScheme::sign(&(), &sk, msgs[0], rng).unwrap())
     });
     benchmark_group.bench_function("Verification", |b| {
-        b.iter(|| BLSOverBN254CurveSignatureScheme::verify(&pp, &vk, &msgs[0], &sig).unwrap())
+        b.iter(|| BLSOverBN254CurveSignatureScheme::verify(&(), &vk, msgs[0], &sig).unwrap())
     });
 
     bench_aggregate::<BLSOverBN254CurveSignatureScheme, _>(

--- a/primitives/benches/merkle_path.rs
+++ b/primitives/benches/merkle_path.rs
@@ -10,9 +10,7 @@ extern crate criterion;
 use ark_ed_on_bls12_381::Fq as Fq381;
 use ark_std::rand::Rng;
 use criterion::Criterion;
-use jf_primitives::merkle_tree::{
-    prelude::RescueMerkleTree, AppendableMerkleTreeScheme, MerkleCommitment, MerkleTreeScheme,
-};
+use jf_primitives::merkle_tree::{prelude::RescueMerkleTree, MerkleCommitment, MerkleTreeScheme};
 use std::time::Duration;
 
 const BENCH_NAME: &str = "merkle_path_height_20";

--- a/primitives/benches/merkle_path.rs
+++ b/primitives/benches/merkle_path.rs
@@ -26,7 +26,7 @@ fn twenty_hashes(c: &mut Criterion) {
 
     let leaf: Fq381 = rng.gen();
 
-    let mt = RescueMerkleTree::<Fq381>::from_elems(20, [leaf, leaf]).unwrap();
+    let mt = RescueMerkleTree::<Fq381>::from_elems(Some(20), [leaf, leaf]).unwrap();
     let root = mt.commitment().digest();
     let (_, proof) = mt.lookup(0).expect_ok().unwrap();
 

--- a/primitives/benches/merkle_path.rs
+++ b/primitives/benches/merkle_path.rs
@@ -10,7 +10,9 @@ extern crate criterion;
 use ark_ed_on_bls12_381::Fq as Fq381;
 use ark_std::rand::Rng;
 use criterion::Criterion;
-use jf_primitives::merkle_tree::{prelude::RescueMerkleTree, MerkleCommitment, MerkleTreeScheme};
+use jf_primitives::merkle_tree::{
+    prelude::RescueMerkleTree, AppendableMerkleTreeScheme, MerkleCommitment, MerkleTreeScheme,
+};
 use std::time::Duration;
 
 const BENCH_NAME: &str = "merkle_path_height_20";

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -447,8 +447,7 @@ mod test {
             constrain_sibling_order, Merkle3AryMembershipProofVar, MerkleTreeGadget,
         },
         merkle_tree::{
-            internal::MerkleNode, prelude::RescueMerkleTree, AppendableMerkleTreeScheme as _,
-            MerkleCommitment, MerkleTreeScheme,
+            internal::MerkleNode, prelude::RescueMerkleTree, MerkleCommitment, MerkleTreeScheme,
         },
         rescue::RescueParameter,
     };

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -447,7 +447,8 @@ mod test {
             constrain_sibling_order, Merkle3AryMembershipProofVar, MerkleTreeGadget,
         },
         merkle_tree::{
-            internal::MerkleNode, prelude::RescueMerkleTree, MerkleCommitment, MerkleTreeScheme,
+            internal::MerkleNode, prelude::RescueMerkleTree, AppendableMerkleTreeScheme as _,
+            MerkleCommitment, MerkleTreeScheme,
         },
         rescue::RescueParameter,
     };

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -38,7 +38,7 @@ use super::rescue::RescueNativeGadget;
 /// let mut circuit = PlonkCircuit::<Fq>::new_turbo_plonk();
 /// // Create a 3-ary MT, instantiated with a Rescue-based hash, of height 1.
 /// let elements = vec![Fq::from(1_u64), Fq::from(2_u64), Fq::from(100_u64)];
-/// let mt = RescueMerkleTree::<Fq>::from_elems(1, elements).unwrap();
+/// let mt = RescueMerkleTree::<Fq>::from_elems(Some(1), elements).unwrap();
 /// let expected_root = mt.commitment().digest();
 /// // Get a proof for the element in position 2
 /// let (_, proof) = mt.lookup(2).expect_ok().unwrap();

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -566,7 +566,7 @@ mod test {
             let mut circuit = PlonkCircuit::<F>::new_turbo_plonk();
             let mut elements = (1u64..=9u64).map(|x| F::from(x)).collect::<Vec<_>>();
             elements[uid as usize] = elem;
-            let mt = RescueMerkleTree::<F>::from_elems(2, elements).unwrap();
+            let mt = RescueMerkleTree::<F>::from_elems(Some(2), elements).unwrap();
             let expected_root = mt.commitment().digest();
             let (retrieved_elem, proof) = mt.lookup(uid).expect_ok().unwrap();
             assert_eq!(retrieved_elem, &elem);

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -33,7 +33,7 @@ use super::rescue::RescueNativeGadget;
 /// use ark_bls12_377::Fq;
 /// use jf_primitives::circuit::merkle_tree::MerkleTreeGadget;
 /// use jf_relation::{Circuit, PlonkCircuit};
-/// use jf_primitives::merkle_tree::{prelude::RescueMerkleTree, MerkleTreeScheme, MerkleCommitment};
+/// use jf_primitives::merkle_tree::{prelude::RescueMerkleTree, AppendableMerkleTreeScheme, MerkleTreeScheme, MerkleCommitment};
 ///
 /// let mut circuit = PlonkCircuit::<Fq>::new_turbo_plonk();
 /// // Create a 3-ary MT, instantiated with a Rescue-based hash, of height 1.

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -937,7 +937,7 @@ mod tests {
 
         // bad path: incorrect number of inputs
         let mut circuit = PlonkCircuit::new_turbo_plonk();
-        let input_vec = vec![
+        let input_vec = [
             F::from(11_u32),
             F::from(144_u32),
             F::from(87_u32),

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -25,7 +25,7 @@ use num_traits::pow::pow;
 use serde::{Deserialize, Serialize};
 use typenum::Unsigned;
 
-impl_merkle_tree_scheme!(MerkleTree, build_tree_internal);
+impl_merkle_tree_scheme!(MerkleTree);
 impl_forgetable_merkle_tree_scheme!(MerkleTree);
 
 impl<E, H, I, Arity, T> AppendableMerkleTreeScheme for MerkleTree<E, H, I, Arity, T>
@@ -36,6 +36,19 @@ where
     Arity: Unsigned,
     T: NodeValue,
 {
+    fn from_elems(
+        height: usize,
+        elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
+    ) -> Result<Self, PrimitivesError> {
+        let (root, num_leaves) = build_tree_internal::<E, H, I, Arity, T>(height, elems)?;
+        Ok(Self {
+            root,
+            height,
+            num_leaves,
+            _phantom: PhantomData,
+        })
+    }
+
     fn push(&mut self, elem: impl Borrow<Self::Element>) -> Result<(), PrimitivesError> {
         <Self as AppendableMerkleTreeScheme>::extend(self, [elem])
     }

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -10,7 +10,8 @@ use core::ops::AddAssign;
 
 use super::{
     internal::{
-        build_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment, MerkleTreeIter,
+        build_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment, MerkleTreeIntoIter,
+        MerkleTreeIter,
     },
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
     LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -172,7 +172,7 @@ mod mt_tests {
         let mut mt = RescueMerkleTree::<F>::from_elems(2, &[F::from(3u64), F::from(1u64)]).unwrap();
         let root = mt.commitment().digest();
         let (lookup_elem, lookup_proof) = mt.lookup(0).expect_ok().unwrap();
-        let lookup_elem = lookup_elem.clone();
+        let lookup_elem = *lookup_elem;
         let (elem, proof) = mt.forget(0).expect_ok().unwrap();
         assert_eq!(lookup_elem, elem);
         assert_eq!(lookup_proof, proof);

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -9,7 +9,9 @@
 use core::ops::AddAssign;
 
 use super::{
-    internal::{build_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment},
+    internal::{
+        build_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment, MerkleTreeIter,
+    },
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
     LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
 };
@@ -259,5 +261,19 @@ mod mt_tests {
             *node,
             bincode::deserialize(&bincode::serialize(node).unwrap()).unwrap()
         );
+    }
+
+    #[test]
+    fn test_mt_iter() {
+        test_mt_iter_helper::<Fq254>();
+        test_mt_iter_helper::<Fq377>();
+        test_mt_iter_helper::<Fq381>();
+    }
+
+    fn test_mt_iter_helper<F: RescueParameter>() {
+        let mt =
+            RescueMerkleTree::<F>::from_elems(2, &[F::from(0u64), F::from(1u64), F::from(2u64)])
+                .unwrap();
+        assert!(mt.iter().all(|(index, elem)| { elem == &F::from(*index) }));
     }
 }

--- a/primitives/src/merkle_tree/append_only.rs
+++ b/primitives/src/merkle_tree/append_only.rs
@@ -40,10 +40,10 @@ where
     T: NodeValue,
 {
     fn from_elems(
-        height: usize,
+        height: Option<usize>,
         elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
     ) -> Result<Self, PrimitivesError> {
-        let (root, num_leaves) = build_tree_internal::<E, H, I, Arity, T>(height, elems)?;
+        let (root, height, num_leaves) = build_tree_internal::<E, H, I, Arity, T>(height, elems)?;
         Ok(Self {
             root,
             height,
@@ -104,8 +104,8 @@ mod mt_tests {
     }
 
     fn test_mt_builder_helper<F: RescueParameter>() {
-        assert!(RescueMerkleTree::<F>::from_elems(1, &[F::from(0u64); 3]).is_ok());
-        assert!(RescueMerkleTree::<F>::from_elems(1, &[F::from(0u64); 4]).is_err());
+        assert!(RescueMerkleTree::<F>::from_elems(None, &[F::from(0u64); 3]).is_ok());
+        assert!(RescueMerkleTree::<F>::from_elems(Some(1), &[F::from(0u64); 4]).is_err());
     }
 
     #[test]
@@ -116,7 +116,7 @@ mod mt_tests {
     }
 
     fn test_mt_insertion_helper<F: RescueParameter>() {
-        let mut mt = RescueMerkleTree::<F>::from_elems(2, &[]).unwrap();
+        let mut mt = RescueMerkleTree::<F>::from_elems(Some(2), &[]).unwrap();
         assert_eq!(mt.capacity(), BigUint::from(9u64));
         assert!(mt.push(F::from(2u64)).is_ok());
         assert!(mt.push(F::from(3u64)).is_ok());
@@ -137,7 +137,8 @@ mod mt_tests {
     }
 
     fn test_mt_lookup_helper<F: RescueParameter>() {
-        let mt = RescueMerkleTree::<F>::from_elems(2, &[F::from(3u64), F::from(1u64)]).unwrap();
+        let mt =
+            RescueMerkleTree::<F>::from_elems(Some(2), &[F::from(3u64), F::from(1u64)]).unwrap();
         let root = mt.commitment().digest();
         let (elem, proof) = mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, &F::from(3u64));
@@ -185,7 +186,8 @@ mod mt_tests {
     }
 
     fn test_mt_forget_remember_helper<F: RescueParameter>() {
-        let mut mt = RescueMerkleTree::<F>::from_elems(2, &[F::from(3u64), F::from(1u64)]).unwrap();
+        let mut mt =
+            RescueMerkleTree::<F>::from_elems(Some(2), &[F::from(3u64), F::from(1u64)]).unwrap();
         let root = mt.commitment().digest();
         let (lookup_elem, lookup_proof) = mt.lookup(0).expect_ok().unwrap();
         let lookup_elem = *lookup_elem;
@@ -246,7 +248,8 @@ mod mt_tests {
     }
 
     fn test_mt_serde_helper<F: RescueParameter>() {
-        let mt = RescueMerkleTree::<F>::from_elems(2, &[F::from(3u64), F::from(1u64)]).unwrap();
+        let mt =
+            RescueMerkleTree::<F>::from_elems(Some(2), &[F::from(3u64), F::from(1u64)]).unwrap();
         let proof = mt.lookup(0).expect_ok().unwrap().1;
         let node = &proof.proof[0];
 
@@ -272,9 +275,11 @@ mod mt_tests {
     }
 
     fn test_mt_iter_helper<F: RescueParameter>() {
-        let mt =
-            RescueMerkleTree::<F>::from_elems(2, &[F::from(0u64), F::from(1u64), F::from(2u64)])
-                .unwrap();
+        let mt = RescueMerkleTree::<F>::from_elems(
+            Some(2),
+            &[F::from(0u64), F::from(1u64), F::from(2u64)],
+        )
+        .unwrap();
         assert!(mt.iter().all(|(index, elem)| { elem == &F::from(*index) }));
     }
 }

--- a/primitives/src/merkle_tree/hasher.rs
+++ b/primitives/src/merkle_tree/hasher.rs
@@ -15,7 +15,7 @@
 //! let my_data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 //!
 //! // payload type is `usize`, hash function is `Sha256`.
-//! let mt = HasherMerkleTree::<Sha256, usize>::from_elems(2, &my_data)?;
+//! let mt = HasherMerkleTree::<Sha256, usize>::from_elems(Some(2), &my_data)?;
 //!
 //! let root = mt.commitment().digest();
 //! let (val, proof) = mt.lookup(2).expect_ok()?;
@@ -86,7 +86,7 @@ pub type GenericHasherMerkleTree<H, E, I, Arity> =
 ///     H: HasherDigest,
 /// {
 ///     let my_data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-///     let mt = HasherMerkleTree::<H, usize>::from_elems(2, &my_data).unwrap();
+///     let mt = HasherMerkleTree::<H, usize>::from_elems(None, &my_data).unwrap();
 /// }
 /// ```
 ///
@@ -102,7 +102,7 @@ pub type GenericHasherMerkleTree<H, E, I, Arity> =
 ///     <<H as OutputSizeUser>::OutputSize as ArrayLength<u8>>::ArrayType: Copy,
 /// {
 ///     let my_data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-///     let mt = HasherMerkleTree::<H, usize>::from_elems(2, &my_data).unwrap();
+///     let mt = HasherMerkleTree::<H, usize>::from_elems(None, &my_data).unwrap();
 /// }
 /// ```
 ///
@@ -117,7 +117,7 @@ pub type GenericHasherMerkleTree<H, E, I, Arity> =
 ///     H: Digest + Write,
 /// {
 ///     let my_data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-///     let mt = HasherMerkleTree::<H, usize>::from_elems(2, &my_data).unwrap();
+///     let mt = HasherMerkleTree::<H, usize>::from_elems(None, &my_data).unwrap();
 /// }
 /// ```
 pub trait HasherDigest: Digest<OutputSize = Self::Foo> + Write {

--- a/primitives/src/merkle_tree/hasher.rs
+++ b/primitives/src/merkle_tree/hasher.rs
@@ -8,7 +8,7 @@
 //!
 //! ```
 //! # use jf_primitives::errors::PrimitivesError;
-//! use jf_primitives::merkle_tree::{hasher::HasherMerkleTree, MerkleCommitment, MerkleTreeScheme};
+//! use jf_primitives::merkle_tree::{hasher::HasherMerkleTree, AppendableMerkleTreeScheme, MerkleCommitment, MerkleTreeScheme};
 //! use sha2::Sha256;
 //!
 //! # fn main() -> Result<(), PrimitivesError> {
@@ -79,7 +79,7 @@ pub type GenericHasherMerkleTree<H, E, I, Arity> =
 ///
 /// Do this:
 /// ```
-/// # use jf_primitives::merkle_tree::{hasher::HasherMerkleTree, MerkleTreeScheme};
+/// # use jf_primitives::merkle_tree::{hasher::HasherMerkleTree, AppendableMerkleTreeScheme};
 /// # use jf_primitives::merkle_tree::hasher::HasherDigest;
 /// fn generic_over_hasher<H>()
 /// where
@@ -94,7 +94,7 @@ pub type GenericHasherMerkleTree<H, E, I, Arity> =
 /// ```
 /// # use digest::{crypto_common::generic_array::ArrayLength, Digest, OutputSizeUser};
 /// # use ark_serialize::Write;
-/// # use jf_primitives::merkle_tree::{hasher::HasherMerkleTree, MerkleTreeScheme};
+/// # use jf_primitives::merkle_tree::{hasher::HasherMerkleTree, AppendableMerkleTreeScheme};
 /// # use jf_primitives::merkle_tree::hasher::HasherDigest;
 /// fn generic_over_hasher<H>()
 /// where
@@ -110,7 +110,7 @@ pub type GenericHasherMerkleTree<H, E, I, Arity> =
 /// ```compile_fail
 /// # use digest::{crypto_common::generic_array::ArrayLength, Digest, OutputSizeUser};
 /// # use ark_serialize::Write;
-/// # use jf_primitives::merkle_tree::{hasher::HasherMerkleTree, MerkleTreeScheme};
+/// # use jf_primitives::merkle_tree::{hasher::HasherMerkleTree, AppendableMerkleTreeScheme};
 /// # use jf_primitives::merkle_tree::hasher::HasherDigest;
 /// fn generic_over_hasher<H>()
 /// where

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -903,7 +903,7 @@ where
 impl<E, I, T, Arity> MerkleProof<E, I, T, Arity>
 where
     E: Element,
-    I: Index + From<u64> + ToTraversalPath<Arity>,
+    I: Index + ToTraversalPath<Arity>,
     T: NodeValue,
     Arity: Unsigned,
 {

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -978,6 +978,12 @@ where
                     children
                         .iter()
                         .rev()
+                        .filter(|child| {
+                            matches!(
+                                ***child,
+                                MerkleNode::Branch { .. } | MerkleNode::Leaf { .. }
+                            )
+                        })
                         .for_each(|child| self.stack.push(child));
                 },
                 MerkleNode::Leaf {
@@ -1021,6 +1027,9 @@ where
                     children
                         .into_iter()
                         .rev()
+                        .filter(|child| {
+                            matches!(**child, MerkleNode::Branch { .. } | MerkleNode::Leaf { .. })
+                        })
                         .for_each(|child| self.stack.push(child));
                 },
                 MerkleNode::Leaf {

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -927,3 +927,46 @@ where
         }
     }
 }
+
+/// Iterator type for a merkle tree
+pub struct MerkleTreeIter<'a, E: Element, I: Index, T: NodeValue> {
+    stack: Vec<&'a MerkleNode<E, I, T>>,
+}
+
+impl<'a, E: Element, I: Index, T: NodeValue> MerkleTreeIter<'a, E, I, T> {
+    /// Initialize an iterator
+    pub fn new(root: &'a MerkleNode<E, I, T>) -> Self {
+        Self { stack: vec![root] }
+    }
+}
+
+impl<'a, E, I, T> Iterator for MerkleTreeIter<'a, E, I, T>
+where
+    E: Element,
+    I: Index,
+    T: NodeValue,
+{
+    type Item = (&'a I, &'a E);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(node) = self.stack.pop() {
+            match node {
+                MerkleNode::Branch { value: _, children } => {
+                    children
+                        .iter()
+                        .rev()
+                        .for_each(|child| self.stack.push(child));
+                },
+                MerkleNode::Leaf {
+                    value: _,
+                    pos,
+                    elem,
+                } => {
+                    return Some((pos, elem));
+                },
+                _ => {},
+            }
+        }
+        None
+    }
+}

--- a/primitives/src/merkle_tree/internal.rs
+++ b/primitives/src/merkle_tree/internal.rs
@@ -589,10 +589,9 @@ where
                     f,
                 )?;
                 if matches!(*children[branch], MerkleNode::ForgettenSubtree { .. }) {
-                    // If the branch containing the update was not in memory,
-                    // the update failed and nothing was
-                    // changed, so we can short-circuit without recomputing this
-                    // node's value.
+                    // If the branch containing the update was forgotten by
+                    // user, the update failed and nothing was changed, so we
+                    // can short-circuit without recomputing this node's value.
                 } else if children
                     .iter()
                     .all(|child| matches!(**child, MerkleNode::Empty))

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -26,7 +26,7 @@ use num_traits::pow::pow;
 use serde::{Deserialize, Serialize};
 use typenum::Unsigned;
 
-impl_merkle_tree_scheme!(LightWeightMerkleTree, build_light_weight_tree_internal);
+impl_merkle_tree_scheme!(LightWeightMerkleTree);
 impl_forgetable_merkle_tree_scheme!(LightWeightMerkleTree);
 
 impl<E, H, I, Arity, T> AppendableMerkleTreeScheme for LightWeightMerkleTree<E, H, I, Arity, T>
@@ -37,6 +37,20 @@ where
     Arity: Unsigned,
     T: NodeValue,
 {
+    fn from_elems(
+        height: usize,
+        elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
+    ) -> Result<Self, PrimitivesError> {
+        let (root, num_leaves) =
+            build_light_weight_tree_internal::<E, H, I, Arity, T>(height, elems)?;
+        Ok(Self {
+            root,
+            height,
+            num_leaves,
+            _phantom: PhantomData,
+        })
+    }
+
     fn push(&mut self, elem: impl Borrow<Self::Element>) -> Result<(), PrimitivesError> {
         <Self as AppendableMerkleTreeScheme>::extend(self, [elem])
     }

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -10,7 +10,10 @@
 use core::ops::AddAssign;
 
 use super::{
-    internal::{build_light_weight_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment},
+    internal::{
+        build_light_weight_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment,
+        MerkleTreeIter,
+    },
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
     LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
 };

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -41,10 +41,10 @@ where
     T: NodeValue,
 {
     fn from_elems(
-        height: usize,
+        height: Option<usize>,
         elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
     ) -> Result<Self, PrimitivesError> {
-        let (root, num_leaves) =
+        let (root, height, num_leaves) =
             build_light_weight_tree_internal::<E, H, I, Arity, T>(height, elems)?;
         Ok(Self {
             root,
@@ -105,9 +105,9 @@ mod mt_tests {
     fn test_light_mt_builder_helper<F: RescueParameter>() {
         let arity: usize = RescueLightWeightMerkleTree::<F>::ARITY;
         let mut data = vec![F::from(0u64); arity];
-        assert!(RescueLightWeightMerkleTree::<F>::from_elems(1, &data).is_ok());
+        assert!(RescueLightWeightMerkleTree::<F>::from_elems(Some(1), &data).is_ok());
         data.push(F::from(0u64));
-        assert!(RescueLightWeightMerkleTree::<F>::from_elems(1, &data).is_err());
+        assert!(RescueLightWeightMerkleTree::<F>::from_elems(Some(1), &data).is_err());
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod mt_tests {
     }
 
     fn test_light_mt_insertion_helper<F: RescueParameter>() {
-        let mut mt = RescueLightWeightMerkleTree::<F>::from_elems(2, &[]).unwrap();
+        let mut mt = RescueLightWeightMerkleTree::<F>::from_elems(Some(2), &[]).unwrap();
         assert_eq!(mt.capacity(), BigUint::from(9u64));
         assert!(mt.push(F::from(2u64)).is_ok());
         assert!(mt.push(F::from(3u64)).is_ok());
@@ -144,10 +144,10 @@ mod mt_tests {
 
     fn test_light_mt_lookup_helper<F: RescueParameter>() {
         let mut mt =
-            RescueLightWeightMerkleTree::<F>::from_elems(2, &[F::from(3u64), F::from(1u64)])
+            RescueLightWeightMerkleTree::<F>::from_elems(Some(2), &[F::from(3u64), F::from(1u64)])
                 .unwrap();
         let mut mock_mt =
-            RescueMerkleTree::<F>::from_elems(2, &[F::from(3u64), F::from(1u64)]).unwrap();
+            RescueMerkleTree::<F>::from_elems(Some(2), &[F::from(3u64), F::from(1u64)]).unwrap();
         assert!(mt.lookup(0).expect_not_in_memory().is_ok());
         assert!(mt.lookup(1).expect_ok().is_ok());
         assert!(mt.extend(&[F::from(3u64), F::from(1u64)]).is_ok());
@@ -204,8 +204,9 @@ mod mt_tests {
     }
 
     fn test_light_mt_serde_helper<F: RescueParameter>() {
-        let mt = RescueLightWeightMerkleTree::<F>::from_elems(2, &[F::from(3u64), F::from(1u64)])
-            .unwrap();
+        let mt =
+            RescueLightWeightMerkleTree::<F>::from_elems(Some(2), &[F::from(3u64), F::from(1u64)])
+                .unwrap();
         let proof = mt.lookup(1).expect_ok().unwrap().1;
         let node = &proof.proof[0];
 

--- a/primitives/src/merkle_tree/light_weight.rs
+++ b/primitives/src/merkle_tree/light_weight.rs
@@ -12,7 +12,7 @@ use core::ops::AddAssign;
 use super::{
     internal::{
         build_light_weight_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment,
-        MerkleTreeIter,
+        MerkleTreeIntoIter, MerkleTreeIter,
     },
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme, Index,
     LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -49,15 +49,6 @@ macro_rules! impl_merkle_tree_scheme {
 
             const ARITY: usize = Arity::USIZE;
 
-            fn new(height: usize) -> Self {
-                Self {
-                    root: Box::new(MerkleNode::<E, I, T>::Empty),
-                    height,
-                    num_leaves: 0,
-                    _phantom: PhantomData,
-                }
-            }
-
             fn height(&self) -> usize {
                 self.height
             }

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -103,6 +103,10 @@ macro_rules! impl_merkle_tree_scheme {
             fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue> {
                 MerkleTreeIter::new(&self.root)
             }
+
+            fn into_iter(self) -> MerkleTreeIntoIter<Self::Element, Self::Index, Self::NodeValue> {
+                MerkleTreeIntoIter::new(self.root)
+            }
         }
     };
 }

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -100,14 +100,45 @@ macro_rules! impl_merkle_tree_scheme {
                 proof.borrow().verify_membership_proof::<H>(root.borrow())
             }
 
-            fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue> {
+            fn iter(&self) -> MerkleTreeIter<E, I, T> {
                 MerkleTreeIter::new(&self.root)
             }
+        }
 
-            fn into_iter(self) -> MerkleTreeIntoIter<Self::Element, Self::Index, Self::NodeValue> {
+        impl<'a, E, H, I, Arity, T> IntoIterator for &'a $name<E, H, I, Arity, T>
+        where
+            E: Element,
+            H: DigestAlgorithm<E, I, T>,
+            I: Index + ToTraversalPath<Arity>,
+            Arity: Unsigned,
+            T: NodeValue,
+        {
+            type Item = (&'a I, &'a E);
+
+            type IntoIter = MerkleTreeIter<'a, E, I, T>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                MerkleTreeIter::new(&self.root)
+            }
+        }
+
+        impl<E, H, I, Arity, T> IntoIterator for $name<E, H, I, Arity, T>
+        where
+            E: Element,
+            H: DigestAlgorithm<E, I, T>,
+            I: Index + ToTraversalPath<Arity>,
+            Arity: Unsigned,
+            T: NodeValue,
+        {
+            type Item = (I, E);
+
+            type IntoIter = MerkleTreeIntoIter<E, I, T>;
+
+            fn into_iter(self) -> Self::IntoIter {
                 MerkleTreeIntoIter::new(self.root)
             }
         }
+
     };
 }
 

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -28,8 +28,7 @@ macro_rules! impl_merkle_tree_scheme {
             height: usize,
             num_leaves: u64,
 
-            _phantom_h: PhantomData<H>,
-            _phantom_ta: PhantomData<Arity>,
+            _phantom: PhantomData<(H, Arity)>,
         }
 
         impl<E, H, I, Arity, T> MerkleTreeScheme for $name<E, H, I, Arity, T>
@@ -50,6 +49,15 @@ macro_rules! impl_merkle_tree_scheme {
 
             const ARITY: usize = Arity::USIZE;
 
+            fn new(height: usize) -> Self {
+                Self {
+                    root: Box::new(MerkleNode::<E, I, T>::Empty),
+                    height,
+                    num_leaves: 0,
+                    _phantom: PhantomData,
+                }
+            }
+
             fn from_elems(
                 height: usize,
                 elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
@@ -59,8 +67,7 @@ macro_rules! impl_merkle_tree_scheme {
                     root,
                     height,
                     num_leaves,
-                    _phantom_h: PhantomData,
-                    _phantom_ta: PhantomData,
+                    _phantom: PhantomData,
                 })
             }
 
@@ -129,8 +136,7 @@ macro_rules! impl_forgetable_merkle_tree_scheme {
                     }),
                     height: com.height(),
                     num_leaves: com.size(),
-                    _phantom_h: PhantomData,
-                    _phantom_ta: PhantomData,
+                    _phantom: PhantomData,
                 }
             }
 

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -9,7 +9,7 @@
 /// Macro for generating a standard merkle tree implementation
 #[macro_export]
 macro_rules! impl_merkle_tree_scheme {
-    ($name: ident, $builder: ident) => {
+    ($name: ident) => {
         /// A standard append only Merkle tree implementation
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[serde(
@@ -35,7 +35,7 @@ macro_rules! impl_merkle_tree_scheme {
         where
             E: Element,
             H: DigestAlgorithm<E, I, T>,
-            I: Index + From<u64> + ToTraversalPath<Arity>,
+            I: Index + ToTraversalPath<Arity>,
             Arity: Unsigned,
             T: NodeValue,
         {
@@ -56,19 +56,6 @@ macro_rules! impl_merkle_tree_scheme {
                     num_leaves: 0,
                     _phantom: PhantomData,
                 }
-            }
-
-            fn from_elems(
-                height: usize,
-                elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
-            ) -> Result<Self, PrimitivesError> {
-                let (root, num_leaves) = $builder::<E, H, I, Arity, T>(height, elems)?;
-                Ok($name {
-                    root,
-                    height,
-                    num_leaves,
-                    _phantom: PhantomData,
-                })
             }
 
             fn height(&self) -> usize {
@@ -124,7 +111,7 @@ macro_rules! impl_forgetable_merkle_tree_scheme {
         where
             E: Element,
             H: DigestAlgorithm<E, I, T>,
-            I: Index + From<u64> + ToTraversalPath<Arity>,
+            I: Index + ToTraversalPath<Arity>,
             Arity: Unsigned,
             T: NodeValue,
         {

--- a/primitives/src/merkle_tree/macros.rs
+++ b/primitives/src/merkle_tree/macros.rs
@@ -99,6 +99,10 @@ macro_rules! impl_merkle_tree_scheme {
                 }
                 proof.borrow().verify_membership_proof::<H>(root.borrow())
             }
+
+            fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue> {
+                MerkleTreeIter::new(&self.root)
+            }
         }
     };
 }

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -299,6 +299,20 @@ pub trait UniversalMerkleTreeScheme: MerkleTreeScheme {
         elem: impl Borrow<Self::Element>,
     ) -> Result<LookupResult<Self::Element, (), ()>, PrimitivesError>;
 
+    /// Apply an update function `f` at a given position
+    /// * `pos` - zero-based index of the leaf in the tree
+    /// * `f` - the update function, `None` means the given leaf doesn't exist
+    ///   or should be removed.
+    /// * `returns` - Ok(()) if the update is success, Err() if the update
+    ///   fails.
+    fn update_with<F>(
+        &mut self,
+        pos: impl Borrow<Self::Index>,
+        f: F,
+    ) -> Result<(), PrimitivesError>
+    where
+        F: FnOnce(Option<&Self::Element>) -> Option<Self::Element>;
+
     /// Returns the leaf value given a position
     /// * `pos` - zero-based index of the leaf in the tree
     /// * `returns` - Leaf value at the position along with a proof.

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -250,8 +250,12 @@ pub trait MerkleTreeScheme: Sized {
 /// append-only vector.
 pub trait AppendableMerkleTreeScheme: MerkleTreeScheme {
     /// Construct a new Merkle tree with given height from a data slice
+    /// * `height` - height of the Merkle tree, if `None`, it will calculate the
+    ///   minimum height that could hold all elements.
+    /// * `elems` - an iterator to all elements
+    /// * `returns` - A constructed Merkle tree, or `Err()` if errors
     fn from_elems(
-        height: usize,
+        height: Option<usize>,
         elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
     ) -> Result<Self, PrimitivesError>;
 

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -241,7 +241,8 @@ pub trait MerkleTreeScheme: Sized {
     //     proof: impl Borrow<Self::BatchProof>,
     // ) -> Result<(), PrimitivesError>;
 
-    /// Return an iterator that iterates through all element that's not forgetton
+    /// Return an iterator that iterates through all element that are not
+    /// forgetton
     fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue>;
 }
 

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -294,25 +294,34 @@ pub trait UniversalMerkleTreeScheme: MerkleTreeScheme {
     /// Update the leaf value at a given position
     /// * `pos` - zero-based index of the leaf in the tree
     /// * `elem` - newly updated element
-    /// * `returns` - Ok(elem) if the update is success, and `elem` is the
-    ///   original element at the given `pos`. Err() if the update fails.
+    /// * `returns` - Err() if any error occurs internally. Ok(result) if the
+    ///   update is success or the given leaf is not in memory.
     fn update(
         &mut self,
         pos: impl Borrow<Self::Index>,
         elem: impl Borrow<Self::Element>,
     ) -> Result<LookupResult<Self::Element, (), ()>, PrimitivesError>;
 
+    /// Remove a leaf at the given position
+    /// * `pos` - zero-based index of the leaf in the tree
+    /// * `returns` - Err() if any error occurs internally. Ok(result) if the
+    ///   update is success or the given leaf is not in memory.
+    fn remove(
+        &mut self,
+        pos: impl Borrow<Self::Index>,
+    ) -> Result<LookupResult<Self::Element, (), ()>, PrimitivesError>;
+
     /// Apply an update function `f` at a given position
     /// * `pos` - zero-based index of the leaf in the tree
     /// * `f` - the update function, `None` means the given leaf doesn't exist
     ///   or should be removed.
-    /// * `returns` - Ok(()) if the update is success, Err() if the update
-    ///   fails.
+    /// * `returns` - Err() if any error occurs internally. Ok(result) if the
+    ///   update is success or the given leaf is not in memory.
     fn update_with<F>(
         &mut self,
         pos: impl Borrow<Self::Index>,
         f: F,
-    ) -> Result<(), PrimitivesError>
+    ) -> Result<LookupResult<Self::Element, (), ()>, PrimitivesError>
     where
         F: FnOnce(Option<&Self::Element>) -> Option<Self::Element>;
 

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -28,7 +28,7 @@ use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use typenum::Unsigned;
 
-use self::internal::{MerkleTreeIntoIter, MerkleTreeIter};
+use self::internal::MerkleTreeIter;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 /// The result of querying at an index in the tree
@@ -244,10 +244,6 @@ pub trait MerkleTreeScheme: Sized {
     /// Return an iterator that iterates through all element that are not
     /// forgetton
     fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue>;
-
-    /// Return an owned iterator that iterates through all element that are not
-    /// forgetton
-    fn into_iter(self) -> MerkleTreeIntoIter<Self::Element, Self::Index, Self::NodeValue>;
 }
 
 /// Merkle tree that allows insertion at back. Abstracted as a commitment for

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -28,7 +28,7 @@ use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use typenum::Unsigned;
 
-use self::internal::MerkleTreeIter;
+use self::internal::{MerkleTreeIntoIter, MerkleTreeIter};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 /// The result of querying at an index in the tree
@@ -244,6 +244,10 @@ pub trait MerkleTreeScheme: Sized {
     /// Return an iterator that iterates through all element that are not
     /// forgetton
     fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue>;
+
+    /// Return an owned iterator that iterates through all element that are not
+    /// forgetton
+    fn into_iter(self) -> MerkleTreeIntoIter<Self::Element, Self::Index, Self::NodeValue>;
 }
 
 /// Merkle tree that allows insertion at back. Abstracted as a commitment for

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -28,6 +28,8 @@ use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use typenum::Unsigned;
 
+use self::internal::MerkleTreeIter;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 /// The result of querying at an index in the tree
 /// Typically, F for element type, P for membership proof type and N for
@@ -238,6 +240,9 @@ pub trait MerkleTreeScheme: Sized {
     //     pos: impl Iterator<Item = usize>,
     //     proof: impl Borrow<Self::BatchProof>,
     // ) -> Result<(), PrimitivesError>;
+
+    /// Return an iterator that iterates through all element that's not forgetton
+    fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue>;
 }
 
 /// Merkle tree that allows insertion at back. Abstracted as a commitment for

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -196,7 +196,10 @@ pub trait MerkleTreeScheme: Sized {
     /// Tree arity
     const ARITY: usize;
 
-    /// Construct a new merkle tree with given height from a data slice
+    /// Initialize an empty Merkle tree
+    fn new(height: usize) -> Self;
+
+    /// Construct a new Merkle tree with given height from a data slice
     fn from_elems(
         height: usize,
         elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -199,12 +199,6 @@ pub trait MerkleTreeScheme: Sized {
     /// Initialize an empty Merkle tree
     fn new(height: usize) -> Self;
 
-    /// Construct a new Merkle tree with given height from a data slice
-    fn from_elems(
-        height: usize,
-        elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
-    ) -> Result<Self, PrimitivesError>;
-
     /// Return the height of this merkle tree
     fn height(&self) -> usize;
     /// Return the maximum allowed number leaves
@@ -249,6 +243,12 @@ pub trait MerkleTreeScheme: Sized {
 /// Merkle tree that allows insertion at back. Abstracted as a commitment for
 /// append-only vector.
 pub trait AppendableMerkleTreeScheme: MerkleTreeScheme {
+    /// Construct a new Merkle tree with given height from a data slice
+    fn from_elems(
+        height: usize,
+        elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
+    ) -> Result<Self, PrimitivesError>;
+
     /// Insert a new value at the leftmost available slot
     /// * `elem` - element to insert in the tree
     /// * `returns` - Ok(()) if successful

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -198,9 +198,6 @@ pub trait MerkleTreeScheme: Sized {
     /// Tree arity
     const ARITY: usize;
 
-    /// Initialize an empty Merkle tree
-    fn new(height: usize) -> Self;
-
     /// Return the height of this merkle tree
     fn height(&self) -> usize;
     /// Return the maximum allowed number leaves
@@ -249,16 +246,6 @@ pub trait MerkleTreeScheme: Sized {
 /// Merkle tree that allows insertion at back. Abstracted as a commitment for
 /// append-only vector.
 pub trait AppendableMerkleTreeScheme: MerkleTreeScheme {
-    /// Construct a new Merkle tree with given height from a data slice
-    /// * `height` - height of the Merkle tree, if `None`, it will calculate the
-    ///   minimum height that could hold all elements.
-    /// * `elems` - an iterator to all elements
-    /// * `returns` - A constructed Merkle tree, or `Err()` if errors
-    fn from_elems(
-        height: Option<usize>,
-        elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
-    ) -> Result<Self, PrimitivesError>;
-
     /// Insert a new value at the leftmost available slot
     /// * `elem` - element to insert in the tree
     /// * `returns` - Ok(()) if successful
@@ -288,18 +275,6 @@ pub trait UniversalMerkleTreeScheme: MerkleTreeScheme {
     type NonMembershipProof;
     /// Batch non membership proof
     type BatchNonMembershipProof;
-
-    /// Build a universal merkle tree from a key-value set.
-    /// * `height` - height of the merkle tree
-    /// * `data` - an iterator of key-value pairs. Could be a hashmap or simply
-    ///   an array or a slice of (key, value) pairs
-    fn from_kv_set<BI, BE>(
-        height: usize,
-        data: impl IntoIterator<Item = impl Borrow<(BI, BE)>>,
-    ) -> Result<Self, PrimitivesError>
-    where
-        BI: Borrow<Self::Index>,
-        BE: Borrow<Self::Element>;
 
     /// Update the leaf value at a given position
     /// * `pos` - zero-based index of the leaf in the tree

--- a/primitives/src/merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/mod.rs
@@ -245,7 +245,7 @@ pub trait MerkleTreeScheme: Sized {
 
 /// Merkle tree that allows insertion at back. Abstracted as a commitment for
 /// append-only vector.
-pub trait AppendableMerkleTreeScheme: MerkleTreeScheme {
+pub trait AppendableMerkleTreeScheme: MerkleTreeScheme<Index = u64> {
     /// Insert a new value at the leftmost available slot
     /// * `elem` - element to insert in the tree
     /// * `returns` - Ok(()) if successful

--- a/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
@@ -215,7 +215,7 @@ where
     Arity: Unsigned,
 {
     fn from_elems(
-        height: usize,
+        height: Option<usize>,
         elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
     ) -> Result<Self, PrimitivesError> {
         let mut namespace_ranges: BTreeMap<N, Range<u64>> = BTreeMap::new();
@@ -453,7 +453,7 @@ mod nmt_tests {
 
     fn build_tree(leaves: &[Leaf], build_type: BuildType) -> TestNMT {
         match build_type {
-            BuildType::FromElems => TestNMT::from_elems(3, leaves).unwrap(),
+            BuildType::FromElems => TestNMT::from_elems(Some(3), leaves).unwrap(),
             BuildType::Extend => {
                 let mut nmt = TestNMT::new(3);
                 nmt.extend(leaves).unwrap();

--- a/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
@@ -168,20 +168,6 @@ where
         }
     }
 
-    fn from_elems(
-        height: usize,
-        elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
-    ) -> Result<Self, PrimitivesError> {
-        let mut namespace_ranges: BTreeMap<N, Range<u64>> = BTreeMap::new();
-        let leaves =
-            NMT::<E, H, Arity, N, T>::update_namespace_metadata(&mut namespace_ranges, elems)?;
-        let inner = <InnerTree<E, H, T, N, Arity> as MerkleTreeScheme>::from_elems(height, leaves)?;
-        Ok(NMT {
-            inner,
-            namespace_ranges,
-        })
-    }
-
     fn height(&self) -> usize {
         self.inner.height()
     }
@@ -222,6 +208,22 @@ where
     N: Namespace,
     Arity: Unsigned,
 {
+    fn from_elems(
+        height: usize,
+        elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
+    ) -> Result<Self, PrimitivesError> {
+        let mut namespace_ranges: BTreeMap<N, Range<u64>> = BTreeMap::new();
+        let leaves =
+            NMT::<E, H, Arity, N, T>::update_namespace_metadata(&mut namespace_ranges, elems)?;
+        let inner = <InnerTree<E, H, T, N, Arity> as AppendableMerkleTreeScheme>::from_elems(
+            height, leaves,
+        )?;
+        Ok(NMT {
+            inner,
+            namespace_ranges,
+        })
+    }
+
     fn extend(
         &mut self,
         elems: impl IntoIterator<Item = impl core::borrow::Borrow<Self::Element>>,

--- a/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
@@ -159,6 +159,15 @@ where
     const ARITY: usize = <InnerTree<E, H, T, N, Arity> as MerkleTreeScheme>::ARITY;
     type Commitment = <InnerTree<E, H, T, N, Arity> as MerkleTreeScheme>::Commitment;
 
+    fn new(height: usize) -> Self {
+        let namespace_ranges: BTreeMap<N, Range<u64>> = BTreeMap::new();
+        let inner = <InnerTree<E, H, T, N, Arity> as MerkleTreeScheme>::new(height);
+        NMT {
+            inner,
+            namespace_ranges,
+        }
+    }
+
     fn from_elems(
         height: usize,
         elems: impl IntoIterator<Item = impl Borrow<Self::Element>>,
@@ -438,12 +447,12 @@ mod nmt_tests {
         match build_type {
             BuildType::FromElems => TestNMT::from_elems(3, leaves).unwrap(),
             BuildType::Extend => {
-                let mut nmt = TestNMT::from_elems(3, &[]).unwrap();
+                let mut nmt = TestNMT::new(3);
                 nmt.extend(leaves).unwrap();
                 nmt
             },
             BuildType::Push => {
-                let mut nmt = TestNMT::from_elems(3, &[]).unwrap();
+                let mut nmt = TestNMT::new(3);
                 for leaf in leaves {
                     nmt.push(leaf).unwrap();
                 }

--- a/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
@@ -22,7 +22,7 @@ use self::{
 
 use super::{
     append_only::MerkleTree,
-    internal::{MerkleProof, MerkleTreeIntoIter, MerkleTreeIter},
+    internal::{MerkleProof, MerkleTreeIter},
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, Index, LookupResult, MerkleCommitment,
     MerkleTreeScheme, NodeValue,
 };
@@ -203,10 +203,6 @@ where
 
     fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue> {
         self.inner.iter()
-    }
-
-    fn into_iter(self) -> MerkleTreeIntoIter<Self::Element, Self::Index, Self::NodeValue> {
-        self.inner.into_iter()
     }
 }
 

--- a/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
@@ -22,7 +22,7 @@ use self::{
 
 use super::{
     append_only::MerkleTree,
-    internal::{MerkleProof, MerkleTreeIter},
+    internal::{MerkleProof, MerkleTreeIntoIter, MerkleTreeIter},
     AppendableMerkleTreeScheme, DigestAlgorithm, Element, Index, LookupResult, MerkleCommitment,
     MerkleTreeScheme, NodeValue,
 };
@@ -203,6 +203,10 @@ where
 
     fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue> {
         self.inner.iter()
+    }
+
+    fn into_iter(self) -> MerkleTreeIntoIter<Self::Element, Self::Index, Self::NodeValue> {
+        self.inner.into_iter()
     }
 }
 

--- a/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
+++ b/primitives/src/merkle_tree/namespaced_merkle_tree/mod.rs
@@ -21,8 +21,10 @@ use self::{
 };
 
 use super::{
-    append_only::MerkleTree, internal::MerkleProof, AppendableMerkleTreeScheme, DigestAlgorithm,
-    Element, Index, LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue,
+    append_only::MerkleTree,
+    internal::{MerkleProof, MerkleTreeIter},
+    AppendableMerkleTreeScheme, DigestAlgorithm, Element, Index, LookupResult, MerkleCommitment,
+    MerkleTreeScheme, NodeValue,
 };
 
 mod hash;
@@ -197,6 +199,10 @@ where
         proof: impl Borrow<Self::MembershipProof>,
     ) -> Result<VerificationResult, PrimitivesError> {
         <InnerTree<E, H, T, N, Arity> as MerkleTreeScheme>::verify(root, pos, proof)
+    }
+
+    fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue> {
+        self.inner.iter()
     }
 }
 

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -6,7 +6,7 @@
 
 //! Implementation of a typical Sparse Merkle Tree.
 use super::{
-    internal::{build_tree_internal, MerkleNode, MerkleProof, MerkleTreeCommitment},
+    internal::{MerkleNode, MerkleProof, MerkleTreeCommitment},
     DigestAlgorithm, Element, ForgetableMerkleTreeScheme, ForgetableUniversalMerkleTreeScheme,
     Index, LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
     UniversalMerkleTreeScheme,
@@ -24,14 +24,14 @@ use serde::{Deserialize, Serialize};
 use typenum::Unsigned;
 
 // A standard Universal Merkle tree implementation
-impl_merkle_tree_scheme!(UniversalMerkleTree, build_tree_internal);
+impl_merkle_tree_scheme!(UniversalMerkleTree);
 impl_forgetable_merkle_tree_scheme!(UniversalMerkleTree);
 
 impl<E, H, I, Arity, T> UniversalMerkleTreeScheme for UniversalMerkleTree<E, H, I, Arity, T>
 where
     E: Element,
     H: DigestAlgorithm<E, I, T>,
-    I: Index + From<u64> + ToTraversalPath<Arity>,
+    I: Index + ToTraversalPath<Arity>,
     Arity: Unsigned,
     T: NodeValue,
 {
@@ -73,7 +73,7 @@ where
         BI: Borrow<Self::Index>,
         BE: Borrow<Self::Element>,
     {
-        let mut mt = Self::from_elems(height, [] as [&Self::Element; 0])?;
+        let mut mt = Self::new(height);
         for tuple in data.into_iter() {
             let (key, value) = tuple.borrow();
             UniversalMerkleTreeScheme::update(&mut mt, key.borrow(), value.borrow())?;
@@ -124,7 +124,7 @@ impl<E, H, I, Arity, T> ForgetableUniversalMerkleTreeScheme
 where
     E: Element,
     H: DigestAlgorithm<E, I, T>,
-    I: Index + From<u64> + ToTraversalPath<Arity>,
+    I: Index + ToTraversalPath<Arity>,
     Arity: Unsigned,
     T: NodeValue,
 {
@@ -274,7 +274,7 @@ mod mt_tests {
 
     fn test_update_and_lookup_helper<I, F>()
     where
-        I: Index + ToTraversalPath<U3> + From<u64>,
+        I: Index + ToTraversalPath<U3>,
         F: RescueParameter + ToTraversalPath<U3>,
         RescueHash<F>: DigestAlgorithm<F, I, F>,
     {

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -55,6 +55,16 @@ where
         Ok(ret)
     }
 
+    fn update_with<F>(&mut self, pos: impl Borrow<Self::Index>, f: F) -> Result<(), PrimitivesError>
+    where
+        F: FnOnce(Option<&Self::Element>) -> Option<Self::Element>,
+    {
+        let pos = pos.borrow();
+        let traversal_path = pos.to_traversal_path(self.height);
+        self.root
+            .update_with_internal::<H, Arity, F>(self.height, pos, &traversal_path, f)
+    }
+
     fn from_kv_set<BI, BE>(
         height: usize,
         data: impl IntoIterator<Item = impl Borrow<(BI, BE)>>,

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -323,6 +323,7 @@ mod mt_tests {
             .universal_lookup(F::from(8u64))
             .expect_not_found()
             .is_ok());
+        assert_eq!(mt.num_leaves(), 9);
     }
 
     #[test]

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -6,7 +6,7 @@
 
 //! Implementation of a typical Sparse Merkle Tree.
 use super::{
-    internal::{MerkleNode, MerkleProof, MerkleTreeCommitment, MerkleTreeIter},
+    internal::{MerkleNode, MerkleProof, MerkleTreeCommitment, MerkleTreeIntoIter, MerkleTreeIter},
     DigestAlgorithm, Element, ForgetableMerkleTreeScheme, ForgetableUniversalMerkleTreeScheme,
     Index, LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
     UniversalMerkleTreeScheme,

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -320,7 +320,7 @@ mod mt_tests {
             .universal_lookup(BigUint::from(0u64))
             .expect_ok()
             .unwrap();
-        let lookup_elem = lookup_elem.clone();
+        let lookup_elem = *lookup_elem;
         let (elem, mem_proof) = mt.universal_forget(0u64.into()).expect_ok().unwrap();
         assert_eq!(lookup_elem, elem);
         assert_eq!(lookup_mem_proof, mem_proof);

--- a/primitives/src/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/merkle_tree/universal_merkle_tree.rs
@@ -6,7 +6,7 @@
 
 //! Implementation of a typical Sparse Merkle Tree.
 use super::{
-    internal::{MerkleNode, MerkleProof, MerkleTreeCommitment},
+    internal::{MerkleNode, MerkleProof, MerkleTreeCommitment, MerkleTreeIter},
     DigestAlgorithm, Element, ForgetableMerkleTreeScheme, ForgetableUniversalMerkleTreeScheme,
     Index, LookupResult, MerkleCommitment, MerkleTreeScheme, NodeValue, ToTraversalPath,
     UniversalMerkleTreeScheme,

--- a/primitives/src/pcs/multilinear_kzg/batching.rs
+++ b/primitives/src/pcs/multilinear_kzg/batching.rs
@@ -338,7 +338,7 @@ mod tests {
 
         let evals = generate_evaluations(polys, &points)?;
 
-        let com = MultilinearKzgPCS::batch_commit(&(ml_ck.clone(), uni_ck.clone()), polys)?;
+        let com = MultilinearKzgPCS::batch_commit((ml_ck.clone(), uni_ck.clone()), polys)?;
         let (batch_proof, evaluations) =
             batch_open_internal(&uni_ck, &ml_ck, polys, &com, &points)?;
 

--- a/primitives/src/pcs/multilinear_kzg/srs.rs
+++ b/primitives/src/pcs/multilinear_kzg/srs.rs
@@ -322,7 +322,7 @@ mod tests {
         let scalar_bits = E::ScalarField::MODULUS_BIT_SIZE as usize;
 
         let mut eq: LinkedList<DenseMultilinearExtension<E::ScalarField>> =
-            LinkedList::from_iter(eq_extension(&t).into_iter());
+            LinkedList::from_iter(eq_extension(&t));
         let mut eq_arr = LinkedList::new();
         let mut base = eq.pop_back().unwrap().evaluations;
 

--- a/primitives/src/signatures/bls_over_bn254.rs
+++ b/primitives/src/signatures/bls_over_bn254.rs
@@ -504,10 +504,10 @@ mod tests {
 
     #[test]
     fn test_agg_sig_trait() {
-        let m1 = vec![87u8, 32u8];
-        let m2 = vec![12u8, 2u8, 7u8];
-        let m3 = vec![3u8, 6u8];
-        let m4 = vec![72u8];
+        let m1 = [87u8, 32u8];
+        let m2 = [12u8, 2u8, 7u8];
+        let m3 = [3u8, 6u8];
+        let m4 = [72u8];
         let messages = vec![&m1[..], &m2[..], &m3[..], &m4[..]];
         let wrong_message = vec![255u8];
         agg_sign_and_verify::<BLSOverBN254CurveSignatureScheme>(
@@ -565,7 +565,7 @@ mod tests {
             // Generate two group elements that are equal but have different projective
             // representation.
             let mut vk = VerKey::from(&SignKey::generate(&mut rng));
-            let vk_copy = vk.clone();
+            let vk_copy = vk;
             let scalar = ark_bn254::Fq::rand(&mut rng);
             let scalar_sq = scalar * scalar;
             let scalar_cube = scalar_sq * scalar;

--- a/primitives/src/toeplitz.rs
+++ b/primitives/src/toeplitz.rs
@@ -308,7 +308,7 @@ mod tests {
 
         // bad path
         // mismatched matrix.col.len() and msgs.len() should fail
-        let bad_msg = vec![msgs.to_vec(), vec![G1Projective::rand(&mut rng)]].concat();
+        let bad_msg = [msgs.to_vec(), vec![G1Projective::rand(&mut rng)]].concat();
         assert!(cir_matrix.fast_vec_mul(&bad_msg).is_err());
 
         // non power-of-two matrix fast mul should fail

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -13,7 +13,7 @@ use crate::{
     alloc::string::ToString,
     merkle_tree::{
         hasher::{HasherDigest, HasherMerkleTree, HasherNode},
-        AppendableMerkleTreeScheme, MerkleCommitment, MerkleTreeScheme,
+        MerkleCommitment, MerkleTreeScheme,
     },
     pcs::{
         prelude::UnivariateKzgPCS, PolynomialCommitmentScheme, StructuredReferenceString,

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -290,21 +290,8 @@ where
         // TODO why do I need to compute the height of the merkle tree?
         let all_evals_commit_timer =
             start_timer!(|| "compute merkle root of all storage node evals");
-        let height: usize = all_storage_node_evals
-            .len()
-            .checked_ilog(KzgEvalsMerkleTree::<E, H>::ARITY)
-            .ok_or_else(|| {
-                VidError::Argument(format!(
-                    "num_storage_nodes {} log base {} invalid",
-                    all_storage_node_evals.len(),
-                    KzgEvalsMerkleTree::<E, H>::ARITY
-                ))
-            })?
-            .try_into()
-            .expect("num_storage_nodes log base arity should fit into usize");
-        let height = height + 1; // avoid fully qualified syntax for try_into()
         let all_evals_commit =
-            KzgEvalsMerkleTree::<E, H>::from_elems(height, &all_storage_node_evals).map_err(vid)?;
+            KzgEvalsMerkleTree::<E, H>::from_elems(None, &all_storage_node_evals).map_err(vid)?;
         end_timer!(all_evals_commit_timer);
 
         let common_timer = start_timer!(|| format!("compute {} KZG commitments", polys.len()));

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -13,7 +13,7 @@ use crate::{
     alloc::string::ToString,
     merkle_tree::{
         hasher::{HasherDigest, HasherMerkleTree, HasherNode},
-        MerkleCommitment, MerkleTreeScheme,
+        AppendableMerkleTreeScheme, MerkleCommitment, MerkleTreeScheme,
     },
     pcs::{
         prelude::UnivariateKzgPCS, PolynomialCommitmentScheme, StructuredReferenceString,

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -706,7 +706,7 @@ mod tests {
             Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, srs).unwrap();
         let payload_random = init_random_payload(1 << 20, &mut rng);
 
-        let _ = advz.disperse(&payload_random);
+        let _ = advz.disperse(payload_random);
     }
 
     // #[test]
@@ -720,13 +720,13 @@ mod tests {
             Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, srs).unwrap();
         let payload_random = init_random_payload(1 << 20, &mut rng);
 
-        let _ = advz.commit_only(&payload_random);
+        let _ = advz.commit_only(payload_random);
     }
 
     #[test]
     fn sad_path_verify_share_corrupt_share() {
         let (advz, bytes_random) = avdz_init();
-        let disperse = advz.disperse(&bytes_random).unwrap();
+        let disperse = advz.disperse(bytes_random).unwrap();
         let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
 
         for (i, share) in shares.iter().enumerate() {
@@ -792,7 +792,7 @@ mod tests {
     #[test]
     fn sad_path_verify_share_corrupt_commit() {
         let (advz, bytes_random) = avdz_init();
-        let disperse = advz.disperse(&bytes_random).unwrap();
+        let disperse = advz.disperse(bytes_random).unwrap();
         let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
 
         // missing commit
@@ -838,7 +838,7 @@ mod tests {
     #[test]
     fn sad_path_verify_share_corrupt_share_and_commit() {
         let (advz, bytes_random) = avdz_init();
-        let disperse = advz.disperse(&bytes_random).unwrap();
+        let disperse = advz.disperse(bytes_random).unwrap();
         let (mut shares, mut common, commit) = (disperse.shares, disperse.common, disperse.commit);
 
         common.poly_commits.pop();

--- a/primitives/src/vid/advz/bytes_to_field.rs
+++ b/primitives/src/vid/advz/bytes_to_field.rs
@@ -215,7 +215,7 @@ mod tests {
 
         // empty input -> empty output
         let bytes = Vec::new();
-        assert!(bytes.iter().next().is_none());
+        assert!(bytes.first().is_none());
         let mut elems_iter = bytes_to_field::<_, F>(bytes.iter());
         assert!(elems_iter.next().is_none());
 

--- a/primitives/tests/merkle_tree_hasher.rs
+++ b/primitives/tests/merkle_tree_hasher.rs
@@ -1,6 +1,8 @@
 use jf_primitives::{
     errors::PrimitivesError,
-    merkle_tree::{hasher::HasherMerkleTree, MerkleCommitment, MerkleTreeScheme},
+    merkle_tree::{
+        hasher::HasherMerkleTree, AppendableMerkleTreeScheme, MerkleCommitment, MerkleTreeScheme,
+    },
 };
 use sha2::Sha256;
 

--- a/primitives/tests/merkle_tree_hasher.rs
+++ b/primitives/tests/merkle_tree_hasher.rs
@@ -1,8 +1,6 @@
 use jf_primitives::{
     errors::PrimitivesError,
-    merkle_tree::{
-        hasher::HasherMerkleTree, AppendableMerkleTreeScheme, MerkleCommitment, MerkleTreeScheme,
-    },
+    merkle_tree::{hasher::HasherMerkleTree, MerkleCommitment, MerkleTreeScheme},
 };
 use sha2::Sha256;
 

--- a/primitives/tests/merkle_tree_hasher.rs
+++ b/primitives/tests/merkle_tree_hasher.rs
@@ -11,7 +11,7 @@ fn doctest_example() -> Result<(), PrimitivesError> {
     let my_data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
     // payload type is `usize`, hash function is `Sha256`.
-    let mt = HasherMerkleTree::<Sha256, usize>::from_elems(2, my_data)?;
+    let mt = HasherMerkleTree::<Sha256, usize>::from_elems(Some(2), my_data)?;
 
     let root = mt.commitment().digest();
     let (val, proof) = mt.lookup(2).expect_ok()?;


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #465 

- Remove the unnecessary trait bound `From<u64>` to the merkle tree index
- A new `update_with` interface for the universal merkle tree as requested here
  - https://github.com/EspressoSystems/espresso-sequencer/pull/989#discussion_r1453715569
- A new `iter()` interface for Merkle tree scheme, allows user to iterate through all elements that's in memory.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
