### PR TITLE
feat: ICICLE msm integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Check all tests and binaries compilation
         run: |
           cargo check --workspace --tests --lib --bins
-          cargo check --workspace --all-features --exclude-feature 'icicle'
+          cargo check --workspace --features 'std parallel test-srs test-apis'
 
       - name: Check no_std support and WASM compilation
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Check all tests and binaries compilation
         run: |
           cargo check --workspace --tests --lib --bins
-          cargo check --workspace --all-features
+          cargo check --workspace --all-features --exclude-feature 'icicle'
 
       - name: Check no_std support and WASM compilation
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ We take inspiration from [keep changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
+- [#498](https://github.com/EspressoSystems/jellyfish/pull/498) (`jf-primitives`) Add GPU-accelerated MSM for `UnivariateKzgPCS::commit/batch_commit()` using ICICLE.
+
 ### Changed
 
 ### Removed

--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
         devShells = {
           # run with `nix develop .#cudaShell`
           cudaShell =
-            let cudatoolkit = pkgsAllowUnfree.cudatoolkit;
+            let cudatoolkit = pkgsAllowUnfree.cudaPackages_12_3.cudatoolkit;
             in baseShell.overrideAttrs (oldAttrs: {
               # for GPU/CUDA env (e.g. to run ICICLE code)
               name = "cuda-env-shell";
@@ -137,15 +137,15 @@
               # CXX is overridden to use gcc as icicle-curves's build scripts need them
               shellHook = oldAttrs.shellHook + ''
 
-              export PATH="${pkgs.gcc11}/bin:${cudatoolkit}/bin:${cudatoolkit}/nvvm/bin:$PATH"
-              export LD_LIBRARY_PATH=${cudatoolkit}/lib
-              export CUDA_PATH=${cudatoolkit}
-              export CPATH="${cudatoolkit}/include"
-              export LIBRARY_PATH="$LIBRARY_PATH:/lib"
-              export CMAKE_CUDA_COMPILER=$CUDA_PATH/bin/nvcc
-              export LIBCLANG_PATH=${llvmPackages_15.libclang.lib}/lib
-              export CFLAGS=""
-            '';
+                export PATH="${pkgs.gcc11}/bin:${cudatoolkit}/bin:${cudatoolkit}/nvvm/bin:$PATH"
+                export LD_LIBRARY_PATH=${cudatoolkit}/lib
+                export CUDA_PATH=${cudatoolkit}
+                export CPATH="${cudatoolkit}/include"
+                export LIBRARY_PATH="$LIBRARY_PATH:/lib"
+                export CMAKE_CUDA_COMPILER=$CUDA_PATH/bin/nvcc
+                export LIBCLANG_PATH=${llvmPackages_15.libclang.lib}/lib
+                export CFLAGS=""
+              '';
             });
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,15 @@
   outputs = { self, nixpkgs, flake-utils, rust-overlay, pre-commit-hooks, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        overlays = [
-          (import rust-overlay)
-        ];
+        overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
-        nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith
-          (toolchain: toolchain.minimal.override { extensions = [ "rustfmt" ]; });
+        pkgsAllowUnfree = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+        gcc11 = pkgs.overrideCC pkgs.stdenv pkgs.gcc11;
+        nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain:
+          toolchain.minimal.override { extensions = [ "rustfmt" ]; });
 
         stableToolchain = pkgs.rust-bin.stable.latest.minimal.override {
           extensions = [ "clippy" "llvm-tools-preview" "rust-src" ];
@@ -42,8 +45,52 @@
           fi
           exec ${stableToolchain}/bin/cargo "$@"
         '';
-      in with pkgs;
-      {
+        baseShell = with pkgs;
+          clang15Stdenv.mkDerivation {
+            name = "clang15-nix-shell";
+            buildInputs = [
+              argbash
+              openssl
+              pkg-config
+              git
+              nixpkgs-fmt
+
+              cargo-with-nightly
+              stableToolchain
+              nightlyToolchain
+              cargo-sort
+              clang-tools_15
+              clangStdenv
+              llvm_15
+            ] ++ lib.optionals stdenv.isDarwin
+              [ darwin.apple_sdk.frameworks.Security ];
+
+            CARGO_TARGET_DIR = "target/nix_rustc";
+
+            shellHook = ''
+              export RUST_BACKTRACE=full
+              export PATH="$PATH:$(pwd)/target/debug:$(pwd)/target/release"
+              # Prevent cargo aliases from using programs in `~/.cargo` to avoid conflicts with local rustup installations.
+              export CARGO_HOME=$HOME/.cargo-nix
+
+              # Ensure `cargo fmt` uses `rustfmt` from nightly.
+              export RUSTFMT="${nightlyToolchain}/bin/rustfmt"
+
+              export C_INCLUDE_PATH="${llvmPackages_15.libclang.lib}/lib/clang/${llvmPackages_15.libclang.version}/include"
+              export LIBCLANG_PATH=
+              export CC="${clang-tools_15.clang}/bin/clang"
+              export CXX="${clang-tools_15.clang}/bin/clang++"
+              export AR="${llvm_15}/bin/llvm-ar"
+              export CFLAGS="-mcpu=generic"
+
+              # by default choose u64_backend
+              export RUSTFLAGS='--cfg curve25519_dalek_backend="u64"'
+            ''
+            # install pre-commit hooks
+            + self.check.${system}.pre-commit-check.shellHook;
+          };
+      in
+      with pkgs; {
         check = {
           pre-commit-check = pre-commit-hooks.lib.${system}.run {
             src = ./.;
@@ -72,48 +119,34 @@
                 entry = "cargo sort -w";
                 pass_filenames = false;
               };
+              nixpkgs-fmt.enable = true;
             };
           };
         };
-        devShell = clang15Stdenv.mkDerivation {
-          name = "clang15-nix-shell";
-          buildInputs = [
-            argbash
-            openssl
-            pkg-config
-            git
+        devShell = baseShell;
+        # extra dev shells
+        devShells = {
+          # run with `nix develop .#cudaShell`
+          cudaShell =
+            let cudatoolkit = pkgsAllowUnfree.cudatoolkit;
+            in baseShell.overrideAttrs (oldAttrs: {
+              # for GPU/CUDA env (e.g. to run ICICLE code)
+              name = "cuda-env-shell";
+              buildInputs = oldAttrs.buildInputs
+                ++ [ cmake cudatoolkit util-linux gcc11 ];
+              # CXX is overridden to use gcc as icicle-curves's build scripts need them
+              shellHook = oldAttrs.shellHook + ''
 
-            cargo-with-nightly
-            stableToolchain
-            nightlyToolchain
-            cargo-sort
-            clang-tools_15
-            clangStdenv
-            llvm_15
-          ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
-
-          CARGO_TARGET_DIR = "target/nix_rustc";
-
-          shellHook = ''
-            export RUST_BACKTRACE=full
-            export PATH="$PATH:$(pwd)/target/debug:$(pwd)/target/release"
-            # Prevent cargo aliases from using programs in `~/.cargo` to avoid conflicts with local rustup installations.
-            export CARGO_HOME=$HOME/.cargo-nix
-
-            # Ensure `cargo fmt` uses `rustfmt` from nightly.
-            export RUSTFMT="${nightlyToolchain}/bin/rustfmt"
-
-            export C_INCLUDE_PATH="${llvmPackages_15.libclang.lib}/lib/clang/${llvmPackages_15.libclang.version}/include"
-            export CC="${clang-tools_15.clang}/bin/clang"
-            export AR="${llvm_15}/bin/llvm-ar"
-            export CFLAGS="-mcpu=generic"
-
-            # by default choose u64_backend
-            export RUSTFLAGS='--cfg curve25519_dalek_backend="u64"'
-          ''
-          # install pre-commit hooks
-          + self.check.${system}.pre-commit-check.shellHook;
+              export PATH="${pkgs.gcc11}/bin:${cudatoolkit}/bin:${cudatoolkit}/nvvm/bin:$PATH"
+              export LD_LIBRARY_PATH=${cudatoolkit}/lib
+              export CUDA_PATH=${cudatoolkit}
+              export CPATH="${cudatoolkit}/include"
+              export LIBRARY_PATH="$LIBRARY_PATH:/lib"
+              export CMAKE_CUDA_COMPILER=$CUDA_PATH/bin/nvcc
+              export LIBCLANG_PATH=${llvmPackages_15.libclang.lib}/lib
+              export CFLAGS=""
+            '';
+            });
         };
-      }
-    );
+      });
 }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -153,4 +153,5 @@ icicle = [
        "icicle-bn254",
        "icicle-bls12-381",
        "icicle-bls12-377",
+       "parallel",
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -90,8 +90,8 @@ harness = false
 required-features = ["test-srs"]
 
 [[bench]]
-name = "msm"
-path = "benches/msm.rs"
+name = "kzg-gpu"
+path = "benches/kzg_gpu.rs"
 harness = false
 required-features = ["test-srs"]
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -39,6 +39,9 @@ generic-array = { version = "0", features = [
         "serde",
 ] } # not a direct dependency, but we need serde
 hashbrown = "0.14.3"
+icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.3.0", optional = true }
+icicle-core = { version = "1.3.0", optional = true }
+icicle-cuda-runtime = { version = "1.3.0", optional = true }
 itertools = { workspace = true, features = ["use_alloc"] }
 jf-relation = { path = "../relation", default-features = false }
 jf-utils = { path = "../utilities" }
@@ -135,3 +138,4 @@ parallel = [
 ]
 test-srs = []
 seq-fk-23 = [] # FK23 without parallelism
+icicle = ["icicle-cuda-runtime", "icicle-core", "icicle-bn254"]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -88,6 +88,12 @@ harness = false
 required-features = ["test-srs"]
 
 [[bench]]
+name = "msm"
+path = "benches/msm.rs"
+harness = false
+required-features = ["test-srs"]
+
+[[bench]]
 name = "reed-solomon"
 path = "benches/reed_solomon.rs"
 harness = false

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -39,9 +39,11 @@ generic-array = { version = "0", features = [
         "serde",
 ] } # not a direct dependency, but we need serde
 hashbrown = "0.14.3"
-icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.3.0", optional = true }
-icicle-core = { version = "1.3.0", optional = true }
-icicle-cuda-runtime = { version = "1.3.0", optional = true }
+icicle-bls12-377 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true, features = ["arkworks"] }
+icicle-bls12-381 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true, features = ["arkworks"] }
+icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true, features = ["arkworks"] }
+icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true }
+icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true }
 itertools = { workspace = true, features = ["use_alloc"] }
 jf-relation = { path = "../relation", default-features = false }
 jf-utils = { path = "../utilities" }
@@ -144,4 +146,11 @@ parallel = [
 ]
 test-srs = []
 seq-fk-23 = [] # FK23 without parallelism
-icicle = ["icicle-cuda-runtime", "icicle-core", "icicle-bn254"]
+icicle = [
+       "icicle-cuda-runtime",
+       "icicle-core",
+       "icicle-core/arkworks",
+       "icicle-bn254",
+       "icicle-bls12-381",
+       "icicle-bls12-377",
+]

--- a/primitives/benches/kzg_gpu.rs
+++ b/primitives/benches/kzg_gpu.rs
@@ -1,26 +1,28 @@
 //! This benchmark meant for MSM speed comparison between arkworks and
 //! GPU-accelerated code We use `UnivariateKzgPCS::commit()` as a proxy for MSM
 //!
-//! Run `cargo bench --bench msm --features "test-srs icicle"`
+//! Run `cargo bench --bench kzg-gpu --features "test-srs icicle"`
 use ark_bn254::Bn254;
-#[cfg(feature = "icicle")]
-use ark_ec::models::{short_weierstrass::Affine, CurveConfig};
-use ark_ec::pairing::Pairing;
+use ark_ec::{
+    models::{short_weierstrass::Affine, CurveConfig},
+    pairing::Pairing,
+};
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-#[cfg(feature = "icicle")]
-use jf_primitives::icicle_deps::*;
-use jf_primitives::pcs::{
-    prelude::{PolynomialCommitmentScheme, UnivariateKzgPCS},
-    StructuredReferenceString,
+use jf_primitives::{
+    icicle_deps::*,
+    pcs::{
+        prelude::{PolynomialCommitmentScheme, UnivariateKzgPCS},
+        StructuredReferenceString,
+    },
 };
 use jf_utils::test_rng;
 
-const MIN_LOG_DEGREE: usize = 12;
+const MIN_LOG_DEGREE: usize = 19;
 const MAX_LOG_DEGREE: usize = 23;
 
 /// running MSM using arkworks backend
-pub fn bench_msm_ark<E: Pairing>(c: &mut Criterion) {
+pub fn kzg_ark<E: Pairing>(c: &mut Criterion) {
     let mut group = c.benchmark_group("MSM with arkworks");
     let mut rng = test_rng();
 
@@ -46,7 +48,7 @@ pub fn bench_msm_ark<E: Pairing>(c: &mut Criterion) {
 
 /// running MSM using ICICLE backends
 #[cfg(feature = "icicle")]
-pub fn bench_msm_icicle<E, C>(c: &mut Criterion)
+pub fn kzg_icicle<E, C>(c: &mut Criterion)
 where
     C: IcicleCurve + MSM<C>,
     C::ScalarField: ArkConvertible<ArkEquivalent = E::ScalarField>,
@@ -58,6 +60,11 @@ where
 
     let supported_degree = 2usize.pow(MAX_LOG_DEGREE as u32);
     let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(&mut rng, supported_degree).unwrap();
+    // TODO: (alex) figure out load longer SRS first, and only use part of it later
+    // currently it will error if the `scalars.len() % points.len() != 0`
+    // while we can tap into a slice behind the reference via
+    // `HostOrDeviceSlice[..]` which gives `&[T]` however msm() doesn't accept
+    // &[T], only `&HostOrDeviceSlice`
 
     // setup for commit first
     for log_degree in MIN_LOG_DEGREE..MAX_LOG_DEGREE {
@@ -78,17 +85,16 @@ where
     group.finish();
 }
 
-fn msm_bn254(c: &mut Criterion) {
-    bench_msm_ark::<Bn254>(c);
-    #[cfg(feature = "icicle")]
-    bench_msm_icicle::<Bn254, icicle_bn254::curve::CurveCfg>(c);
+fn kzg_gpu_bn254(c: &mut Criterion) {
+    // kzg_ark::<Bn254>(c);
+    kzg_icicle::<Bn254, icicle_bn254::curve::CurveCfg>(c);
 }
 
 criterion_group! {
-    name = msm_benches;
+    name = kzg_gpu_benches;
     config = Criterion::default().sample_size(10);
     targets =
-        msm_bn254,
+        kzg_gpu_bn254,
 }
 
-criterion_main!(msm_benches);
+criterion_main!(kzg_gpu_benches);

--- a/primitives/benches/kzg_gpu.rs
+++ b/primitives/benches/kzg_gpu.rs
@@ -82,21 +82,12 @@ where
             &log_degree,
             |b, _log_degree| {
                 b.iter(|| {
-                    // step-by-step commitment on gpu
-                    let poly_on_gpu =
-                        <UnivariateKzgPCS<E> as GPUCommit<E, C>>::load_poly_to_gpu(&p).unwrap();
-                    let msm_result_on_gpu =
-                        <UnivariateKzgPCS<E> as GPUCommit<E, C>>::commit_on_gpu(
-                            &mut srs_on_gpu,
-                            &poly_on_gpu,
-                            &stream,
-                        )
-                        .unwrap();
-                    let _comm = <UnivariateKzgPCS<E> as GPUCommit<E, C>>::load_commitment_to_host(
-                        msm_result_on_gpu,
+                    <UnivariateKzgPCS<E> as GPUCommit<E, C>>::gpu_commit_with_loaded_prover_param(
+                        &mut srs_on_gpu,
+                        &p,
                         &stream,
                     )
-                    .unwrap();
+                    .unwrap()
                 })
             },
         );

--- a/primitives/benches/kzg_gpu.rs
+++ b/primitives/benches/kzg_gpu.rs
@@ -3,18 +3,16 @@
 //!
 //! Run `cargo bench --bench kzg-gpu --features "test-srs icicle"`
 use ark_bn254::Bn254;
-use ark_ec::{
-    models::{short_weierstrass::Affine, CurveConfig},
-    pairing::Pairing,
-};
+#[cfg(feature = "icicle")]
+use ark_ec::models::{short_weierstrass::Affine, CurveConfig};
+use ark_ec::pairing::Pairing;
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use jf_primitives::{
-    icicle_deps::*,
-    pcs::{
-        prelude::{PolynomialCommitmentScheme, UnivariateKzgPCS},
-        StructuredReferenceString,
-    },
+#[cfg(feature = "icicle")]
+use jf_primitives::icicle_deps::*;
+use jf_primitives::pcs::{
+    prelude::{PolynomialCommitmentScheme, UnivariateKzgPCS},
+    StructuredReferenceString,
 };
 use jf_utils::test_rng;
 
@@ -86,7 +84,8 @@ where
 }
 
 fn kzg_gpu_bn254(c: &mut Criterion) {
-    // kzg_ark::<Bn254>(c);
+    kzg_ark::<Bn254>(c);
+    #[cfg(feature = "icicle")]
     kzg_icicle::<Bn254, icicle_bn254::curve::CurveCfg>(c);
 }
 

--- a/primitives/benches/msm.rs
+++ b/primitives/benches/msm.rs
@@ -1,10 +1,15 @@
 //! This benchmark meant for MSM speed comparison between arkworks and
 //! GPU-accelerated code We use `UnivariateKzgPCS::commit()` as a proxy for MSM
-
+//!
+//! Run `cargo bench --bench msm --features "test-srs icicle"`
 use ark_bn254::Bn254;
+#[cfg(feature = "icicle")]
+use ark_ec::models::{short_weierstrass::Affine, CurveConfig};
 use ark_ec::pairing::Pairing;
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+#[cfg(feature = "icicle")]
+use jf_primitives::icicle_deps::*;
 use jf_primitives::pcs::{
     prelude::{PolynomialCommitmentScheme, UnivariateKzgPCS},
     StructuredReferenceString,
@@ -12,7 +17,7 @@ use jf_primitives::pcs::{
 use jf_utils::test_rng;
 
 const MIN_LOG_DEGREE: usize = 12;
-const MAX_LOG_DEGREE: usize = 15; // TODO: change to 22
+const MAX_LOG_DEGREE: usize = 23;
 
 /// running MSM using arkworks backend
 pub fn bench_msm_ark<E: Pairing>(c: &mut Criterion) {
@@ -40,19 +45,47 @@ pub fn bench_msm_ark<E: Pairing>(c: &mut Criterion) {
 }
 
 /// running MSM using ICICLE backends
-pub fn bench_msm_icicle(c: &mut Criterion) {
-    todo!()
+pub fn bench_msm_icicle<E, C>(c: &mut Criterion)
+where
+    C: IcicleCurve + MSM<C>,
+    C::ScalarField: ArkConvertible<ArkEquivalent = E::ScalarField>,
+    C::BaseField: ArkConvertible<ArkEquivalent = <C::ArkSWConfig as CurveConfig>::BaseField>,
+    E: Pairing<G1Affine = Affine<<C as IcicleCurve>::ArkSWConfig>>,
+{
+    let mut group = c.benchmark_group("MSM with ICICLE");
+    let mut rng = test_rng();
+
+    let supported_degree = 2usize.pow(MAX_LOG_DEGREE as u32);
+    let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(&mut rng, supported_degree).unwrap();
+
+    // setup for commit first
+    for log_degree in MIN_LOG_DEGREE..MAX_LOG_DEGREE {
+        let degree = 2usize.pow(log_degree as u32);
+        let (ck, _vk) = pp.trim(degree).unwrap();
+        let p = <DensePolynomial<E::ScalarField> as DenseUVPolynomial<E::ScalarField>>::rand(
+            degree, &mut rng,
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(log_degree),
+            &log_degree,
+            |b, _log_degree| {
+                b.iter(|| UnivariateKzgPCS::<E>::commit_with_gpu::<C>(&ck, &p).unwrap())
+            },
+        );
+    }
+    group.finish();
 }
 
 fn msm_bn254(c: &mut Criterion) {
     bench_msm_ark::<Bn254>(c);
     #[cfg(feature = "icicle")]
-    bench_msm_icicle(c);
+    bench_msm_icicle::<Bn254, icicle_bn254::curve::CurveCfg>(c);
 }
 
 criterion_group! {
     name = msm_benches;
-    config = Criterion::default();
+    config = Criterion::default().sample_size(10);
     targets =
         msm_bn254,
 }

--- a/primitives/benches/msm.rs
+++ b/primitives/benches/msm.rs
@@ -45,6 +45,7 @@ pub fn bench_msm_ark<E: Pairing>(c: &mut Criterion) {
 }
 
 /// running MSM using ICICLE backends
+#[cfg(feature = "icicle")]
 pub fn bench_msm_icicle<E, C>(c: &mut Criterion)
 where
     C: IcicleCurve + MSM<C>,

--- a/primitives/benches/msm.rs
+++ b/primitives/benches/msm.rs
@@ -1,0 +1,60 @@
+//! This benchmark meant for MSM speed comparison between arkworks and
+//! GPU-accelerated code We use `UnivariateKzgPCS::commit()` as a proxy for MSM
+
+use ark_bn254::Bn254;
+use ark_ec::pairing::Pairing;
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use jf_primitives::pcs::{
+    prelude::{PolynomialCommitmentScheme, UnivariateKzgPCS},
+    StructuredReferenceString,
+};
+use jf_utils::test_rng;
+
+const MIN_LOG_DEGREE: usize = 12;
+const MAX_LOG_DEGREE: usize = 15; // TODO: change to 22
+
+/// running MSM using arkworks backend
+pub fn bench_msm_ark<E: Pairing>(c: &mut Criterion) {
+    let mut group = c.benchmark_group("MSM with arkworks");
+    let mut rng = test_rng();
+
+    let supported_degree = 2usize.pow(MAX_LOG_DEGREE as u32);
+    let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(&mut rng, supported_degree).unwrap();
+
+    // setup for commit first
+    for log_degree in MIN_LOG_DEGREE..MAX_LOG_DEGREE {
+        let degree = 2usize.pow(log_degree as u32);
+        let (ck, _vk) = pp.trim(degree).unwrap();
+        let p = <DensePolynomial<E::ScalarField> as DenseUVPolynomial<E::ScalarField>>::rand(
+            degree, &mut rng,
+        );
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(log_degree),
+            &log_degree,
+            |b, _log_degree| b.iter(|| UnivariateKzgPCS::<E>::commit(&ck, &p).unwrap()),
+        );
+    }
+    group.finish();
+}
+
+/// running MSM using ICICLE backends
+pub fn bench_msm_icicle(c: &mut Criterion) {
+    todo!()
+}
+
+fn msm_bn254(c: &mut Criterion) {
+    bench_msm_ark::<Bn254>(c);
+    #[cfg(feature = "icicle")]
+    bench_msm_icicle(c);
+}
+
+criterion_group! {
+    name = msm_benches;
+    config = Criterion::default();
+    targets =
+        msm_bn254,
+}
+
+criterion_main!(msm_benches);

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -54,10 +54,8 @@ pub mod icicle_deps {
     pub mod curves {
         pub use ark_bls12_381::Bls12_381;
         pub use ark_bn254::Bn254;
-        pub use icicle_bls12_381::curve::{
-            CurveCfg as IcicleBls12_381, ScalarField as IcicleBls12_381Scalar,
-        };
-        pub use icicle_bn254::curve::{CurveCfg as IcicleBn254, ScalarField as IcicleBn254Scalar};
+        pub use icicle_bls12_381::curve::CurveCfg as IcicleBls12_381;
+        pub use icicle_bn254::curve::CurveCfg as IcicleBn254;
     }
 }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -45,9 +45,20 @@ pub mod icicle_deps {
     pub use icicle_core::{
         curve::{Affine as IcicleAffine, Curve as IcicleCurve, Projective as IcicleProjective},
         msm::{MSMConfig, MSM},
-        traits::ArkConvertible,
+        traits::{ArkConvertible, FieldImpl},
     };
     pub use icicle_cuda_runtime::{memory::HostOrDeviceSlice, stream::CudaStream};
+
+    /// curve-specific types both from arkworks and from ICICLE
+    /// including Pairing, CurveCfg, Fr, Fq etc.
+    pub mod curves {
+        pub use ark_bls12_381::Bls12_381;
+        pub use ark_bn254::Bn254;
+        pub use icicle_bls12_381::curve::{
+            CurveCfg as IcicleBls12_381, ScalarField as IcicleBls12_381Scalar,
+        };
+        pub use icicle_bn254::curve::{CurveCfg as IcicleBn254, ScalarField as IcicleBn254Scalar};
+    }
 }
 
 pub(crate) mod utils;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -57,6 +57,16 @@ pub mod icicle_deps {
         pub use icicle_bls12_381::curve::CurveCfg as IcicleBls12_381;
         pub use icicle_bn254::curve::CurveCfg as IcicleBn254;
     }
+
+    // TODO: remove this after `warmup()` is added upstream
+    // https://github.com/ingonyama-zk/icicle/pull/422#issuecomment-1980881638
+    /// Create a new stream and warmup
+    pub fn warmup_new_stream() -> Result<CudaStream, ()> {
+        let stream = CudaStream::create().unwrap();
+        // TODO: consider using an error type?
+        let _warmup_bytes = HostOrDeviceSlice::<'_, u8>::cuda_malloc_async(1024, &stream).unwrap();
+        Ok(stream)
+    }
 }
 
 pub(crate) mod utils;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -58,6 +58,8 @@ pub mod icicle_deps {
         pub use icicle_bn254::curve::CurveCfg as IcicleBn254;
     }
 
+    pub use crate::pcs::univariate_kzg::icicle::GPUCommit;
+
     // TODO: remove this after `warmup()` is added upstream
     // https://github.com/ingonyama-zk/icicle/pull/422#issuecomment-1980881638
     /// Create a new stream and warmup

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -39,4 +39,15 @@ pub mod vdf;
 pub mod vid;
 pub mod vrf;
 
+/// dependecies required for ICICLE-related code, group import for convenience
+#[cfg(feature = "icicle")]
+pub mod icicle_deps {
+    pub use icicle_core::{
+        curve::{Affine as IcicleAffine, Curve as IcicleCurve, Projective as IcicleProjective},
+        msm::{MSMConfig, MSM},
+        traits::ArkConvertible,
+    };
+    pub use icicle_cuda_runtime::{memory::HostOrDeviceSlice, stream::CudaStream};
+}
+
 pub(crate) mod utils;

--- a/primitives/src/pcs/mod.rs
+++ b/primitives/src/pcs/mod.rs
@@ -6,12 +6,12 @@
 
 //! Polynomial Commitment Scheme
 pub mod errors;
-mod multilinear_kzg;
+pub(crate) mod multilinear_kzg;
 mod poly;
 pub mod prelude;
 mod structs;
 pub mod transcript;
-mod univariate_kzg;
+pub(crate) mod univariate_kzg;
 
 use ark_ff::{FftField, Field};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -793,10 +793,10 @@ pub(crate) mod icicle {
 
             #[cfg(feature = "kzg-print-trace")]
             let conv_time = start_timer!(|| "Type Conversion: ark->ICICLE: Group");
-            let bases: Vec<IcicleAffine<C>> =
-                parallelizable_slice_iter(&prover_param.powers_of_g[..supported_degree + 1])
-                    .map(|&p| Self::ark_affine_to_icicle(p))
-                    .collect();
+            let bases: Vec<IcicleAffine<C>> = prover_param.powers_of_g[..supported_degree + 1]
+                .par_iter()
+                .map(|&p| Self::ark_affine_to_icicle(p))
+                .collect();
             #[cfg(feature = "kzg-print-trace")]
             end_timer!(conv_time);
 
@@ -819,7 +819,8 @@ pub(crate) mod icicle {
 
             #[cfg(feature = "kzg-print-trace")]
             let conv_time = start_timer!(|| "Type Conversion: ark->ICICLE: Scalar");
-            let scalars: Vec<C::ScalarField> = parallelizable_slice_iter(&poly.coeffs()[..size])
+            let scalars: Vec<C::ScalarField> = poly.coeffs()[..size]
+                .par_iter()
                 .map(|&s| Self::ark_field_to_icicle(s))
                 .collect();
             #[cfg(feature = "kzg-print-trace")]
@@ -857,12 +858,12 @@ pub(crate) mod icicle {
 
             #[cfg(feature = "kzg-print-trace")]
             let conv_time = start_timer!(|| "Type Conversion: ark->ICICLE: Scalar");
-            let scalars: Vec<C::ScalarField> = parallelizable_slice_iter(polys)
-                .map(|poly| {
-                    parallelizable_slice_iter(&poly.coeffs()[..size])
-                        .map(|&s| Self::ark_field_to_icicle(s))
-                })
-                .flatten()
+            let scalars: Vec<C::ScalarField> = polys
+                .iter()
+                .flat_map(|poly| poly.coeffs())
+                .collect::<Vec<_>>()
+                .into_par_iter()
+                .map(|&s| Self::ark_field_to_icicle(s))
                 .collect();
             #[cfg(feature = "kzg-print-trace")]
             end_timer!(conv_time);
@@ -950,7 +951,8 @@ pub(crate) mod icicle {
 
             #[cfg(feature = "kzg-print-trace")]
             let conv_time = start_timer!(|| "Type Conversion: ICICLE->ark: Group");
-            let comms = parallelizable_slice_iter(&msm_host_result)
+            let comms = msm_host_result
+                .par_iter()
                 .map(|p| Commitment(p.to_ark().into_affine()))
                 .collect();
             #[cfg(feature = "kzg-print-trace")]

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -1313,16 +1313,12 @@ mod tests {
             let p = <DensePolynomial<E::ScalarField> as DenseUVPolynomial<E::ScalarField>>::rand(
                 degree, rng,
             );
-            let comm = <UnivariateKzgPCS<E> as GPUCommit<E, C>>::gpu_commit(&ck, &p)?;
-
-            // step-by-step commitment on gpu
-            let comm2 =
+            let _comm =
                 <UnivariateKzgPCS<E> as GPUCommit<E, C>>::gpu_commit_with_loaded_prover_param(
                     &mut srs_on_gpu,
                     &p,
                     &stream,
                 )?;
-            assert_eq!(comm, comm2);
 
             let polys: Vec<_> = (0..10)
                 .map(|_| {
@@ -1331,7 +1327,8 @@ mod tests {
                     )
                 })
                 .collect();
-            let _comms = <UnivariateKzgPCS<E> as GPUCommit<E, C>>::gpu_batch_commit(&ck, &polys)?;
+            let _comms = <UnivariateKzgPCS<E> as GPUCommit<E, C>>::gpu_batch_commit_with_loaded_prover_param(
+                &mut srs_on_gpu, &polys, &stream)?;
 
             Ok(())
         }


### PR DESCRIPTION
## Description

closes: #490 

Unit tests already test the correctness of the MSM results.
Benchmark can be run via `cargo bench --bench msm --features "test-srs icicle"`

- [ ] Fixed cudatoolkit inside nix shell is incompatible with cuda driver problem (causing [`CudaErrorInsufficientDriver`](https://github.com/ingonyama-zk/icicle/blob/e6035698b5e54632f2c44e600391352ccc11cad4/wrappers/golang/cuda_runtime/const.go#L63C2-L63C30) err)
- [x] Tweak around benchmark code and setup
- [x] Update Changelog

## Benchmark

**TL;DR: it's about 50x speedup compared to arkworks!** 🎉

Current `criterion` benchmark:
```
MSM with arkworks/19    time:   [1.5497 s 1.5526 s 1.5554 s]
MSM with arkworks/20    time:   [2.8726 s 2.8801 s 2.8848 s]
MSM with arkworks/21    time:   [5.8268 s 5.8572 s 5.8847 s]
MSM with arkworks/22    time:   [11.618 s 11.641 s 11.665 s]

MSM with ICICLE/19      time:   [26.753 ms 26.841 ms 27.018 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
MSM with ICICLE/20      time:   [48.716 ms 48.728 ms 48.737 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
MSM with ICICLE/21      time:   [87.649 ms 87.671 ms 87.697 ms]
MSM with ICICLE/22      time:   [164.33 ms 164.40 ms 164.45 ms]
```

Individual GPU-accelerated breakdown `MSM(2^20)`

```
Start:   Committing to polynomial of degree 1048576
··Start:   Type Conversion: ark->ICICLE: Group
··End:     Type Conversion: ark->ICICLE: Group .....................................11.500ms
··Start:   Load group elements: CPU->GPU
··End:     Load group elements: CPU->GPU ...........................................5.197ms
··Start:   Type Conversion: ark->ICICLE: Scalar
··End:     Type Conversion: ark->ICICLE: Scalar ....................................5.835ms
··Start:   Load scalars: CPU->GPU
··End:     Load scalars: CPU->GPU ..................................................2.624ms
··Start:   GPU-accelerated MSM
··End:     GPU-accelerated MSM .....................................................20.493ms
··Start:   Load MSM result GPU->CPU
··End:     Load MSM result GPU->CPU ................................................26.000ms
··Start:   Type Conversion: ICICLE->ark: Group
··End:     Type Conversion: ICICLE->ark: Group .....................................27.140µs
End:     Committing to polynomial of degree 1048576  ...............................84.879ms
```
_note_: the "GPU-accelerated MSM" is somewhat misleading, because we use non-blocking async MSM on GPU, the computation actually wasn't finished before our CPU moved on, thus part of "Load MSM result GPU->CPU" is "synchronizing the result on the cuda stream" which means wait for the work to finish. Since we know the loading a single projective group should be instant, the more accurate MSM computation time is `20.49 + 26 = 47 sec` which aligns with the `criterion` output above.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
