### PR TITLE
fix: `gpu_batch_commit` with empty polys

### DIFF
--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -705,6 +705,10 @@ pub(crate) mod icicle {
             prover_param: impl Borrow<UnivariateProverParam<E>>,
             polys: &[DensePolynomial<E::ScalarField>],
         ) -> Result<Vec<Commitment<E>>, PCSError> {
+            if polys.len() == 0 {
+                return Ok(vec![]);
+            }
+
             let stream = warmup_new_stream().unwrap();
 
             let degree = polys[0].degree();
@@ -736,6 +740,10 @@ pub(crate) mod icicle {
             polys: &[DensePolynomial<E::ScalarField>],
             stream: &CudaStream,
         ) -> Result<Vec<Commitment<E>>, PCSError> {
+            if polys.len() == 0 {
+                return Ok(vec![]);
+            }
+
             let poly_on_gpu = Self::load_batch_poly_to_gpu(polys)?;
             let msm_result_on_gpu =
                 Self::commit_on_gpu(prover_param_on_gpu, &poly_on_gpu, polys.len(), stream)?;
@@ -1381,6 +1389,9 @@ mod tests {
                     <UnivariateKzgPCS<E> as GPUCommittable<E>>::gpu_batch_commit(&ck, &polys)?;
                 let comms_cpu = UnivariateKzgPCS::<E>::batch_commit(&ck, &polys)?;
                 assert_eq!(comms_gpu, comms_cpu);
+                assert!(
+                    <UnivariateKzgPCS<E> as GPUCommittable<E>>::gpu_batch_commit(&ck, &[]).is_ok()
+                );
             }
             Ok(())
         }


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Originally, you'll panic if you feed the empty poly list to `gpu_batch_commit()`.
This PR adds a shortcut to prevent it.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
