### PR TITLE
refactor: hide IcicleCurve as associated type, much cleaner trait bound

### DIFF
--- a/primitives/benches/kzg_gpu.rs
+++ b/primitives/benches/kzg_gpu.rs
@@ -47,7 +47,7 @@ pub fn kzg_ark<E: Pairing>(c: &mut Criterion) {
 pub fn kzg_icicle<E>(c: &mut Criterion)
 where
     E: Pairing,
-    UnivariateKzgPCS<E>: GPUCommit<E>,
+    UnivariateKzgPCS<E>: GPUCommittable<E>,
 {
     let mut group = c.benchmark_group("MSM with ICICLE");
     let mut rng = test_rng();
@@ -56,9 +56,11 @@ where
     let supported_degree = 2usize.pow(MAX_LOG_DEGREE as u32);
     let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(&mut rng, supported_degree).unwrap();
     let (full_ck, _vk) = pp.trim(supported_degree).unwrap();
-    let mut srs_on_gpu =
-        <UnivariateKzgPCS<E> as GPUCommit<E>>::load_prover_param_to_gpu(full_ck, supported_degree)
-            .unwrap();
+    let mut srs_on_gpu = <UnivariateKzgPCS<E> as GPUCommittable<E>>::load_prover_param_to_gpu(
+        full_ck,
+        supported_degree,
+    )
+    .unwrap();
 
     // setup for commit first
     for log_degree in MIN_LOG_DEGREE..MAX_LOG_DEGREE {
@@ -72,7 +74,7 @@ where
             &log_degree,
             |b, _log_degree| {
                 b.iter(|| {
-                    <UnivariateKzgPCS<E> as GPUCommit<E>>::gpu_commit_with_loaded_prover_param(
+                    <UnivariateKzgPCS<E> as GPUCommittable<E>>::gpu_commit_with_loaded_prover_param(
                         &mut srs_on_gpu,
                         &p,
                         &stream,

--- a/primitives/benches/kzg_gpu.rs
+++ b/primitives/benches/kzg_gpu.rs
@@ -3,15 +3,11 @@
 //!
 //! Run `cargo bench --bench kzg-gpu --features "test-srs icicle"`
 use ark_bn254::Bn254;
-#[cfg(feature = "icicle")]
-use ark_ec::models::{short_weierstrass::Affine, CurveConfig};
 use ark_ec::pairing::Pairing;
-#[cfg(feature = "icicle")]
-use ark_ff::PrimeField;
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(feature = "icicle")]
-use jf_primitives::icicle_deps::{curves::*, *};
+use jf_primitives::icicle_deps::*;
 use jf_primitives::pcs::{
     prelude::{PolynomialCommitmentScheme, UnivariateKzgPCS},
     StructuredReferenceString,
@@ -48,14 +44,10 @@ pub fn kzg_ark<E: Pairing>(c: &mut Criterion) {
 
 /// running MSM using ICICLE backends
 #[cfg(feature = "icicle")]
-pub fn kzg_icicle<E, C>(c: &mut Criterion)
+pub fn kzg_icicle<E>(c: &mut Criterion)
 where
-    C: IcicleCurve + MSM<C>,
-    C::ScalarField: ArkConvertible<ArkEquivalent = E::ScalarField>,
-    C::BaseField: ArkConvertible<ArkEquivalent = <C::ArkSWConfig as CurveConfig>::BaseField>,
-    <C::ArkSWConfig as CurveConfig>::BaseField: PrimeField,
-    E: Pairing<G1Affine = Affine<<C as IcicleCurve>::ArkSWConfig>>,
-    UnivariateKzgPCS<E>: GPUCommit<E, C>,
+    E: Pairing,
+    UnivariateKzgPCS<E>: GPUCommit<E>,
 {
     let mut group = c.benchmark_group("MSM with ICICLE");
     let mut rng = test_rng();
@@ -64,11 +56,9 @@ where
     let supported_degree = 2usize.pow(MAX_LOG_DEGREE as u32);
     let pp = UnivariateKzgPCS::<E>::gen_srs_for_testing(&mut rng, supported_degree).unwrap();
     let (full_ck, _vk) = pp.trim(supported_degree).unwrap();
-    let mut srs_on_gpu = <UnivariateKzgPCS<E> as GPUCommit<E, C>>::load_prover_param_to_gpu(
-        full_ck,
-        supported_degree,
-    )
-    .unwrap();
+    let mut srs_on_gpu =
+        <UnivariateKzgPCS<E> as GPUCommit<E>>::load_prover_param_to_gpu(full_ck, supported_degree)
+            .unwrap();
 
     // setup for commit first
     for log_degree in MIN_LOG_DEGREE..MAX_LOG_DEGREE {
@@ -82,7 +72,7 @@ where
             &log_degree,
             |b, _log_degree| {
                 b.iter(|| {
-                    <UnivariateKzgPCS<E> as GPUCommit<E, C>>::gpu_commit_with_loaded_prover_param(
+                    <UnivariateKzgPCS<E> as GPUCommit<E>>::gpu_commit_with_loaded_prover_param(
                         &mut srs_on_gpu,
                         &p,
                         &stream,
@@ -98,7 +88,7 @@ where
 fn kzg_gpu_bn254(c: &mut Criterion) {
     kzg_ark::<Bn254>(c);
     #[cfg(feature = "icicle")]
-    kzg_icicle::<Bn254, IcicleBn254>(c);
+    kzg_icicle::<Bn254>(c);
 }
 
 criterion_group! {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -45,7 +45,6 @@ pub mod icicle_deps {
     pub use icicle_core::{
         curve::{Affine as IcicleAffine, Curve as IcicleCurve, Projective as IcicleProjective},
         msm::{MSMConfig, MSM},
-        traits::{ArkConvertible, FieldImpl},
     };
     pub use icicle_cuda_runtime::{memory::HostOrDeviceSlice, stream::CudaStream};
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -57,7 +57,7 @@ pub mod icicle_deps {
         pub use icicle_bn254::curve::CurveCfg as IcicleBn254;
     }
 
-    pub use crate::pcs::univariate_kzg::icicle::GPUCommit;
+    pub use crate::pcs::univariate_kzg::icicle::GPUCommittable;
 
     // TODO: remove this after `warmup()` is added upstream
     // https://github.com/ingonyama-zk/icicle/pull/422#issuecomment-1980881638


### PR DESCRIPTION
## Description

closes: #490 (particularly addressing the https://github.com/EspressoSystems/jellyfish/issues/490#issuecomment-1986098853)

@mrain you had such a good suggestion. 👍 

the key of breaking from the evil compiler deep-hole is just "completely disassociated `E` and  `C`", and remove generic implementation, let specialized implementor to fill in `xx_to_ark/icicle()` function, so we can just throw away all those `ArkEquivalent` bound and `CurveConfig` bound. 

just a comparison,

```rust
// Previous: 
pub fn kzg_icicle<E, C>(c: &mut Criterion)
where
    C: IcicleCurve + MSM<C>,
    C::ScalarField: ArkConvertible<ArkEquivalent = E::ScalarField>,
    C::BaseField: ArkConvertible<ArkEquivalent = <C::ArkSWConfig as CurveConfig>::BaseField>,
    <C::ArkSWConfig as CurveConfig>::BaseField: PrimeField,
    E: Pairing<G1Affine = Affine<<C as IcicleCurve>::ArkSWConfig>>,
    UnivariateKzgPCS<E>: GPUCommit<E, C>,

// Now: 
pub fn kzg_icicle<E>(c: &mut Criterion)
where
    E: Pairing,
    UnivariateKzgPCS<E>: GPUCommit<E>,
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] ~Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`~
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
