### PR TITLE
fix: incorrect VID verification/recovery (multiplicity > 1)

### DIFF
--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -981,30 +981,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn disperse_and_recover_with_multiplicity() {
-        let multiplicity = 4;
-        let bytes_per_element = bytes_to_field::elem_byte_capacity::<KzgEval<Bls12_381>>();
-        let payload_size = bytes_per_element * 1 << 7; // 128 field elements
-        let (payload_chunk_size, num_storage_nodes) = (4, 6);
-        let mut rng = jf_utils::test_rng();
-        let srs = init_srs(payload_chunk_size * multiplicity, &mut rng);
-        let advz = Advz::new(payload_chunk_size, num_storage_nodes, multiplicity, srs).unwrap();
-        let bytes_random = init_random_payload(payload_size, &mut rng);
-
-        let disperse: VidDisperse<Advz<Bls12_381, Sha256>> = advz.disperse(&bytes_random).unwrap();
-        let (shares_multiplicity, common) = (disperse.shares, disperse.common);
-        let bytes_per_element = bytes_to_field::elem_byte_capacity::<KzgEval<Bls12_381>>();
-        let bytes_per_poly = payload_chunk_size * multiplicity * bytes_per_element;
-
-        assert_eq!(common.poly_commits.len(), payload_size / bytes_per_poly);
-
-        let bytes_recovered = advz
-            .recover_payload(&shares_multiplicity, &common)
-            .expect("recover_payload should succeed with multiplicity");
-        assert_eq!(bytes_recovered, bytes_random);
-    }
-
     /// Routine initialization tasks.
     ///
     /// Returns the following tuple:

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -19,10 +19,13 @@ fn round_trip() {
 
     // more items as a function of the above
     let supported_degree = vid_sizes.iter().max_by_key(|v| v.0).unwrap().0 - 1;
-    let num_coeff = checked_fft_size(supported_degree).unwrap();
-
-    let mut sample_rng = jf_utils::test_rng();
-    multiplicities.shuffle(&mut sample_rng);
+    let mut rng = jf_utils::test_rng();
+    multiplicities.shuffle(&mut rng);
+    let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
+        &mut rng,
+        checked_fft_size(supported_degree).unwrap() * multiplicities.iter().max().unwrap(),
+    )
+    .unwrap();
 
     println!(
             "modulus byte len: {}",
@@ -32,12 +35,6 @@ fn round_trip() {
 
     vid::round_trip(
         |payload_chunk_size, num_storage_nodes, multiplicity| {
-            let mut srs_rng = jf_utils::test_rng();
-            let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
-                &mut srs_rng,
-                num_coeff * multiplicity,
-            )
-            .unwrap();
             Advz::<Bls12_381, Sha256>::new(
                 payload_chunk_size,
                 num_storage_nodes,
@@ -49,6 +46,6 @@ fn round_trip() {
         &vid_sizes,
         &multiplicities,
         &payload_byte_lens,
-        &mut sample_rng,
+        &mut rng,
     );
 }

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -14,13 +14,14 @@ fn round_trip() {
     // play with these items
     let vid_sizes = [(2, 3), (8, 11)];
     let payload_byte_lens = [0, 1, 2, 16, 32, 47, 48, 49, 64, 100, 400];
+    let multiplicity = 1;
 
     // more items as a function of the above
     let supported_degree = vid_sizes.iter().max_by_key(|v| v.0).unwrap().0 - 1;
     let mut rng = jf_utils::test_rng();
     let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
         &mut rng,
-        checked_fft_size(supported_degree).unwrap(),
+        checked_fft_size(supported_degree).unwrap() * multiplicity,
     )
     .unwrap();
 
@@ -32,7 +33,13 @@ fn round_trip() {
 
     vid::round_trip(
         |payload_chunk_size, num_storage_nodes| {
-            Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, 1, &srs).unwrap()
+            Advz::<Bls12_381, Sha256>::new(
+                payload_chunk_size,
+                num_storage_nodes,
+                multiplicity,
+                &srs,
+            )
+            .unwrap()
         },
         &vid_sizes,
         &payload_byte_lens,

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "test-srs")]
 use ark_bls12_381::Bls12_381;
 use ark_ff::{Field, PrimeField};
+use ark_std::rand::seq::SliceRandom;
 use jf_primitives::{
     pcs::{checked_fft_size, prelude::UnivariateKzgPCS, PolynomialCommitmentScheme},
     vid::advz::Advz,
@@ -14,16 +15,14 @@ fn round_trip() {
     // play with these items
     let vid_sizes = [(2, 3), (8, 11)];
     let payload_byte_lens = [0, 1, 2, 16, 32, 47, 48, 49, 64, 100, 400];
-    let multiplicity = 1;
+    let mut multiplicities = [1, 2, 4, 8, 16];
 
     // more items as a function of the above
     let supported_degree = vid_sizes.iter().max_by_key(|v| v.0).unwrap().0 - 1;
-    let mut rng = jf_utils::test_rng();
-    let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
-        &mut rng,
-        checked_fft_size(supported_degree).unwrap() * multiplicity,
-    )
-    .unwrap();
+    let num_coeff = checked_fft_size(supported_degree).unwrap();
+
+    let mut sample_rng = jf_utils::test_rng();
+    multiplicities.shuffle(&mut sample_rng);
 
     println!(
             "modulus byte len: {}",
@@ -32,7 +31,13 @@ fn round_trip() {
         );
 
     vid::round_trip(
-        |payload_chunk_size, num_storage_nodes| {
+        |payload_chunk_size, num_storage_nodes, multiplicity| {
+            let mut srs_rng = jf_utils::test_rng();
+            let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
+                &mut srs_rng,
+                num_coeff * multiplicity,
+            )
+            .unwrap();
             Advz::<Bls12_381, Sha256>::new(
                 payload_chunk_size,
                 num_storage_nodes,
@@ -42,7 +47,8 @@ fn round_trip() {
             .unwrap()
         },
         &vid_sizes,
+        &multiplicities,
         &payload_byte_lens,
-        &mut rng,
+        &mut sample_rng,
     );
 }


### PR DESCRIPTION
## Description

#480 introduced a new feature that allows for building polynomials of larger degree when encoding the VID payload by choosing a multiplicity parameter but no tests were submitted with the new features.
 
This PR fixes issues in the VID verification and payload recovery when `multiplicity > 1` and **creates a test** to exercise the new part of the code.

closes: #483 