### PR TITLE
feat: Enable precomputation of VID dispersal data

### DIFF
--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -108,6 +108,7 @@ pub struct VidDisperse<V: VidScheme + ?Sized> {
     /// VID payload commitment.
     pub commit: V::Commit,
 }
+pub mod precomputable;
 
 pub mod payload_prover;
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -46,6 +46,7 @@ use serde::{Deserialize, Serialize};
 
 mod bytes_to_field;
 pub mod payload_prover;
+pub mod precomputable;
 
 /// The [ADVZ VID scheme](https://eprint.iacr.org/2021/1500), a concrete impl for [`VidScheme`].
 ///
@@ -253,7 +254,8 @@ where
             .into_iter()
             .map(|evals_iter| self.polynomial(evals_iter))
             .collect();
-        let poly_commits = UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
+        let poly_commits: Vec<crate::pcs::prelude::Commitment<E>> =
+            UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
         Self::derive_commit(&poly_commits, payload.len(), code_word_size)
     }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -16,14 +16,16 @@ use crate::{
         MerkleCommitment, MerkleTreeScheme,
     },
     pcs::{
-        prelude::UnivariateKzgPCS, PolynomialCommitmentScheme, StructuredReferenceString,
-        UnivariatePCS,
+        prelude::{UnivariateKzgPCS, UnivariateKzgProof},
+        PolynomialCommitmentScheme, StructuredReferenceString, UnivariatePCS,
     },
     reed_solomon_code::reed_solomon_erasure_decode_rou,
 };
 use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_ff::{Field, PrimeField};
-use ark_poly::{DenseUVPolynomial, EvaluationDomain, Radix2EvaluationDomain};
+use ark_poly::{
+    univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, Radix2EvaluationDomain,
+};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
     borrow::Borrow,
@@ -246,13 +248,7 @@ where
         B: AsRef<[u8]>,
     {
         let payload = payload.as_ref();
-        let chunk_size = self.multiplicity * self.payload_chunk_size;
-
-        let polys: Vec<_> = bytes_to_field::<_, KzgEval<E>>(payload)
-            .chunks(chunk_size)
-            .into_iter()
-            .map(|evals_iter| self.polynomial(evals_iter))
-            .collect();
+        let polys = self.bytes_to_polys(payload);
         let poly_commits = UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
         Self::derive_commit(&poly_commits, payload.len(), self.num_storage_nodes)
     }
@@ -267,52 +263,22 @@ where
             "VID disperse {} payload bytes to {} nodes",
             payload_byte_len, self.num_storage_nodes
         ));
-        let chunk_size = self.multiplicity * self.payload_chunk_size;
+        let _chunk_size = self.multiplicity * self.payload_chunk_size;
         let code_word_size = self.multiplicity * self.num_storage_nodes;
 
         // partition payload into polynomial coefficients
         // and count `elems_len` for later
         let bytes_to_polys_time = start_timer!(|| "encode payload bytes into polynomials");
-        let elems_iter = bytes_to_field::<_, KzgEval<E>>(payload);
-        let polys: Vec<_> = elems_iter
-            .chunks(chunk_size)
-            .into_iter()
-            .map(|evals_iter| self.polynomial(evals_iter))
-            .collect();
+        let polys = self.bytes_to_polys(payload);
         end_timer!(bytes_to_polys_time);
 
         // evaluate polynomials
         let all_storage_node_evals_timer = start_timer!(|| format!(
             "compute all storage node evals for {} polynomials with {} coefficients",
             polys.len(),
-            chunk_size
+            _chunk_size
         ));
-        let all_storage_node_evals = {
-            let mut all_storage_node_evals = vec![Vec::with_capacity(polys.len()); code_word_size];
-
-            for poly in polys.iter() {
-                let poly_evals = UnivariateKzgPCS::<E>::multi_open_rou_evals(
-                    poly,
-                    code_word_size,
-                    &self.multi_open_domain,
-                )
-                .map_err(vid)?;
-
-                for (storage_node_evals, poly_eval) in
-                    all_storage_node_evals.iter_mut().zip(poly_evals)
-                {
-                    storage_node_evals.push(poly_eval);
-                }
-            }
-
-            // sanity checks
-            assert_eq!(all_storage_node_evals.len(), code_word_size);
-            for storage_node_evals in all_storage_node_evals.iter() {
-                assert_eq!(storage_node_evals.len(), polys.len());
-            }
-
-            all_storage_node_evals
-        };
+        let all_storage_node_evals = self.evaluate_polys(&polys)?;
         end_timer!(all_storage_node_evals_timer);
 
         // vector commitment to polynomial evaluations
@@ -360,31 +326,11 @@ where
         end_timer!(agg_proofs_timer);
 
         let assemblage_timer = start_timer!(|| "assemble shares for dispersal");
-        let mut shares = Vec::with_capacity(self.num_storage_nodes);
-        let mut evals = Vec::with_capacity(polys.len() * self.multiplicity);
-        let mut proofs = Vec::with_capacity(self.multiplicity);
-        let mut index = 0;
-        for i in 0..code_word_size {
-            evals.extend(all_storage_node_evals[i].iter());
-            proofs.push(aggregate_proofs[i].clone());
-            if (i + 1) % self.multiplicity == 0 {
-                shares.push(Share {
-                    index,
-                    evals: mem::take(&mut evals),
-                    aggregate_proofs: mem::take(&mut proofs),
-                    evals_proof: all_evals_commit // TODO: check MT lookup for each index
-                        .lookup(KzgEvalsMerkleTreeIndex::<E, H>::from(index as u64))
-                        .expect_ok()
-                        .map_err(vid)?
-                        .1,
-                });
-                index += 1;
-            }
-        }
-
+        let shares =
+            self.assemble_shares(all_storage_node_evals, aggregate_proofs, all_evals_commit)?;
         end_timer!(assemblage_timer);
-
         end_timer!(disperse_time);
+
         Ok(VidDisperse {
             shares,
             common,
@@ -602,6 +548,44 @@ where
     E: Pairing,
     H: HasherDigest,
 {
+    fn evaluate_polys(
+        &self,
+        polys: &Vec<DensePolynomial<<E as Pairing>::ScalarField>>,
+    ) -> Result<Vec<Vec<<E as Pairing>::ScalarField>>, VidError>
+    where
+        E: Pairing,
+        H: HasherDigest,
+    {
+        let code_word_size = self.num_storage_nodes * self.multiplicity;
+        let all_storage_node_evals = {
+            let mut all_storage_node_evals = vec![Vec::with_capacity(polys.len()); code_word_size];
+
+            for poly in polys.iter() {
+                let poly_evals = UnivariateKzgPCS::<E>::multi_open_rou_evals(
+                    poly,
+                    code_word_size,
+                    &self.multi_open_domain,
+                )
+                .map_err(vid)?;
+
+                for (storage_node_evals, poly_eval) in
+                    all_storage_node_evals.iter_mut().zip(poly_evals)
+                {
+                    storage_node_evals.push(poly_eval);
+                }
+            }
+
+            // sanity checks
+            assert_eq!(all_storage_node_evals.len(), code_word_size);
+            for storage_node_evals in all_storage_node_evals.iter() {
+                assert_eq!(storage_node_evals.len(), polys.len());
+            }
+
+            all_storage_node_evals
+        };
+        Ok(all_storage_node_evals)
+    }
+
     fn pseudorandom_scalar(
         common: &<Self as VidScheme>::Common,
         commit: &<Self as VidScheme>::Commit,
@@ -627,6 +611,18 @@ where
         //   indistinguishable from uniformly random. We only need it to be
         //   unpredictable. So it suffices to use
         Ok(PrimeField::from_le_bytes_mod_order(&hasher.finalize()))
+    }
+
+    fn bytes_to_polys(&self, payload: &[u8]) -> Vec<DensePolynomial<<E as Pairing>::ScalarField>>
+    where
+        E: Pairing,
+    {
+        let chunk_size = self.payload_chunk_size * self.multiplicity;
+        bytes_to_field::<_, KzgEval<E>>(payload)
+            .chunks(chunk_size)
+            .into_iter()
+            .map(|evals_iter| self.polynomial(evals_iter))
+            .collect()
     }
 
     fn polynomial<I>(&self, coeffs: I) -> KzgPolynomial<E>
@@ -683,6 +679,45 @@ where
                 .map_err(vid)?;
         }
         Ok(hasher.finalize().into())
+    }
+
+    /// Assemble shares from evaluations and proofs.
+    ///
+    /// Each share contains (for multiplicity m):
+    /// 1. (m * num_poly) evaluations.
+    /// 2. m aggregated KZG proofs.
+    /// 3. a merkle tree membership proof.
+    fn assemble_shares(
+        &self,
+        all_storage_node_evals: Vec<Vec<<E as Pairing>::ScalarField>>,
+        aggregate_proofs: Vec<UnivariateKzgProof<E>>,
+        all_evals_commit: KzgEvalsMerkleTree<E, H>,
+    ) -> Result<Vec<Share<E, H>>, VidError>
+    where
+        E: Pairing,
+        H: HasherDigest,
+    {
+        let code_word_size = self.num_storage_nodes * self.multiplicity;
+        let mut shares = Vec::with_capacity(code_word_size);
+        let mut evals = Vec::new();
+        let mut proofs = Vec::new();
+        for index in 0..code_word_size {
+            evals.extend(all_storage_node_evals[index].iter());
+            proofs.push(aggregate_proofs[index].clone());
+            if (index + 1) % self.multiplicity == 0 {
+                shares.push(Share {
+                    index,
+                    evals: mem::take(&mut evals),
+                    aggregate_proofs: mem::take(&mut proofs),
+                    evals_proof: all_evals_commit // TODO: check MT lookup for each index
+                        .lookup(KzgEvalsMerkleTreeIndex::<E, H>::from(index as u64))
+                        .expect_ok()
+                        .map_err(vid)?
+                        .1,
+                });
+            }
+        }
+        Ok(shares)
     }
 }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -253,8 +253,7 @@ where
             .into_iter()
             .map(|evals_iter| self.polynomial(evals_iter))
             .collect();
-        let poly_commits: Vec<crate::pcs::prelude::Commitment<E>> =
-            UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
+        let poly_commits = UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
         Self::derive_commit(&poly_commits, payload.len(), self.num_storage_nodes)
     }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -247,7 +247,6 @@ where
     {
         let payload = payload.as_ref();
         let chunk_size = self.multiplicity * self.payload_chunk_size;
-        let code_word_size = self.multiplicity * self.num_storage_nodes;
 
         let polys: Vec<_> = bytes_to_field::<_, KzgEval<E>>(payload)
             .chunks(chunk_size)
@@ -256,7 +255,7 @@ where
             .collect();
         let poly_commits: Vec<crate::pcs::prelude::Commitment<E>> =
             UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
-        Self::derive_commit(&poly_commits, payload.len(), code_word_size)
+        Self::derive_commit(&poly_commits, payload.len(), self.num_storage_nodes)
     }
 
     fn disperse<B>(&self, payload: B) -> VidResult<VidDisperse<Self>>

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -267,7 +267,6 @@ where
         let code_word_size = self.multiplicity * self.num_storage_nodes;
 
         // partition payload into polynomial coefficients
-        // and count `elems_len` for later
         let bytes_to_polys_time = start_timer!(|| "encode payload bytes into polynomials");
         let polys = self.bytes_to_polys(payload);
         end_timer!(bytes_to_polys_time);

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -685,7 +685,7 @@ where
     ///
     /// Each share contains (for multiplicity m):
     /// 1. (m * num_poly) evaluations.
-    /// 2. m aggregated KZG proofs.
+    /// 2. a collection of m KZG proofs. TODO KZG aggregation https://github.com/EspressoSystems/jellyfish/issues/356
     /// 3. a merkle tree membership proof.
     fn assemble_shares(
         &self,

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -550,7 +550,7 @@ where
 {
     fn evaluate_polys(
         &self,
-        polys: &Vec<DensePolynomial<<E as Pairing>::ScalarField>>,
+        polys: &[DensePolynomial<<E as Pairing>::ScalarField>],
     ) -> Result<Vec<Vec<<E as Pairing>::ScalarField>>, VidError>
     where
         E: Pairing,

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -10,7 +10,7 @@ use core::mem;
 
 use crate::{
     merkle_tree::{MerkleCommitment, MerkleTreeScheme},
-    pcs::{PolynomialCommitmentScheme, UnivariatePCS},
+    pcs::{prelude::Commitment, PolynomialCommitmentScheme, UnivariatePCS},
     vid::{
         advz::{
             bytes_to_field, polynomial_eval, Advz, Common, HasherDigest, KzgEval,
@@ -51,11 +51,12 @@ where
             .into_iter()
             .map(|evals_iter| self.polynomial(evals_iter))
             .collect();
-        let poly_commits: Vec<crate::pcs::prelude::Commitment<E>> =
+        let poly_commits: Vec<Commitment<E>> =
             UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
-        let commit = Self::derive_commit(&poly_commits, payload.len(), self.num_storage_nodes);
-
-        commit.map(|c| (c, PrecomputeData { poly_commits }))
+        Ok((
+            Self::derive_commit(&poly_commits, payload.len(), self.num_storage_nodes)?,
+            PrecomputeData { poly_commits },
+        ))
     }
 
     fn disperse_precompute<B>(

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -137,8 +137,7 @@ where
             polys.len()
         ));
         let common = Common {
-            poly_commits: data.poly_commits.clone(), /* UnivariateKzgPCS::batch_commit(&self.ck,
-                                                      * &polys).map_err(vid)?, */
+            poly_commits: data.poly_commits.clone(),
             all_evals_digest: all_evals_commit.commitment().digest(),
             payload_byte_len,
             num_storage_nodes: self.num_storage_nodes.try_into().map_err(vid)?,

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Espresso Systems (espressosys.com)
+// Copyright (c) 2024 Espresso Systems (espressosys.com)
 // This file is part of the Jellyfish library.
 
 // You should have received a copy of the MIT License

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -1,0 +1,290 @@
+// Copyright (c) 2023 Espresso Systems (espressosys.com)
+// This file is part of the Jellyfish library.
+
+// You should have received a copy of the MIT License
+// along with the Jellyfish library. If not, see <https://mit-license.org/>.
+
+//! Implementations of [`Precomputable`] for `Advz`.
+
+use core::mem;
+
+use crate::{
+    merkle_tree::{MerkleCommitment, MerkleTreeScheme},
+    pcs::{PolynomialCommitmentScheme, UnivariatePCS},
+    vid::{
+        advz::{
+            bytes_to_field, polynomial_eval, Advz, Common, HasherDigest, KzgEval,
+            KzgEvalsMerkleTree, KzgEvalsMerkleTreeIndex, Pairing, PolynomialMultiplier, Share,
+            UnivariateKzgPCS,
+        },
+        precomputable::Precomputable,
+        vid, VidDisperse,
+    },
+};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::{end_timer, start_timer, vec, vec::Vec};
+use itertools::Itertools;
+use jf_utils::canonical;
+use serde::{Deserialize, Serialize};
+
+use super::KzgCommit;
+
+impl<E, H> Precomputable for Advz<E, H>
+where
+    E: Pairing,
+    H: HasherDigest,
+{
+    type PrecomputeData = PrecomputeData<E>;
+
+    fn commit_only_precompute<B>(
+        &self,
+        payload: B,
+    ) -> crate::vid::VidResult<(Self::Commit, Self::PrecomputeData)>
+    where
+        B: AsRef<[u8]>,
+    {
+        let payload = payload.as_ref();
+        let chunk_size = self.multiplicity * self.payload_chunk_size;
+        let code_word_size = self.multiplicity * self.num_storage_nodes;
+
+        let polys: Vec<_> = bytes_to_field::<_, KzgEval<E>>(payload)
+            .chunks(chunk_size)
+            .into_iter()
+            .map(|evals_iter| self.polynomial(evals_iter))
+            .collect();
+        let poly_commits: Vec<crate::pcs::prelude::Commitment<E>> =
+            UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
+        let commit = Self::derive_commit(&poly_commits, payload.len(), code_word_size);
+
+        commit.map(|c| (c, PrecomputeData { poly_commits }))
+    }
+
+    fn disperse_precompute<B>(
+        &self,
+        payload: B,
+        data: &Self::PrecomputeData,
+    ) -> crate::vid::VidResult<crate::vid::VidDisperse<Self>>
+    where
+        B: AsRef<[u8]>,
+    {
+        let payload = payload.as_ref();
+        let payload_byte_len = payload.len().try_into().map_err(vid)?;
+        let disperse_time = start_timer!(|| ark_std::format!(
+            "VID disperse {} payload bytes to {} nodes",
+            payload_byte_len,
+            self.num_storage_nodes
+        ));
+        let chunk_size = self.multiplicity * self.payload_chunk_size;
+        let code_word_size = self.multiplicity * self.num_storage_nodes;
+
+        // partition payload into polynomial coefficients
+        // and count `elems_len` for later
+        let bytes_to_polys_time = start_timer!(|| "encode payload bytes into
+        polynomials");
+        let elems_iter = bytes_to_field::<_, KzgEval<E>>(payload);
+        let polys: Vec<_> = elems_iter
+            .chunks(chunk_size)
+            .into_iter()
+            .map(|evals_iter| self.polynomial(evals_iter))
+            .collect();
+        end_timer!(bytes_to_polys_time);
+
+        // evaluate polynomials
+        let all_storage_node_evals_timer = start_timer!(|| ark_std::format!(
+            "compute all storage node evals for {} polynomials with {} coefficients",
+            polys.len(),
+            chunk_size
+        ));
+        let all_storage_node_evals = {
+            let mut all_storage_node_evals = vec![Vec::with_capacity(polys.len()); code_word_size];
+
+            for poly in polys.iter() {
+                let poly_evals = UnivariateKzgPCS::<E>::multi_open_rou_evals(
+                    poly,
+                    code_word_size,
+                    &self.multi_open_domain,
+                )
+                .map_err(vid)?;
+
+                for (storage_node_evals, poly_eval) in
+                    all_storage_node_evals.iter_mut().zip(poly_evals)
+                {
+                    storage_node_evals.push(poly_eval);
+                }
+            }
+
+            // sanity checks
+            assert_eq!(all_storage_node_evals.len(), code_word_size);
+            for storage_node_evals in all_storage_node_evals.iter() {
+                assert_eq!(storage_node_evals.len(), polys.len());
+            }
+
+            all_storage_node_evals
+        };
+        end_timer!(all_storage_node_evals_timer);
+
+        // vector commitment to polynomial evaluations
+        // TODO why do I need to compute the height of the merkle tree?
+        let all_evals_commit_timer =
+            start_timer!(|| "compute merkle root of all storage node evals");
+        let all_evals_commit =
+            KzgEvalsMerkleTree::<E, H>::from_elems(None, &all_storage_node_evals).map_err(vid)?;
+        end_timer!(all_evals_commit_timer);
+
+        let common_timer =
+            start_timer!(|| ark_std::format!("compute {} KZG commitments", polys.len()));
+        let common = Common {
+            poly_commits: data.poly_commits.clone(), /* UnivariateKzgPCS::batch_commit(&self.ck,
+                                                      * &polys).map_err(vid)?, */
+            all_evals_digest: all_evals_commit.commitment().digest(),
+            payload_byte_len,
+            num_storage_nodes: self.num_storage_nodes.try_into().map_err(vid)?,
+            multiplicity: self.multiplicity.try_into().map_err(vid)?,
+        };
+        end_timer!(common_timer);
+
+        let commit = Self::derive_commit(
+            &common.poly_commits,
+            payload_byte_len,
+            self.num_storage_nodes,
+        )?;
+        let pseudorandom_scalar = Self::pseudorandom_scalar(&common, &commit)?;
+
+        // Compute aggregate polynomial as a pseudorandom linear combo of polynomial via
+        // evaluation of the polynomial whose coefficients are polynomials and whose
+        // input point is the pseudorandom scalar.
+        let aggregate_poly =
+            polynomial_eval(polys.iter().map(PolynomialMultiplier), pseudorandom_scalar);
+
+        let agg_proofs_timer = start_timer!(|| ark_std::format!(
+            "compute aggregate proofs for {} storage nodes",
+            self.num_storage_nodes
+        ));
+        let aggregate_proofs = UnivariateKzgPCS::multi_open_rou_proofs(
+            &self.ck,
+            &aggregate_poly,
+            code_word_size,
+            &self.multi_open_domain,
+        )
+        .map_err(vid)?;
+        end_timer!(agg_proofs_timer);
+
+        let assemblage_timer = start_timer!(|| "assemble shares for dispersal");
+
+        let mut shares = Vec::with_capacity(code_word_size);
+        let mut evals = Vec::new();
+        let mut proofs = Vec::new();
+        for index in 0..code_word_size {
+            evals.extend(all_storage_node_evals[index].iter());
+            proofs.push(aggregate_proofs[index].clone());
+            if (index + 1) % self.multiplicity == 0 {
+                shares.push(Share {
+                    index,
+                    evals: mem::take(&mut evals),
+                    aggregate_proofs: mem::take(&mut proofs),
+                    evals_proof: all_evals_commit // TODO: check MT lookup for each index
+                        .lookup(KzgEvalsMerkleTreeIndex::<E, H>::from(index as u64))
+                        .expect_ok()
+                        .map_err(vid)?
+                        .1,
+                });
+            }
+        }
+
+        end_timer!(assemblage_timer);
+
+        end_timer!(disperse_time);
+        Ok(VidDisperse {
+            shares,
+            common,
+            commit,
+        })
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    CanonicalSerialize,
+    CanonicalDeserialize,
+    Derivative,
+    Deserialize,
+    Serialize,
+    PartialEq,
+    Eq,
+)]
+#[derivative(Hash(bound = ""))]
+/// Data that can be precomputed as used in dispersal
+pub struct PrecomputeData<E>
+where
+    E: Pairing,
+{
+    #[serde(with = "canonical")]
+    poly_commits: Vec<KzgCommit<E>>,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::vid::precomputable::Precomputable;
+    use ark_bls12_381::Bls12_381;
+
+    use sha2::Sha256;
+
+    use crate::vid::{
+        advz::{
+            tests::{avdz_init, init_random_payload, init_srs},
+            Advz,
+        },
+        VidScheme,
+    };
+
+    #[test]
+    fn commit_only_with_data_timer() {
+        // run with 'print-trace' feature to see timer output
+        let (payload_chunk_size, num_storage_nodes) = (256, 512);
+        let mut rng = jf_utils::test_rng();
+        let multiplicity = 1;
+        let srs = init_srs(payload_chunk_size * multiplicity, &mut rng);
+        let advz = Advz::<Bls12_381, Sha256>::new(
+            payload_chunk_size,
+            num_storage_nodes,
+            multiplicity,
+            srs,
+        )
+        .unwrap();
+        let payload_random = init_random_payload(1 << 20, &mut rng);
+
+        let (_commit, _data) = advz.commit_only_precompute(payload_random).unwrap();
+    }
+
+    #[test]
+    fn disperse_with_data_timer() {
+        // run with 'print-trace' feature to see timer output
+        let (payload_chunk_size, num_storage_nodes) = (256, 512);
+        let mut rng = jf_utils::test_rng();
+        let srs = init_srs(payload_chunk_size, &mut rng);
+        let advz =
+            Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, 1, srs).unwrap();
+        let payload_random = init_random_payload(1 << 25, &mut rng);
+        let (_commit, data) = advz.commit_only_precompute(&payload_random).unwrap();
+        let _ = advz.disperse_precompute(payload_random, &data);
+    }
+
+    #[test]
+    fn commit_disperse_recover_with_precomputed_data() {
+        let (advz, bytes_random) = avdz_init();
+        let (commit, data) = advz.commit_only_precompute(&bytes_random).unwrap();
+        let disperse = advz.disperse_precompute(&bytes_random, &data).unwrap();
+        let (shares, common) = (disperse.shares, disperse.common);
+        for share in &shares {
+            let v = advz.verify_share(share, &common, &commit);
+            assert!(v.is_ok(), "all advz shares should verify");
+        }
+
+        let bytes_recovered = advz
+            .recover_payload(&shares, &common)
+            .expect("recover_payload should succeed when indices are in bounds");
+        assert_eq!(bytes_recovered, bytes_random);
+    }
+}

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -45,7 +45,6 @@ where
     {
         let payload = payload.as_ref();
         let chunk_size = self.multiplicity * self.payload_chunk_size;
-        let code_word_size = self.multiplicity * self.num_storage_nodes;
 
         let polys: Vec<_> = bytes_to_field::<_, KzgEval<E>>(payload)
             .chunks(chunk_size)
@@ -54,7 +53,7 @@ where
             .collect();
         let poly_commits: Vec<crate::pcs::prelude::Commitment<E>> =
             UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
-        let commit = Self::derive_commit(&poly_commits, payload.len(), code_word_size);
+        let commit = Self::derive_commit(&poly_commits, payload.len(), self.num_storage_nodes);
 
         commit.map(|c| (c, PrecomputeData { poly_commits }))
     }
@@ -275,7 +274,7 @@ mod tests {
             srs,
         )
         .unwrap();
-        let payload_random = init_random_payload(1 << 22, &mut rng);
+        let payload_random = init_random_payload(1 << 20, &mut rng);
         let (_commit, data) = advz.commit_only_precompute(&payload_random).unwrap();
         let _ = advz.disperse_precompute(payload_random, &data);
     }

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -18,7 +18,7 @@ use crate::{
             UnivariateKzgPCS,
         },
         precomputable::Precomputable,
-        vid, VidDisperse,
+        vid, VidDisperse, VidResult,
     },
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -39,7 +39,7 @@ where
     fn commit_only_precompute<B>(
         &self,
         payload: B,
-    ) -> crate::vid::VidResult<(Self::Commit, Self::PrecomputeData)>
+    ) -> VidResult<(Self::Commit, Self::PrecomputeData)>
     where
         B: AsRef<[u8]>,
     {
@@ -63,7 +63,7 @@ where
         &self,
         payload: B,
         data: &Self::PrecomputeData,
-    ) -> crate::vid::VidResult<crate::vid::VidDisperse<Self>>
+    ) -> VidResult<VidDisperse<Self>>
     where
         B: AsRef<[u8]>,
     {

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -241,6 +241,7 @@ mod tests {
         VidScheme,
     };
 
+    #[ignore]
     #[test]
     fn commit_only_with_data_timer() {
         // run with 'print-trace' feature to see timer output
@@ -260,6 +261,7 @@ mod tests {
         let (_commit, _data) = advz.commit_only_precompute(payload_random).unwrap();
     }
 
+    #[ignore]
     #[test]
     fn disperse_with_data_timer() {
         // run with 'print-trace' feature to see timer output

--- a/primitives/src/vid/precomputable.rs
+++ b/primitives/src/vid/precomputable.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Espresso Systems (espressosys.com)
+// Copyright (c) 2024 Espresso Systems (espressosys.com)
 // This file is part of the Jellyfish library.
 
 // You should have received a copy of the MIT License

--- a/primitives/src/vid/precomputable.rs
+++ b/primitives/src/vid/precomputable.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 Espresso Systems (espressosys.com)
+// This file is part of the Jellyfish library.
+
+// You should have received a copy of the MIT License
+// along with the Jellyfish library. If not, see <https://mit-license.org/>.
+
+//! Trait for additional functionality in Verifiable Information Retrieval (VID)
+//! for precomputation of specific data that allows for calling
+//! methods using the data to save computation for the callee.
+
+use core::fmt::Debug;
+
+use super::{VidDisperse, VidResult, VidScheme};
+use ark_std::hash::Hash;
+use serde::{de::DeserializeOwned, Serialize};
+/// Allow for precomputation of certain data for [`VidScheme`].
+pub trait Precomputable: VidScheme {
+    /// Precomputed data that can be (re-)used during disperse computation
+    type PrecomputeData: Clone + Debug + Eq + PartialEq + Hash + Sync + Serialize + DeserializeOwned;
+
+    /// Similar to [`VidScheme::commit_only`] but returns additional data that
+    /// can be used as input to `disperse_precompute` for faster dispersal.
+    fn commit_only_precompute<B>(
+        &self,
+        payload: B,
+    ) -> VidResult<(Self::Commit, Self::PrecomputeData)>
+    where
+        B: AsRef<[u8]>;
+
+    /// Similar to [`VidScheme::disperse`] but takes as input additional
+    /// data for more efficient computation and faster disersal.
+    fn disperse_precompute<B>(
+        &self,
+        payload: B,
+        data: &Self::PrecomputeData,
+    ) -> VidResult<VidDisperse<Self>>
+    where
+        B: AsRef<[u8]>;
+}


### PR DESCRIPTION
## Description

Follows the approach described here: #479.

Introducing the subtrait `Precomputable` to a VID scheme.
This allows for re-using the polynomial commitments (from `commit_only_precompute`) when calling `disperse_precompute`.

Lots of code-duplication but was a bit reluctant to refactor and make pre-mature code optimizations since we might have more data that can potentially be pre-computed and keeping the disperse code as is (in one function) makes it easy to map tracing output to code (readability of benchmarks).

---

Preliminary testing for pre-computation approach:
`payload_size = 33MB, num_storage_nodes = 128, multiplicity = 8`

We get running times:
commit_only_precompute: 2.768s
**disperse_precompute: 2.580s**

(see test run below)
```
Espressos-MBP:jellyfish espressosystems$ cargo test --release --package jf-primitives --lib --features print-trace -- vid::advz::precomputable::tests::disperse_with_data_timer --exact --nocapture
   Compiling jf-primitives v0.4.0-pre.0 (/Users/espressosystems/projects/jellyfish/primitives)
    Finished release [optimized] target(s) in 17.71s
     Running unittests src/lib.rs (target/nix_rustc/release/deps/jf_primitives-a0dd78b380e04750)

running 1 test
Start:   KZG10::Setup with prover degree 512 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................4.297ms
End:     KZG10::Setup with prover degree 512 and verifier degree 1 .................7.846ms
Start:   batch commit 2115 polynomials
End:     batch commit 2115 polynomials .............................................2.768s
Start:   (PRECOMPUTE): VID disperse 33554432 payload bytes to 128 nodes
··Start:   encode payload into field elements
··End:     encode payload into field elements ......................................0ns
··Start:   field elements into polynomials (inverse FFT)
··End:     field elements into polynomials (inverse FFT) ...........................864.920ms
··Start:   compute all storage node evals for 2115 polynomials with 512 coefficients
··End:     compute all storage node evals for 2115 polynomials with 512 coefficients 871.298ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................237.428ms
··Start:   (PRECOMPUTE): compute 2115 KZG commitments
··End:     (PRECOMPUTE): compute 2115 KZG commitments ..............................28.417µs
··Start:   compute aggregate proofs for 128 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................392.693ms
····Start:   gen eval proofs with parallel_factor 2 and num_points 1024
····End:     gen eval proofs with parallel_factor 2 and num_points 1024 ............170.916ms
··End:     compute aggregate proofs for 128 storage nodes ..........................571.669ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................9.214ms
End:     (PRECOMPUTE): VID disperse 33554432 payload bytes to 128 nodes ............2.580s
test vid::advz::precomputable::tests::disperse_with_data_timer ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 113 filtered out; finished in 6.35s
```


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
