### PR TITLE
chore: overhead free type conversion for `load_poly_to_gpu`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["plonk", "primitives", "relation", "utilities"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.3"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 license = "MIT"

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -1308,8 +1308,10 @@ mod tests {
         use super::*;
         #[cfg(feature = "kzg-print-trace")]
         use crate::icicle_deps::warmup_new_stream;
-        use crate::icicle_deps::IcicleCurve;
-        use crate::{icicle_deps::curves::*, pcs::univariate_kzg::icicle::GPUCommittable};
+        use crate::{
+            icicle_deps::{curves::*, IcicleCurve},
+            pcs::univariate_kzg::icicle::GPUCommittable,
+        };
         use core::mem::size_of;
 
         #[cfg(feature = "kzg-print-trace")]

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -1308,7 +1308,9 @@ mod tests {
         use super::*;
         #[cfg(feature = "kzg-print-trace")]
         use crate::icicle_deps::warmup_new_stream;
+        use crate::icicle_deps::IcicleCurve;
         use crate::{icicle_deps::curves::*, pcs::univariate_kzg::icicle::GPUCommittable};
+        use core::mem::size_of;
 
         #[cfg(feature = "kzg-print-trace")]
         fn gpu_profiling<E: Pairing>() -> Result<(), PCSError>
@@ -1401,6 +1403,23 @@ mod tests {
         #[test]
         fn test_gpu_e2e() {
             test_gpu_e2e_template::<Bn254>().unwrap();
+        }
+
+        fn test_gpu_ark_conversion_template<E: Pairing>()
+        where
+            UnivariateKzgPCS<E>: GPUCommittable<E>,
+        {
+            assert_eq!(
+                size_of::<E::ScalarField>(),
+                size_of::<
+                    <<UnivariateKzgPCS<E> as GPUCommittable<E>>::IC as IcicleCurve>::ScalarField,
+                >()
+            );
+        }
+
+        #[test]
+        fn test_gpu_ark_conversion() {
+            test_gpu_ark_conversion_template::<Bn254>();
         }
 
         #[cfg(feature = "kzg-print-trace")]

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -1420,6 +1420,9 @@ mod tests {
         }
 
         #[test]
+        /// This test checks whether the scalar field type in Ark has the size
+        /// with the one in icicle. So that we could do direct reinterpret_cast
+        /// between them.
         fn test_gpu_ark_conversion() {
             test_gpu_ark_conversion_template::<Bn254>();
         }

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -249,9 +249,9 @@ where
     UnivariateKzgPCS<E>: GPUCommittable<E>,
 {
     /// Like [`Advz::new`] except with SRS loaded to GPU
-    pub fn with_multiplicity(
-        num_storage_nodes: usize,
-        recovery_threshold: usize,
+    pub fn new(
+        num_storage_nodes: u32,
+        recovery_threshold: u32,
         srs: impl Borrow<KzgSrs<E>>,
     ) -> VidResult<Self> {
         let mut advz = Self::new_internal(num_storage_nodes, recovery_threshold, srs)?;
@@ -260,9 +260,9 @@ where
     }
     /// Like [`Advz::with_multiplicity`] except with SRS loaded to GPU
     pub fn with_multiplicity(
-        num_storage_nodes: usize,
-        recovery_threshold: usize,
-        multiplicity: usize,
+        num_storage_nodes: u32,
+        recovery_threshold: u32,
+        multiplicity: u32,
         srs: impl Borrow<KzgSrs<E>>,
     ) -> VidResult<Self> {
         let mut advz = Self::with_multiplicity_internal(
@@ -985,11 +985,11 @@ mod tests {
         let (recovery_threshold, num_storage_nodes) = (256, 512);
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(recovery_threshold as usize, &mut rng);
-        let mut advz =
-            Advz::<Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, srs).unwrap();
         #[cfg(feature = "gpu-vid")]
         let mut advz_gpu =
             AdvzGPU::<'_, Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, &srs).unwrap();
+        let mut advz =
+            Advz::<Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, srs).unwrap();
 
         let payload_random = init_random_payload(1 << 25, &mut rng);
 
@@ -1005,11 +1005,11 @@ mod tests {
         let (recovery_threshold, num_storage_nodes) = (256, 512);
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(recovery_threshold as usize, &mut rng);
-        let mut advz =
-            Advz::<Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, srs).unwrap();
         #[cfg(feature = "gpu-vid")]
         let mut advz_gpu =
             AdvzGPU::<'_, Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, &srs).unwrap();
+        let mut advz =
+            Advz::<Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, srs).unwrap();
 
         let payload_random = init_random_payload(1 << 25, &mut rng);
 


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

_Update: this also fixes the API changes when `gpu_vid` is enabled._

This PR avoids a memory copy in `load_poly_to_gpu`. However it contains unsafe rust code.

Before:
```
Start:   KZG10::Setup with prover degree 4194304 and verifier degree 1
...
Start:   Type Conversion: ark->ICICLE: Scalar
End:     Type Conversion: ark->ICICLE: Scalar ......................................17.305ms
...
```

After:

```
Start:   KZG10::Setup with prover degree 4194304 and verifier degree 1
...
Start:   Type Conversion: ark->ICICLE: Scalar
End:     Type Conversion: ark->ICICLE: Scalar ......................................160ns
...
```

It doesn't apply to affine point conversion because of two different underlying struct reprs.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
