### PR TITLE
ci: update ci for unused dep

### DIFF
--- a/.github/workflows/periodic_checks.yml
+++ b/.github/workflows/periodic_checks.yml
@@ -23,6 +23,4 @@ jobs:
       - name: Run cargo-udeps
         uses: aig787/cargo-udeps-action@v1
         with:
-          # not using --all-targets because --examples need "--features test-srs"
-          # checking the rest is sufficient for udeps purposes.
-          args: "--workspace --tests --lib --bins --benches"
+          args: "--workspace --all-targets --features 'test-srs test-apis bls schnorr gadgets'"


### PR DESCRIPTION
### This PR: 

Fix CI failure for periodic check: https://github.com/EspressoSystems/jellyfish/actions/runs/8863541950/job/24337714873 
(which always notify me on weekend 😢 )

### How to test this PR: 

since we didn't install [`cargo-udeps` ](https://github.com/est31/cargo-udeps)in nix shell, I was using my local exec, and I got:

```
└─○ cargo-udeps udeps --workspace --all-targets --features 'test-srs test-apis bls schnorr gadgets'                      
All deps seem to have been used.
``` 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [ ] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [ ] ~Wrote unit tests~
- [ ] ~Updated relevant documentation in the code~
- [ ] ~Added relevant changelog entries to the `CHANGELOG.md` of touched crates.~
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
