### PR TITLE
chore: expose `MerkleNode`, `MerklePath`, and `MerkleProof`

### DIFF
--- a/primitives/src/merkle_tree/prelude.rs
+++ b/primitives/src/merkle_tree/prelude.rs
@@ -9,7 +9,9 @@
 pub use crate::{
     impl_to_traversal_path_biguint, impl_to_traversal_path_primitives,
     merkle_tree::{
-        append_only::MerkleTree, universal_merkle_tree::UniversalMerkleTree,
+        append_only::MerkleTree,
+        internal::{MerkleNode, MerklePath, MerkleProof},
+        universal_merkle_tree::UniversalMerkleTree,
         AppendableMerkleTreeScheme, DigestAlgorithm, Element, ForgetableMerkleTreeScheme,
         ForgetableUniversalMerkleTreeScheme, Index, LookupResult, MerkleCommitment,
         MerkleTreeScheme, NodeValue, ToTraversalPath, UniversalMerkleTreeScheme,


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Requested by sequencer team.
You could access them through `jf_primitives::merkle_tree::prelude::{MerkleNode, MerklePath, MerkleProof}`.
And we already have `MerkleProof::new(index, path)`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
