### PR TITLE
chore: VID-GPU `batch_commit` now takes polynomials of different degrees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ serde = { version = "1.0", default-features = false, features = [ "derive", "rc"
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 itertools = { version = "0.12", default-features = false } 
-tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.3.4" }
+tagged-base64 = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,5 @@ rand_chacha = { version = "0.3.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = [ "derive", "rc" ] }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
-itertools = { version = "0.12", default-features = false }
-tagged-base64 = { version = "0.4" }
+itertools = { version = "0.12", default-features = false } 
+tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.3.4" }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -39,11 +39,11 @@ generic-array = { version = "0", features = [
         "serde",
 ] } # not a direct dependency, but we need serde
 hashbrown = { workspace = true }
-icicle-bls12-377 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true, features = ["arkworks"] }
-icicle-bls12-381 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true, features = ["arkworks"] }
-icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true, features = ["arkworks"] }
-icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true }
-icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.0", optional = true }
+icicle-bls12-377 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.1", optional = true, features = ["arkworks"] }
+icicle-bls12-381 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.1", optional = true, features = ["arkworks"] }
+icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.1", optional = true, features = ["arkworks"] }
+icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.1", optional = true }
+icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.1", optional = true }
 itertools = { workspace = true, features = ["use_alloc"] }
 jf-relation = { path = "../relation", default-features = false }
 jf-utils = { path = "../utilities", default-features = false }

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -1384,17 +1384,24 @@ mod tests {
                 );
 
                 // batch commit
-                let batch_size = rng.gen_range(10..100);
-                let polys: Vec<_> = (0..batch_size).map(|_| <DensePolynomial<E::ScalarField> as DenseUVPolynomial<E::ScalarField>>::rand(
-                        degree, rng,
-                    )).collect();
-                let comms_gpu =
-                    <UnivariateKzgPCS<E> as GPUCommittable<E>>::gpu_batch_commit(&ck, &polys)?;
-                let comms_cpu = UnivariateKzgPCS::<E>::batch_commit(&ck, &polys)?;
-                assert_eq!(comms_gpu, comms_cpu);
-                assert!(
-                    <UnivariateKzgPCS<E> as GPUCommittable<E>>::gpu_batch_commit(&ck, &[]).is_ok()
-                );
+                for i in 0..5 {
+                    let batch_size = 10 + i;
+                    let polys: Vec<_> = (0..batch_size)
+                        .map(|_| {
+                            <DensePolynomial<E::ScalarField> as DenseUVPolynomial<
+                                    E::ScalarField,
+                                >>::rand(degree, rng)
+                        })
+                        .collect();
+                    let comms_gpu =
+                        <UnivariateKzgPCS<E> as GPUCommittable<E>>::gpu_batch_commit(&ck, &polys)?;
+                    let comms_cpu = UnivariateKzgPCS::<E>::batch_commit(&ck, &polys)?;
+                    assert_eq!(comms_gpu, comms_cpu);
+                    assert!(
+                        <UnivariateKzgPCS<E> as GPUCommittable<E>>::gpu_batch_commit(&ck, &[])
+                            .is_ok()
+                    );
+                }
             }
             Ok(())
         }

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -711,6 +711,8 @@ pub(crate) mod icicle {
 
             let stream = warmup_new_stream().unwrap();
 
+            let degree = polys.iter().map(|poly| poly.degree()).max().unwrap_or(0);
+
             #[cfg(feature = "kzg-print-trace")]
             let commit_time = start_timer!(|| format!(
                 "Committing to {} polys of degree {} ",

--- a/primitives/src/pcs/univariate_kzg/mod.rs
+++ b/primitives/src/pcs/univariate_kzg/mod.rs
@@ -856,13 +856,10 @@ pub(crate) mod icicle {
 
             #[cfg(feature = "kzg-print-trace")]
             let conv_time = start_timer!(|| "Type Conversion: ark->ICICLE: Scalar");
+            let zero_for_padding = E::ScalarField::zero();
             let scalars: Vec<<Self::IC as IcicleCurve>::ScalarField> = polys
                 .iter()
-                .flat_map(|poly| {
-                    poly.coeffs()
-                        .iter()
-                        .pad_using(size, |_| &E::ScalarField::zero())
-                })
+                .flat_map(|poly| poly.coeffs().iter().pad_using(size, |_| &zero_for_padding))
                 .collect::<Vec<_>>()
                 .into_par_iter()
                 .map(|&s| Self::ark_field_to_icicle(s))

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -803,7 +803,6 @@ where
         // Remove these FFTs after we get KZG in eval form
         // https://github.com/EspressoSystems/jellyfish/issues/339
         let mut coeffs_vec: Vec<_> = coeffs.map(|c| *c.borrow()).collect();
-        coeffs_vec.resize(chunk_size, <E as Pairing>::ScalarField::zero());
         let pre_fft_len = coeffs_vec.len();
         EvaluationDomain::ifft_in_place(domain_ref, &mut coeffs_vec);
 

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -378,6 +378,9 @@ where
     ) -> VidResult<Vec<KzgCommit<E>>> {
         // let mut srs_on_gpu = self.srs_on_gpu_and_cuda_stream.as_mut().unwrap().0;
         // let stream = &self.srs_on_gpu_and_cuda_stream.as_ref().unwrap().1;
+        if polys.is_empty() {
+            return Ok(vec![]);
+        }
         let (srs_on_gpu, stream) = self.srs_on_gpu_and_cuda_stream.as_mut().unwrap(); // safe by construction
         <UnivariateKzgPCS<E> as GPUCommittable<E>>::gpu_batch_commit_with_loaded_prover_param(
             srs_on_gpu, polys, stream,

--- a/primitives/src/vid/advz.rs
+++ b/primitives/src/vid/advz.rs
@@ -803,6 +803,7 @@ where
         // Remove these FFTs after we get KZG in eval form
         // https://github.com/EspressoSystems/jellyfish/issues/339
         let mut coeffs_vec: Vec<_> = coeffs.map(|c| *c.borrow()).collect();
+        coeffs_vec.resize(chunk_size, <E as Pairing>::ScalarField::zero());
         let pre_fft_len = coeffs_vec.len();
         EvaluationDomain::ifft_in_place(domain_ref, &mut coeffs_vec);
 

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -4,11 +4,18 @@ use ark_ff::{Field, PrimeField};
 use ark_std::rand::seq::SliceRandom;
 use jf_primitives::{
     pcs::{checked_fft_size, prelude::UnivariateKzgPCS, PolynomialCommitmentScheme},
-    vid::advz::Advz,
+    vid::advz,
 };
 use sha2::Sha256;
 
 mod vid;
+
+#[cfg(not(feature = "gpu-vid"))]
+/// Internal Jellyfish VID scheme
+type Advz<E, H> = advz::Advz<E, H>;
+#[cfg(feature = "gpu-vid")]
+/// Internal Jellyfish VID scheme
+type Advz<E, H> = advz::AdvzGPU<'static, E, H>;
 
 #[test]
 fn round_trip() {

--- a/primitives/tests/advz.rs
+++ b/primitives/tests/advz.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "test-srs")]
-use ark_bls12_381::Bls12_381;
+use ark_bn254::Bn254;
 use ark_ff::{Field, PrimeField};
 use ark_std::rand::seq::SliceRandom;
 use jf_primitives::{
@@ -28,7 +28,7 @@ fn round_trip() {
     let supported_degree = vid_sizes.iter().max_by_key(|v| v.0).unwrap().0 - 1;
     let mut rng = jf_utils::test_rng();
     multiplicities.shuffle(&mut rng);
-    let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
+    let srs = UnivariateKzgPCS::<Bn254>::gen_srs_for_testing(
         &mut rng,
         checked_fft_size(supported_degree as usize).unwrap()
             * *multiplicities.iter().max().unwrap() as usize,
@@ -37,13 +37,13 @@ fn round_trip() {
 
     println!(
             "modulus byte len: {}",
-            (<<UnivariateKzgPCS<Bls12_381> as PolynomialCommitmentScheme>::Evaluation as Field>::BasePrimeField
+            (<<UnivariateKzgPCS<Bn254> as PolynomialCommitmentScheme>::Evaluation as Field>::BasePrimeField
                 ::MODULUS_BIT_SIZE - 7)/8 + 1
         );
 
     vid::round_trip(
         |recovery_threshold, num_storage_nodes, multiplicity| {
-            Advz::<Bls12_381, Sha256>::with_multiplicity(
+            Advz::<Bn254, Sha256>::with_multiplicity(
                 num_storage_nodes,
                 recovery_threshold,
                 multiplicity,


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

It's highly possible that, in VID, the last encoded data polynomial is not of the maximum degree.
Now `batch_commit` pads the coefficient vectors for GPU data alignment.

Also update the icicle dependency for bug fix.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
