### PR TITLE
chore!: new Advz constructor, Advz use u32 instead of usize

### DIFF
--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -64,7 +64,8 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("commit"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let mut advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz =
+                Advz::<E, H>::with_multiplicity(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -79,7 +80,8 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("disperse"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let mut advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz =
+                Advz::<E, H>::with_multiplicity(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -94,7 +96,8 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("verify"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let mut advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz =
+                Advz::<E, H>::with_multiplicity(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
             grp.bench_with_input(
@@ -116,7 +119,8 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("recover"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let mut advz = Advz::<E, H>::new(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz =
+                Advz::<E, H>::with_multiplicity(poly_degree, num_storage_nodes, 1, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common) = (disperse.shares, disperse.common);
             grp.bench_with_input(

--- a/primitives/benches/advz.rs
+++ b/primitives/benches/advz.rs
@@ -33,7 +33,7 @@ where
     // degree as a function of storage node count.
     // If desired, you could set polynomial degrees independent of storage node
     // count.
-    const CODE_RATE: usize = 4; // ratio of num_storage_nodes : polynomial_degree
+    const CODE_RATE: u32 = 4; // ratio of num_storage_nodes : polynomial_degree
     let storage_node_counts = [512, 1024];
     let payload_byte_lens = [1 * MB];
 
@@ -44,7 +44,7 @@ where
     let mut rng = jf_utils::test_rng();
     let srs = UnivariateKzgPCS::<E>::gen_srs_for_testing(
         &mut rng,
-        checked_fft_size(supported_degree).unwrap(),
+        checked_fft_size(supported_degree as usize).unwrap(),
     )
     .unwrap();
 
@@ -64,8 +64,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("commit"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let mut advz =
-                Advz::<E, H>::with_multiplicity(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz = Advz::<E, H>::new(num_storage_nodes, poly_degree, &srs).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -80,8 +79,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("disperse"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let mut advz =
-                Advz::<E, H>::with_multiplicity(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz = Advz::<E, H>::new(num_storage_nodes, poly_degree, &srs).unwrap();
             grp.bench_with_input(
                 BenchmarkId::from_parameter(num_storage_nodes),
                 &num_storage_nodes,
@@ -96,8 +94,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("verify"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let mut advz =
-                Advz::<E, H>::with_multiplicity(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz = Advz::<E, H>::new(num_storage_nodes, poly_degree, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common, commit) = (disperse.shares, disperse.common, disperse.commit);
             grp.bench_with_input(
@@ -119,8 +116,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("recover"));
         grp.throughput(Throughput::Bytes(len as u64));
         for (poly_degree, num_storage_nodes) in vid_sizes_iter.clone() {
-            let mut advz =
-                Advz::<E, H>::with_multiplicity(poly_degree, num_storage_nodes, 1, &srs).unwrap();
+            let mut advz = Advz::<E, H>::new(num_storage_nodes, poly_degree, &srs).unwrap();
             let disperse = advz.disperse(&payload_bytes).unwrap();
             let (shares, common) = (disperse.shares, disperse.common);
             grp.bench_with_input(
@@ -129,7 +125,7 @@ where
                 |b, _| {
                     // recover from only the first poly_degree shares
                     b.iter(|| {
-                        advz.recover_payload(&shares[..poly_degree], &common)
+                        advz.recover_payload(&shares[..poly_degree as usize], &common)
                             .unwrap()
                     });
                 },

--- a/primitives/src/vid.rs
+++ b/primitives/src/vid.rs
@@ -73,13 +73,13 @@ pub trait VidScheme {
     fn is_consistent(commit: &Self::Commit, common: &Self::Common) -> VidResult<()>;
 
     /// Extract the payload byte length data from a [`VidScheme::Common`].
-    fn get_payload_byte_len(common: &Self::Common) -> usize;
+    fn get_payload_byte_len(common: &Self::Common) -> u32;
 
     /// Extract the number of storage nodes from a [`VidScheme::Common`].
-    fn get_num_storage_nodes(common: &Self::Common) -> usize;
+    fn get_num_storage_nodes(common: &Self::Common) -> u32;
 
     /// Extract the number of poly evals per share [`VidScheme::Common`].
-    fn get_multiplicity(common: &Self::Common) -> usize;
+    fn get_multiplicity(common: &Self::Common) -> u32;
 }
 
 /// Convenience struct to aggregate disperse data.

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -678,25 +678,16 @@ where
         Ok(())
     }
 
-    fn get_payload_byte_len(common: &Self::Common) -> usize {
-        common
-            .payload_byte_len
-            .try_into()
-            .expect("u32 should be convertible to usize")
+    fn get_payload_byte_len(common: &Self::Common) -> u32 {
+        common.payload_byte_len
     }
 
-    fn get_num_storage_nodes(common: &Self::Common) -> usize {
-        common
-            .num_storage_nodes
-            .try_into()
-            .expect("u32 should be convertible to usize")
+    fn get_num_storage_nodes(common: &Self::Common) -> u32 {
+        common.num_storage_nodes
     }
 
-    fn get_multiplicity(common: &Self::Common) -> usize {
-        common
-            .multiplicity
-            .try_into()
-            .expect("u32 should be convertible to usize")
+    fn get_multiplicity(common: &Self::Common) -> u32 {
+        common.multiplicity
     }
 }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -134,11 +134,6 @@ where
         Self::with_multiplicity_internal(num_storage_nodes, recovery_threshold, multiplicity, srs)
     }
 
-    /// Return a new instance of `Self`.
-    ///
-    /// # Errors
-    /// Return [`VidError::Argument`] if `num_storage_nodes <
-    /// recovery_threshold`.
     pub(crate) fn with_multiplicity_internal(
         num_storage_nodes: usize,  // n (code rate: r = k/n)
         recovery_threshold: usize, // k
@@ -154,10 +149,9 @@ where
             )));
         }
 
-        if !(1..=16).contains(&multiplicity) || !multiplicity.is_power_of_two() {
+        if !multiplicity.is_power_of_two() {
             return Err(VidError::Argument(format!(
-                "multiplicity {} not allowed",
-                multiplicity
+                "multiplicity {multiplicity} should be a power of two"
             )));
         }
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -215,7 +215,7 @@ where
     /// # Errors
     /// Return [`VidError::Argument`] if
     /// - `num_storage_nodes < recovery_threshold`
-    /// - `recovery_threshold` is not a power of two TEMPORARY https://github.com/EspressoSystems/jellyfish/issues/339
+    /// - TEMPORARY `recovery_threshold` is not a power of two [github issue](https://github.com/EspressoSystems/jellyfish/issues/339)
     pub fn new(
         num_storage_nodes: u32,
         recovery_threshold: u32,
@@ -231,7 +231,7 @@ where
     ///
     /// # Errors
     /// In addition to [`Advz::new`], return [`VidError::Argument`] if
-    /// - `multiplicity` is not a power of two TEMPORARY https://github.com/EspressoSystems/jellyfish/issues/339
+    /// - TEMPORARY `multiplicity` is not a power of two [github issue](https://github.com/EspressoSystems/jellyfish/issues/339)
     pub fn with_multiplicity(
         num_storage_nodes: u32,
         recovery_threshold: u32,

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -986,16 +986,10 @@ mod tests {
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(recovery_threshold as usize, &mut rng);
         let mut advz =
-            Advz::<Bn254, Sha256>::with_multiplicity(num_storage_nodes, recovery_threshold, 1, srs)
-                .unwrap();
+            Advz::<Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, srs).unwrap();
         #[cfg(feature = "gpu-vid")]
-        let mut advz_gpu = AdvzGPU::<'_, Bn254, Sha256>::with_multiplicity(
-            num_storage_nodes,
-            recovery_threshold,
-            1,
-            &srs,
-        )
-        .unwrap();
+        let mut advz_gpu =
+            AdvzGPU::<'_, Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, &srs).unwrap();
 
         let payload_random = init_random_payload(1 << 25, &mut rng);
 
@@ -1012,16 +1006,10 @@ mod tests {
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(recovery_threshold as usize, &mut rng);
         let mut advz =
-            Advz::<Bn254, Sha256>::with_multiplicity(num_storage_nodes, recovery_threshold, 1, srs)
-                .unwrap();
+            Advz::<Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, srs).unwrap();
         #[cfg(feature = "gpu-vid")]
-        let mut advz_gpu = AdvzGPU::<'_, Bn254, Sha256>::with_multiplicity(
-            num_storage_nodes,
-            recovery_threshold,
-            1,
-            &srs,
-        )
-        .unwrap();
+        let mut advz_gpu =
+            AdvzGPU::<'_, Bn254, Sha256>::new(num_storage_nodes, recovery_threshold, &srs).unwrap();
 
         let payload_random = init_random_payload(1 << 25, &mut rng);
 
@@ -1234,7 +1222,7 @@ mod tests {
         let (recovery_threshold, num_storage_nodes) = (4, 6);
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(recovery_threshold as usize, &mut rng);
-        let advz = Advz::with_multiplicity(num_storage_nodes, recovery_threshold, 1, srs).unwrap();
+        let advz = Advz::new(num_storage_nodes, recovery_threshold, srs).unwrap();
         let bytes_random = init_random_payload(4000, &mut rng);
         (advz, bytes_random)
     }

--- a/primitives/src/vid/advz/payload_prover.rs
+++ b/primitives/src/vid/advz/payload_prover.rs
@@ -412,8 +412,7 @@ mod tests {
         let poly_bytes_len = recovery_threshold as usize * elem_byte_capacity::<E::ScalarField>();
         let mut rng = jf_utils::test_rng();
         let srs = init_srs(payload_elems_len, &mut rng);
-        let mut advz =
-            Advz::<E, H>::with_multiplicity(num_storage_nodes, recovery_threshold, 1, srs).unwrap();
+        let mut advz = Advz::<E, H>::new(num_storage_nodes, recovery_threshold, srs).unwrap();
 
         // TEST: different payload byte lengths
         let payload_byte_len_noise_cases = vec![0, poly_bytes_len / 2, poly_bytes_len - 1];

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -98,8 +98,8 @@ where
             poly_commits: data.poly_commits.clone(),
             all_evals_digest: all_evals_commit.commitment().digest(),
             payload_byte_len,
-            num_storage_nodes: self.num_storage_nodes.try_into().map_err(vid)?,
-            multiplicity: self.multiplicity.try_into().map_err(vid)?,
+            num_storage_nodes: self.num_storage_nodes,
+            multiplicity: self.multiplicity,
         };
         end_timer!(common_timer);
 
@@ -123,7 +123,7 @@ where
         let aggregate_proofs = UnivariateKzgPCS::multi_open_rou_proofs(
             &self.ck,
             &aggregate_poly,
-            code_word_size,
+            code_word_size as usize,
             &self.multi_open_domain,
         )
         .map_err(vid)?;
@@ -187,7 +187,7 @@ mod tests {
         let (recovery_threshold, num_storage_nodes) = (256, 512);
         let mut rng = jf_utils::test_rng();
         let multiplicity = 1;
-        let srs = init_srs(recovery_threshold * multiplicity, &mut rng);
+        let srs = init_srs((recovery_threshold * multiplicity) as usize, &mut rng);
         let advz = Advz::<Bls12_381, Sha256>::with_multiplicity(
             num_storage_nodes,
             recovery_threshold,
@@ -207,7 +207,7 @@ mod tests {
         let (recovery_threshold, num_storage_nodes) = (64, 128);
         let multiplicity = 4;
         let mut rng = jf_utils::test_rng();
-        let srs = init_srs(recovery_threshold * multiplicity, &mut rng);
+        let srs = init_srs((recovery_threshold * multiplicity) as usize, &mut rng);
         let advz = Advz::<Bls12_381, Sha256>::with_multiplicity(
             num_storage_nodes,
             recovery_threshold,

--- a/primitives/src/vid/advz/precomputable.rs
+++ b/primitives/src/vid/advz/precomputable.rs
@@ -64,7 +64,7 @@ where
             payload_byte_len,
             self.num_storage_nodes
         ));
-        let _chunk_size = self.multiplicity * self.payload_chunk_size;
+        let _chunk_size = self.multiplicity * self.recovery_threshold;
         let code_word_size = self.multiplicity * self.num_storage_nodes;
 
         // partition payload into polynomial coefficients
@@ -184,13 +184,13 @@ mod tests {
     #[test]
     fn commit_only_with_data_timer() {
         // run with 'print-trace' feature to see timer output
-        let (payload_chunk_size, num_storage_nodes) = (256, 512);
+        let (recovery_threshold, num_storage_nodes) = (256, 512);
         let mut rng = jf_utils::test_rng();
         let multiplicity = 1;
-        let srs = init_srs(payload_chunk_size * multiplicity, &mut rng);
-        let advz = Advz::<Bls12_381, Sha256>::new(
-            payload_chunk_size,
+        let srs = init_srs(recovery_threshold * multiplicity, &mut rng);
+        let advz = Advz::<Bls12_381, Sha256>::with_multiplicity(
             num_storage_nodes,
+            recovery_threshold,
             multiplicity,
             srs,
         )
@@ -204,13 +204,13 @@ mod tests {
     #[test]
     fn disperse_with_data_timer() {
         // run with 'print-trace' feature to see timer output
-        let (payload_chunk_size, num_storage_nodes) = (64, 128);
+        let (recovery_threshold, num_storage_nodes) = (64, 128);
         let multiplicity = 4;
         let mut rng = jf_utils::test_rng();
-        let srs = init_srs(payload_chunk_size * multiplicity, &mut rng);
-        let advz = Advz::<Bls12_381, Sha256>::new(
-            payload_chunk_size,
+        let srs = init_srs(recovery_threshold * multiplicity, &mut rng);
+        let advz = Advz::<Bls12_381, Sha256>::with_multiplicity(
             num_storage_nodes,
+            recovery_threshold,
             multiplicity,
             srs,
         )

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -34,10 +34,10 @@ fn round_trip() {
         );
 
     vid::round_trip(
-        |payload_chunk_size, num_storage_nodes, multiplicity| {
-            Advz::<Bls12_381, Sha256>::new(
-                payload_chunk_size,
+        |recovery_threshold, num_storage_nodes, multiplicity| {
+            Advz::<Bls12_381, Sha256>::with_multiplicity(
                 num_storage_nodes,
+                recovery_threshold,
                 multiplicity,
                 &srs,
             )

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -23,7 +23,8 @@ fn round_trip() {
     multiplicities.shuffle(&mut rng);
     let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
         &mut rng,
-        checked_fft_size(supported_degree).unwrap() * multiplicities.iter().max().unwrap(),
+        checked_fft_size(supported_degree as usize).unwrap()
+            * *multiplicities.iter().max().unwrap() as usize,
     )
     .unwrap();
 

--- a/primitives/tests/vid/mod.rs
+++ b/primitives/tests/vid/mod.rs
@@ -15,7 +15,7 @@ pub fn round_trip<V, R>(
     vid_factory: impl Fn(u32, u32, u32) -> V,
     vid_sizes: &[(u32, u32)],
     multiplicities: &[u32],
-    payload_byte_lens: &[usize],
+    payload_byte_lens: &[u32],
     rng: &mut R,
 ) where
     V: VidScheme,
@@ -33,7 +33,7 @@ pub fn round_trip<V, R>(
             );
 
             let bytes_random = {
-                let mut bytes_random = vec![0u8; len];
+                let mut bytes_random = vec![0u8; len as usize];
                 rng.fill_bytes(&mut bytes_random);
                 bytes_random
             };
@@ -43,11 +43,8 @@ pub fn round_trip<V, R>(
             assert_eq!(shares.len(), num_storage_nodes as usize);
             assert_eq!(commit, vid.commit_only(&bytes_random).unwrap());
             assert_eq!(len, V::get_payload_byte_len(&common));
-            assert_eq!(mult as usize, V::get_multiplicity(&common));
-            assert_eq!(
-                num_storage_nodes as usize,
-                V::get_num_storage_nodes(&common)
-            );
+            assert_eq!(mult, V::get_multiplicity(&common));
+            assert_eq!(num_storage_nodes, V::get_num_storage_nodes(&common));
 
             for share in shares.iter() {
                 vid.verify_share(share, &common, &commit).unwrap().unwrap();


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #463 

---

- BREAKING API CHANGE: `Advz::new` no longer take `multiplicity` arg. Instead we choose `multiplicity` for the caller. (Currently we set `mulitiplicity` to 1, issue #534 .) Also, reorder the arg list.
- new constructor `Advz::with_multiplicity` does what `Advz::new` used to do.
- remove limit on `multiplicity` as requested by @mrain 
- rename `payload_chunk_size` -> `recovery_threshold`. Much clearer IMO.
- As discussed, convert everything that will be serialized in VID from `usize` to `u32`. Lots of ugly `as usize` everywhere, but at least these conversions are safe. Dammit, Rust.
- I'm unable to build locally with `gpu-vid` feature. @mrain we might need you to check the build with `gpu-vid`.

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
