### PR TITLE
feat: Enable support for large polynomials in VID

### DIFF
--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -64,7 +64,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("commit"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
+            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -79,7 +79,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("disperse"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
+            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -94,16 +94,17 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("verify"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
+            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
+            let flatten_shares: Vec<_> = shares.into_iter().flatten().collect();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
                 |b, _| {
                     // verify only the 0th share
                     b.iter(|| {
-                        advz.verify_share(&shares, &common, &commit)
+                        advz.verify_share(&flatten_shares, &common, &commit)
                             .unwrap()
                             .unwrap()
                     });
@@ -116,7 +117,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("recover"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, &srs).unwrap();
+            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common) = (disperse.shares, disperse.common);
             grp.bench_with_input(

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -97,14 +97,13 @@ where
             let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
-            let flatten_shares: Vec<_> = shares.into_iter().flatten().collect();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
                 |b, _| {
                     // verify only the 0th share
                     b.iter(|| {
-                        advz.verify_share(&flatten_shares, &common, &commit)
+                        advz.verify_share(&shares[0], &common, &commit)
                             .unwrap()
                             .unwrap()
                     });

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -103,7 +103,7 @@ where
                 |b, _| {
                     // verify only the 0th share
                     b.iter(|| {
-                        advz.verify_share(&shares[0], &common, &commit)
+                        advz.verify_share(&shares, &common, &commit)
                             .unwrap()
                             .unwrap()
                     });

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -99,7 +99,7 @@ pub trait VidScheme {
 )]
 pub struct VidDisperse<V: VidScheme + ?Sized> {
     /// VID disperse shares to send to the storage nodes.
-    pub shares: Vec<V::Share>,
+    pub shares: Vec<Vec<V::Share>>,
     /// VID common data to send to all storage nodes.
     pub common: V::Common,
     /// VID payload commitment.

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -56,7 +56,7 @@ pub trait VidScheme {
     /// - VidResult::Ok(Result::Ok) if verification succeeds
     fn verify_share(
         &self,
-        share: &Self::Share,
+        share: &Vec<Self::Share>,
         common: &Self::Common,
         commit: &Self::Commit,
     ) -> VidResult<Result<(), ()>>;

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -63,7 +63,11 @@ pub trait VidScheme {
 
     /// Recover payload from shares.
     /// Do not verify shares or check recovered payload against anything.
-    fn recover_payload(&self, shares: &[Self::Share], common: &Self::Common) -> VidResult<Vec<u8>>;
+    fn recover_payload(
+        &self,
+        shares: &[Vec<Self::Share>],
+        common: &Self::Common,
+    ) -> VidResult<Vec<u8>>;
 
     /// Check that a [`VidScheme::Common`] is consistent with a
     /// [`VidScheme::Commit`].
@@ -77,6 +81,9 @@ pub trait VidScheme {
 
     /// Extract the number of storage nodes from a [`VidScheme::Common`].
     fn get_num_storage_nodes(common: &Self::Common) -> usize;
+
+    /// Extract multiplicity; number of shares per poly [`VidScheme::Common`].
+    fn get_multiplicity(common: &Self::Common) -> usize;
 }
 
 /// Convenience struct to aggregate disperse data.

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -56,7 +56,7 @@ pub trait VidScheme {
     /// - VidResult::Ok(Result::Ok) if verification succeeds
     fn verify_share(
         &self,
-        share: &Vec<Self::Share>,
+        share: &[Self::Share],
         common: &Self::Common,
         commit: &Self::Commit,
     ) -> VidResult<Result<(), ()>>;

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -56,18 +56,14 @@ pub trait VidScheme {
     /// - VidResult::Ok(Result::Ok) if verification succeeds
     fn verify_share(
         &self,
-        share: &[Self::Share],
+        share: &Self::Share,
         common: &Self::Common,
         commit: &Self::Commit,
     ) -> VidResult<Result<(), ()>>;
 
     /// Recover payload from shares.
     /// Do not verify shares or check recovered payload against anything.
-    fn recover_payload(
-        &self,
-        shares: &[Vec<Self::Share>],
-        common: &Self::Common,
-    ) -> VidResult<Vec<u8>>;
+    fn recover_payload(&self, shares: &[Self::Share], common: &Self::Common) -> VidResult<Vec<u8>>;
 
     /// Check that a [`VidScheme::Common`] is consistent with a
     /// [`VidScheme::Commit`].
@@ -82,7 +78,7 @@ pub trait VidScheme {
     /// Extract the number of storage nodes from a [`VidScheme::Common`].
     fn get_num_storage_nodes(common: &Self::Common) -> usize;
 
-    /// Extract multiplicity; number of shares per poly [`VidScheme::Common`].
+    /// Extract the number of poly evals per share [`VidScheme::Common`].
     fn get_multiplicity(common: &Self::Common) -> usize;
 }
 
@@ -106,7 +102,7 @@ pub trait VidScheme {
 )]
 pub struct VidDisperse<V: VidScheme + ?Sized> {
     /// VID disperse shares to send to the storage nodes.
-    pub shares: Vec<Vec<V::Share>>,
+    pub shares: Vec<V::Share>,
     /// VID common data to send to all storage nodes.
     pub common: V::Common,
     /// VID payload commitment.

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -934,6 +934,18 @@ mod tests {
                     format!("{} shares missing 1 eval should be arg error", i + 1).as_str(),
                 );
             }
+
+            // 1 eval missing from all shares
+            shares_missing_evals.last_mut().unwrap().evals.pop();
+            assert_arg_err(
+                advz.recover_payload(&shares_missing_evals, &common),
+                format!(
+                    "shares contain {} but expected {}",
+                    shares_missing_evals[0].evals.len(),
+                    &common.poly_commits.len()
+                )
+                .as_str(),
+            );
         }
 
         // corrupted index, in bounds

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -395,13 +395,6 @@ where
         commit: &Self::Commit,
     ) -> VidResult<Result<(), ()>> {
         // check arguments
-        let share_length = share.len();
-        if share_length != self.multiplicity {
-            return Err(VidError::Argument(format!(
-                "(shares per poly, multiplicity) differ ({},{})",
-                share_length, common.multiplicity
-            )));
-        }
 
         if share[0].evals.len() != common.poly_commits.len() {
             return Err(VidError::Argument(format!(

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -910,13 +910,9 @@ mod tests {
 
         {
             // unequal share eval lengths
-            let mut shares_missing_evals: Vec<_> = shares
-                .clone()
-                .into_iter()
-                .map(|share| share[0].clone())
-                .collect();
+            let mut shares_missing_evals = shares.clone();
             for i in 0..shares_missing_evals.len() - 1 {
-                shares_missing_evals[i].evals.pop();
+                shares_missing_evals[i][0].evals.pop();
                 assert_arg_err(
                     advz.recover_payload(&shares_missing_evals, &common),
                     format!("{} shares missing 1 eval should be arg error", i + 1).as_str(),
@@ -924,7 +920,7 @@ mod tests {
             }
 
             // 1 eval missing from all shares
-            shares_missing_evals.last_mut().unwrap().evals.pop();
+            shares_missing_evals.last_mut().unwrap()[0].evals.pop();
             let bytes_recovered = advz
                 .recover_payload(&shares_missing_evals, &common)
                 .expect("recover_payload should succeed when shares have equal eval lengths");
@@ -933,15 +929,11 @@ mod tests {
 
         // corrupted index, in bounds
         {
-            let mut shares_bad_indices: Vec<_> = shares
-                .clone()
-                .into_iter()
-                .map(|share| share[0].clone())
-                .collect();
+            let mut shares_bad_indices = shares.clone();
 
             // permute indices to avoid duplicates and keep them in bounds
             for share in &mut shares_bad_indices {
-                share.index = (share.index + 1) % advz.num_storage_nodes;
+                share[0].index = (share[0].index + 1) % advz.num_storage_nodes;
             }
 
             let bytes_recovered = advz
@@ -952,13 +944,9 @@ mod tests {
 
         // corrupted index, out of bounds
         {
-            let mut shares_bad_indices: Vec<_> = shares
-                .clone()
-                .into_iter()
-                .map(|share| share[0].clone())
-                .collect();
+            let mut shares_bad_indices = shares.clone();
             for i in 0..shares_bad_indices.len() {
-                shares_bad_indices[i].index += advz.multi_open_domain.size();
+                shares_bad_indices[i][0].index += advz.multi_open_domain.size();
                 advz.recover_payload(&shares_bad_indices, &common)
                     .expect_err("recover_payload should fail when indices are out of bounds");
             }

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -197,6 +197,8 @@ where
     evals: Vec<KzgEval<E>>,
 
     #[serde(with = "canonical")]
+    // aggretate_proofs.len() equals self.multiplicity
+    // TODO further aggregate into a single KZG proof.
     aggregate_proofs: Vec<KzgProof<E>>,
 
     evals_proof: KzgEvalsMerkleTreeProof<E, H>,

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -408,7 +408,7 @@ mod tests {
         let poly_bytes_len = payload_chunk_size * elem_byte_capacity::<E::ScalarField>();
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(payload_elems_len, &mut rng);
-        let advz = Advz::<E, H>::new(payload_chunk_size, num_storage_nodes, srs).unwrap();
+        let advz = Advz::<E, H>::new(payload_chunk_size, num_storage_nodes, None, srs).unwrap();
 
         // TEST: different payload byte lengths
         let payload_byte_len_noise_cases = vec![0, poly_bytes_len / 2, poly_bytes_len - 1];

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -408,7 +408,7 @@ mod tests {
         let poly_bytes_len = payload_chunk_size * elem_byte_capacity::<E::ScalarField>();
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(payload_elems_len, &mut rng);
-        let advz = Advz::<E, H>::new(payload_chunk_size, num_storage_nodes, None, srs).unwrap();
+        let advz = Advz::<E, H>::new(payload_chunk_size, num_storage_nodes, 1, srs).unwrap();
 
         // TEST: different payload byte lengths
         let payload_byte_len_noise_cases = vec![0, poly_bytes_len / 2, poly_bytes_len - 1];

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -32,7 +32,8 @@ fn round_trip() {
 
     vid::round_trip(
         |payload_chunk_size, num_storage_nodes| {
-            Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, &srs).unwrap()
+            Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, None, &srs)
+                .unwrap()
         },
         &vid_sizes,
         &payload_byte_lens,

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -32,8 +32,7 @@ fn round_trip() {
 
     vid::round_trip(
         |payload_chunk_size, num_storage_nodes| {
-            Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, None, &srs)
-                .unwrap()
+            Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, 1, &srs).unwrap()
         },
         &vid_sizes,
         &payload_byte_lens,

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -38,7 +38,6 @@ pub fn round_trip<V, R>(
             let disperse = vid.disperse(&bytes_random).unwrap();
             let (mut shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
             assert_eq!(shares.len(), num_storage_nodes);
-            assert_eq!(shares[0].len(), V::get_multiplicity(&common));
             assert_eq!(commit, vid.commit_only(&bytes_random).unwrap());
             assert_eq!(len, V::get_payload_byte_len(&common));
             assert_eq!(num_storage_nodes, V::get_num_storage_nodes(&common));

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -38,6 +38,7 @@ pub fn round_trip<V, R>(
             let disperse = vid.disperse(&bytes_random).unwrap();
             let (mut shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
             assert_eq!(shares.len(), num_storage_nodes);
+            assert_eq!(shares[0].len(), V::get_multiplicity(&common));
             assert_eq!(commit, vid.commit_only(&bytes_random).unwrap());
             assert_eq!(len, V::get_payload_byte_len(&common));
             assert_eq!(num_storage_nodes, V::get_num_storage_nodes(&common));


### PR DESCRIPTION
## Description

This PR introduces the concept of multiplicity of the degree for polynomials encoding the payload.
Support for large degree polynomials is done by extending message/codeword length by a factor $\alpha$ while maintaining the same rate $r=\frac{\alpha\cdot m}{\alpha\cdot n}$. Each node in the system will receive $\alpha$ evaluation points (multi-shares) for each polynomial $f_i$  $\forall i\in \{1,\ldots,k\}$.

closes: #393 