### PR TITLE
feat!: GPU accelerated VID disperse

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -151,7 +151,6 @@ icicle = [
        "icicle-core",
        "icicle-core/arkworks",
        "icicle-bn254",
-       "icicle-bls12-381",
-       "icicle-bls12-377",
        "parallel",
 ]
+gpu-vid = ["icicle"]

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -64,7 +64,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("commit"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -79,7 +79,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("disperse"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -94,7 +94,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("verify"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
             grp.bench_with_input(
@@ -116,7 +116,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("recover"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common) = (disperse.shares, disperse.common);
             grp.bench_with_input(

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -51,9 +51,7 @@ pub mod icicle_deps {
     /// curve-specific types both from arkworks and from ICICLE
     /// including Pairing, CurveCfg, Fr, Fq etc.
     pub mod curves {
-        pub use ark_bls12_381::Bls12_381;
         pub use ark_bn254::Bn254;
-        pub use icicle_bls12_381::curve::CurveCfg as IcicleBls12_381;
         pub use icicle_bn254::curve::CurveCfg as IcicleBn254;
     }
 

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -1296,7 +1296,10 @@ mod tests {
     #[cfg(feature = "icicle")]
     mod icicle {
         use super::*;
-        use crate::{icicle_deps::curves::*, pcs::univariate_kzg::icicle::GPUCommittable};
+        use crate::{
+            icicle_deps::{curves::*, warmup_new_stream},
+            pcs::univariate_kzg::icicle::GPUCommittable,
+        };
 
         #[cfg(feature = "kzg-print-trace")]
         fn gpu_profiling<E: Pairing>() -> Result<(), PCSError>

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -1296,10 +1296,7 @@ mod tests {
     #[cfg(feature = "icicle")]
     mod icicle {
         use super::*;
-        use crate::{
-            icicle_deps::{curves::*, *},
-            pcs::univariate_kzg::icicle::GPUCommittable,
-        };
+        use crate::{icicle_deps::curves::*, pcs::univariate_kzg::icicle::GPUCommittable};
 
         #[cfg(feature = "kzg-print-trace")]
         fn gpu_profiling<E: Pairing>() -> Result<(), PCSError>

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -39,12 +39,12 @@ pub trait VidScheme {
     type Common: Clone + Debug + DeserializeOwned + Eq + PartialEq + Hash + Serialize + Sync; // TODO https://github.com/EspressoSystems/jellyfish/issues/253
 
     /// Compute a payload commitment
-    fn commit_only<B>(&self, payload: B) -> VidResult<Self::Commit>
+    fn commit_only<B>(&mut self, payload: B) -> VidResult<Self::Commit>
     where
         B: AsRef<[u8]>;
 
     /// Compute shares to send to the storage nodes
-    fn disperse<B>(&self, payload: B) -> VidResult<VidDisperse<Self>>
+    fn disperse<B>(&mut self, payload: B) -> VidResult<VidDisperse<Self>>
     where
         B: AsRef<[u8]>;
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -70,7 +70,7 @@ pub type AdvzGPU<'srs, E, H> = AdvzInternal<
 >;
 
 /// The [ADVZ VID scheme](https://eprint.iacr.org/2021/1500), a concrete impl for [`VidScheme`].
-/// Consider using either [`Advz`] or [`AdvzGPU`].
+/// Consider using either [`Advz`] or `AdvzGPU` (enabled via `gpu-vid` feature).
 ///
 /// - `E` is any [`Pairing`]
 /// - `H` is a [`digest::Digest`]-compatible hash function.
@@ -210,7 +210,14 @@ where
     E: Pairing,
 {
     /// Construct a new VID instance
-    /// See doc in [`Self::new_internal()`]
+    ///
+    /// - `payload_chunk_size`: k
+    /// - `num_storage_nodes`: n (code rate: r = k/n)
+    /// - `multiplicity`: batch m chunks, keep the rate r = (m*k)/(m*n)
+    ///
+    /// # Errors
+    /// Return [`VidError::Argument`] if `num_storage_nodes <
+    /// payload_chunk_size`.
     pub fn new(
         payload_chunk_size: usize,
         num_storage_nodes: usize,
@@ -228,7 +235,14 @@ where
     UnivariateKzgPCS<E>: GPUCommittable<E>,
 {
     /// construct a new VID instance with SRS loaded to GPU
-    /// See doc in [`Self::new_internal()`]
+    ///
+    /// - `payload_chunk_size`: k
+    /// - `num_storage_nodes`: n (code rate: r = k/n)
+    /// - `multiplicity`: batch m chunks, keep the rate r = (m*k)/(m*n)
+    ///
+    /// # Errors
+    /// Return [`VidError::Argument`] if `num_storage_nodes <
+    /// payload_chunk_size`.
     pub fn new(
         payload_chunk_size: usize,
         num_storage_nodes: usize,
@@ -309,7 +323,7 @@ pub trait MaybeGPU<E: Pairing> {
     /// propagate out to `VidScheme::commit_only/disperse(&mut self)`
     /// This should be fixed once ICICLE improve their `HostOrDeviceSlice`, and
     /// we can update our `GPUCommittable::commit_on_gpu()` input type.
-    /// depends on https://github.com/ingonyama-zk/icicle/pull/412
+    /// depends on <https://github.com/ingonyama-zk/icicle/pull/412>
     fn kzg_batch_commit(
         &mut self,
         polys: &[DensePolynomial<E::ScalarField>],

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -1010,7 +1010,7 @@ mod tests {
 
     #[test]
     fn sad_path_verify_share_corrupt_share() {
-        let (mut advz, bytes_random) = avdz_init();
+        let (mut advz, bytes_random) = advz_init();
         let disperse = advz.disperse(bytes_random).unwrap();
         let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
 
@@ -1076,7 +1076,7 @@ mod tests {
 
     #[test]
     fn sad_path_verify_share_corrupt_commit() {
-        let (mut advz, bytes_random) = avdz_init();
+        let (mut advz, bytes_random) = advz_init();
         let disperse = advz.disperse(bytes_random).unwrap();
         let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
 
@@ -1122,7 +1122,7 @@ mod tests {
 
     #[test]
     fn sad_path_verify_share_corrupt_share_and_commit() {
-        let (mut advz, bytes_random) = avdz_init();
+        let (mut advz, bytes_random) = advz_init();
         let disperse = advz.disperse(bytes_random).unwrap();
         let (mut shares, mut common, commit) = (disperse.shares, disperse.common, disperse.commit);
 
@@ -1147,7 +1147,7 @@ mod tests {
 
     #[test]
     fn sad_path_recover_payload_corrupt_shares() {
-        let (mut advz, bytes_random) = avdz_init();
+        let (mut advz, bytes_random) = advz_init();
         let disperse = advz.disperse(&bytes_random).unwrap();
         let (shares, common) = (disperse.shares, disperse.common);
 
@@ -1206,7 +1206,7 @@ mod tests {
     /// Returns the following tuple:
     /// 1. An initialized [`Advz`] instance.
     /// 2. A `Vec<u8>` filled with random bytes.
-    pub(super) fn avdz_init() -> (Advz<Bls12_381, Sha256>, Vec<u8>) {
+    pub(super) fn advz_init() -> (Advz<Bls12_381, Sha256>, Vec<u8>) {
         let (payload_chunk_size, num_storage_nodes) = (4, 6);
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(payload_chunk_size, &mut rng);

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -408,7 +408,7 @@ mod tests {
         let poly_bytes_len = payload_chunk_size * elem_byte_capacity::<E::ScalarField>();
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(payload_elems_len, &mut rng);
-        let advz = Advz::<E, H>::new(payload_chunk_size, num_storage_nodes, 1, srs).unwrap();
+        let mut advz = Advz::<E, H>::new(payload_chunk_size, num_storage_nodes, 1, srs).unwrap();
 
         // TEST: different payload byte lengths
         let payload_byte_len_noise_cases = vec![0, poly_bytes_len / 2, poly_bytes_len - 1];

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -175,7 +175,7 @@ mod tests {
 
     use crate::vid::{
         advz::{
-            tests::{avdz_init, init_random_payload, init_srs},
+            tests::{advz_init, init_random_payload, init_srs},
             Advz,
         },
         VidScheme,
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     fn commit_disperse_recover_with_precomputed_data() {
-        let (advz, bytes_random) = avdz_init();
+        let (advz, bytes_random) = advz_init();
         let (commit, data) = advz.commit_only_precompute(&bytes_random).unwrap();
         let disperse = advz.disperse_precompute(&bytes_random, &data).unwrap();
         let (shares, common) = (disperse.shares, disperse.common);

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -24,7 +24,7 @@ pub fn round_trip<V, R>(
     for (&mult, &(payload_chunk_size, num_storage_nodes)) in
         zip(multiplicities.iter().cycle(), vid_sizes)
     {
-        let vid = vid_factory(payload_chunk_size, num_storage_nodes, mult);
+        let mut vid = vid_factory(payload_chunk_size, num_storage_nodes, mult);
 
         for &len in payload_byte_lens {
             println!(


### PR DESCRIPTION
## Description

closes: #521 

Major changes include:
- Rename original `struct Advz` to `struct AdvzInternal`, including all of its implementations
- Introduce two type alias `type Advz` (which is a direct replacement of the original struct with the same interface and generic param) and `type AdvzGPU` which contains more icicle-related type declaration
- Introduce `trait MaybeGPU` to allow specialized trait bounds on `kzg_batch_commit()` 
  - GPU version is enabled by feature flag `gpu-vid`
  - ⚠️ unfortunately, due to suboptimal API design of ICICLE's `struct HostOrSlice` which affects how we write `GPUCommit::commit_on_gpu`, we changed the API of `VidScheme::commit_only/disperse(&mut self)` to accept `&mut self` instead of the `&self`. Note that for the CPU version, even though we pass in a mutable reference, we never mutate it in the code! it's only the GPU version that requires a mutable reference. 
- add profile code for GPU version of the vid

## Benchmark 

**TL;DR: `Vid::commit_only()` improved by ~6.4x, `Vid::disperse()` improve by ~5x.**

_note_: this speedup is not entirely accurate since my AWS instance has only 4 cores, thus the CPU parallelized part is not very fast. _If we run our code on a 8~16 core CPU + 1 GPU, I'm fairly confident our disperse of 33MB is ~1 sec_.

In the following section, I add a line break the first group is GPU, the second is CPU. you should probably tell by their numbers as well.

### `k=256, n=512, m=1, |B| = 33MB`

```
running 1 test
Start:   KZG10::Setup with prover degree 256 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................3.592ms
End:     KZG10::Setup with prover degree 256 and verifier degree 1 .................4.949ms
Start:   encode payload bytes into polynomials
End:     encode payload bytes into polynomials .....................................186.731ms
Start:   batch poly commit
End:     batch poly commit .........................................................402.031ms

Start:   encode payload bytes into polynomials
End:     encode payload bytes into polynomials .....................................165.483ms
Start:   batch poly commit
··Start:   batch commit 4229 polynomials
··End:     batch commit 4229 polynomials ...........................................8.006s
End:     batch poly commit .........................................................8.006s
test vid::advz::tests::commit_only_timer ... ok

running 1 test
Start:   KZG10::Setup with prover degree 256 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................3.726ms
End:     KZG10::Setup with prover degree 256 and verifier degree 1 .................5.150ms
Start:   VID disperse 33554432 payload bytes to 512 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................172.910ms
··Start:   compute all storage node evals for 4229 polynomials with 256 coefficients
··End:     compute all storage node evals for 4229 polynomials with 256 coefficients 255.951ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................113.826ms
··Start:   compute 4229 KZG commitments
··End:     compute 4229 KZG commitments ............................................401.086ms
··Start:   compute aggregate proofs for 512 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................288.535ms
····Start:   gen eval proofs with parallel_factor 2 and num_points 512
····End:     gen eval proofs with parallel_factor 2 and num_points 512 .............96.601ms
··End:     compute aggregate proofs for 512 storage nodes ..........................388.802ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................67.736ms
End:     VID disperse 33554432 payload bytes to 512 nodes ..........................1.436s

Start:   VID disperse 33554432 payload bytes to 512 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................166.105ms
··Start:   compute all storage node evals for 4229 polynomials with 256 coefficients
··End:     compute all storage node evals for 4229 polynomials with 256 coefficients 198.006ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................94.184ms
··Start:   compute 4229 KZG commitments
····Start:   batch commit 4229 polynomials
····End:     batch commit 4229 polynomials .........................................8.028s
··End:     compute 4229 KZG commitments ............................................8.028s
··Start:   compute aggregate proofs for 512 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................287.139ms
····Start:   gen eval proofs with parallel_factor 2 and num_points 512
····End:     gen eval proofs with parallel_factor 2 and num_points 512 .............96.493ms
··End:     compute aggregate proofs for 512 storage nodes ..........................387.300ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................17.721ms
End:     VID disperse 33554432 payload bytes to 512 nodes ..........................8.928s
test vid::advz::tests::disperse_timer ... ok
``` 

### `k=32, n=128, m=4, |B| = 33MB`

❗ I believe this setup/regime is closer to what we will actually use.
**With limited CPU cores, our `disperse` takes 1.9 sec.**

```
running 1 test
Start:   KZG10::Setup with prover degree 128 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................2.469ms
End:     KZG10::Setup with prover degree 128 and verifier degree 1 .................3.784ms
Start:   encode payload bytes into polynomials
End:     encode payload bytes into polynomials .....................................176.997ms
Start:   batch poly commit
End:     batch poly commit .........................................................736.935ms

Start:   encode payload bytes into polynomials
End:     encode payload bytes into polynomials .....................................168.720ms
Start:   batch poly commit
··Start:   batch commit 8457 polynomials
··End:     batch commit 8457 polynomials ...........................................9.347s
End:     batch poly commit .........................................................9.347s
test vid::advz::tests::commit_only_timer ... ok

running 1 test
Start:   KZG10::Setup with prover degree 128 and verifier degree 1
··Start:   Generating powers of G
··End:     Generating powers of G ..................................................2.739ms
End:     KZG10::Setup with prover degree 128 and verifier degree 1 .................4.159ms
Start:   VID disperse 33554432 payload bytes to 128 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................179.144ms
··Start:   compute all storage node evals for 8457 polynomials with 128 coefficients
··End:     compute all storage node evals for 8457 polynomials with 128 coefficients 521.122ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................226.218ms
··Start:   compute 8457 KZG commitments
··End:     compute 8457 KZG commitments ............................................736.033ms
··Start:   compute aggregate proofs for 128 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................86.436ms
····Start:   gen eval proofs with parallel_factor 4 and num_points 512
····End:     gen eval proofs with parallel_factor 4 and num_points 512 .............78.720ms
··End:     compute aggregate proofs for 128 storage nodes ..........................168.839ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................81.293ms
End:     VID disperse 33554432 payload bytes to 128 nodes ..........................1.949s

Start:   VID disperse 33554432 payload bytes to 128 nodes
··Start:   encode payload bytes into polynomials
··End:     encode payload bytes into polynomials ...................................161.359ms
··Start:   compute all storage node evals for 8457 polynomials with 128 coefficients
··End:     compute all storage node evals for 8457 polynomials with 128 coefficients 405.542ms
··Start:   compute merkle root of all storage node evals
··End:     compute merkle root of all storage node evals ...........................178.632ms
··Start:   compute 8457 KZG commitments
····Start:   batch commit 8457 polynomials
····End:     batch commit 8457 polynomials .........................................9.348s
··End:     compute 8457 KZG commitments ............................................9.348s
··Start:   compute aggregate proofs for 128 storage nodes
····Start:   compute h_poly
····End:     compute h_poly ........................................................86.483ms
····Start:   gen eval proofs with parallel_factor 4 and num_points 512
····End:     gen eval proofs with parallel_factor 4 and num_points 512 .............78.709ms
··End:     compute aggregate proofs for 128 storage nodes ..........................168.857ms
··Start:   assemble shares for dispersal
··End:     assemble shares for dispersal ...........................................45.354ms
End:     VID disperse 33554432 payload bytes to 128 nodes ..........................10.344s
test vid::advz::tests::disperse_timer ... ok
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
