### PR TITLE
fix: correct lagrange coefficient computation

### DIFF
--- a/plonk/src/lagrange.rs
+++ b/plonk/src/lagrange.rs
@@ -1,0 +1,224 @@
+//! Utilities for Lagrange interpolations, evaluations, coefficients for a
+//! polynomial
+
+use ark_ff::FftField;
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
+use ark_std::{ops::Range, vec, vec::Vec};
+
+// TODO: (alex) include these APIs upstream in arkworks directly
+
+/// A helper trait for computing Lagrange coefficients of an evaluation domain
+///
+/// from arkworks:
+/// Evaluate all Lagrange polynomials at tau to get the lagrange coefficients.
+/// Define the following as
+/// - H: The coset we are in, with generator g and offset h
+/// - n: The size of the coset H
+/// - Z_H: The vanishing polynomial for H. Z_H(x) = prod_{i in n} (x - hg^i) =
+///   x^n - h^n
+/// - v_i: A sequence of values, where v_0 = 1/(n * h^(n-1)), and v_{i + 1} = g
+///   * v_i
+///
+/// We then compute L_{i,H}(tau) as `L_{i,H}(tau) = Z_H(tau) * v_i / (tau - h *
+/// g^i)`
+#[allow(dead_code)]
+pub(crate) trait LagrangeCoeffs<F: FftField> {
+    /// Returns the first coefficient: `L_{0, Domain}(tau)`
+    fn first_lagrange_coeff(&self, tau: F) -> F;
+    /// Returns the last coefficient: `L_{n-1, Domain}(tau)`
+    fn last_lagrange_coeff(&self, tau: F) -> F;
+    /// Return a list of coefficients for `L_{range, Domain}(tau)`
+    fn lagrange_coeffs_for_range(&self, range: Range<usize>, tau: F) -> Vec<F>;
+}
+
+impl<F: FftField> LagrangeCoeffs<F> for Radix2EvaluationDomain<F> {
+    // L_0(tau) = Z_H(tau) * g^0 / (n * h^(n-1) *(tau - h * g^0))
+    // with g^0 = 1
+    // special care when tau in H, as both numerator and denominator is zero
+    fn first_lagrange_coeff(&self, tau: F) -> F {
+        let offset = self.coset_offset();
+        let z_h_at_tau = self.evaluate_vanishing_polynomial(tau);
+        if z_h_at_tau.is_zero() {
+            if tau == F::one() * offset {
+                F::one()
+            } else {
+                F::zero()
+            }
+        } else {
+            let denominator = self.size_as_field_element()
+                * offset.pow([self.size() as u64 - 1])
+                * (tau - offset);
+            z_h_at_tau * denominator.inverse().unwrap()
+        }
+    }
+
+    // L_n-1(tau) = Z_H(tau) * g^-1 / (n * h^(n-1) * (tau - h * g^-1))
+    // with g^n-1 = g^-1
+    fn last_lagrange_coeff(&self, tau: F) -> F {
+        let offset = self.coset_offset();
+        let z_h_at_tau = self.evaluate_vanishing_polynomial(tau);
+        if z_h_at_tau.is_zero() {
+            if tau == self.group_gen_inv() * offset {
+                F::one()
+            } else {
+                F::zero()
+            }
+        } else {
+            let denominator = self.size_as_field_element()
+                * offset.pow([self.size() as u64 - 1])
+                * (tau - offset * self.group_gen_inv());
+            z_h_at_tau * self.group_gen_inv() * denominator.inverse().unwrap()
+        }
+    }
+
+    // similar to `EvaluationDomain::evaluate_all_lagrange_coefficients()`
+    //
+    // # Panic
+    // if `range` exceeds the `self.size()`
+    fn lagrange_coeffs_for_range(&self, range: Range<usize>, tau: F) -> Vec<F> {
+        if range.end > self.size() {
+            panic!("Out of range: domain size smaller than range.end");
+        }
+        let size = range.end - range.start;
+        let z_h_at_tau = self.evaluate_vanishing_polynomial(tau);
+        let offset = self.coset_offset();
+        let group_gen = self.group_gen();
+        let group_start = group_gen.pow([range.start as u64]);
+
+        if z_h_at_tau.is_zero() {
+            // In this case, we know that tau = hg^i, for some value i.
+            // Then i-th lagrange coefficient in this case is then simply 1,
+            // and all other lagrange coefficients are 0.
+            // Thus we find i by brute force.
+            let mut u = vec![F::zero(); size];
+            let mut omega_i = offset * group_start;
+            for u_i in u.iter_mut().take(size) {
+                if omega_i == tau {
+                    *u_i = F::one();
+                    break;
+                }
+                omega_i *= &group_gen;
+            }
+            u
+        } else {
+            // In this case we have to compute `Z_H(tau) * v_i / (tau - h g^i)`
+            // for i in start..end
+            // We actually compute this by computing (Z_H(tau) * v_i)^{-1} * (tau - h g^i)
+            // and then batch inverting to get the correct lagrange coefficients.
+            // We let `l_i = (Z_H(tau) * v_i)^-1` and `r_i = tau - h g^i`
+            // Notice that since Z_H(tau) is i-independent,
+            // and v_i = g * v_{i-1}, it follows that
+            // l_i = g^-1 * l_{i-1}
+
+            let group_gen_inv = self.group_gen_inv();
+            let start = range.start as u64;
+
+            // v_0_inv = n * h^(n-1)
+            let v_0_inv = self.size_as_field_element() * offset.pow([self.size() as u64 - 1]);
+            let mut l_i = z_h_at_tau.inverse().unwrap() * v_0_inv * group_gen_inv.pow([start]);
+
+            let mut negative_cur_elem = -offset * group_gen.pow([start]);
+            let mut lagrange_coefficients_inverse = vec![F::zero(); size];
+            for coeff in lagrange_coefficients_inverse.iter_mut() {
+                let r_i = tau + negative_cur_elem;
+                *coeff = l_i * r_i;
+                // Increment l_i and negative_cur_elem
+                l_i *= &group_gen_inv;
+                negative_cur_elem *= &group_gen;
+            }
+            ark_ff::fields::batch_inversion(lagrange_coefficients_inverse.as_mut_slice());
+            lagrange_coefficients_inverse
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ark_bls12_381::Fr;
+    use ark_std::{rand::Rng, One, UniformRand, Zero};
+
+    /// Test that for points in the domain, coefficients are computed correctly
+    #[test]
+    fn test_in_domain_lagrange_coeff() {
+        let mut rng = jf_utils::test_rng();
+        for domain_log_size in 4..9 {
+            let domain_size = 1 << domain_log_size;
+            let domain = Radix2EvaluationDomain::<Fr>::new(domain_size).unwrap();
+            let coset_domain = domain.get_coset(Fr::GENERATOR).unwrap();
+            for (i, (x, coset_x)) in domain.elements().zip(coset_domain.elements()).enumerate() {
+                if i == 0 {
+                    assert_eq!(domain.first_lagrange_coeff(x), Fr::one());
+                    assert_eq!(domain.last_lagrange_coeff(x), Fr::zero());
+                    assert_eq!(coset_domain.first_lagrange_coeff(coset_x), Fr::one());
+                    assert_eq!(coset_domain.last_lagrange_coeff(coset_x), Fr::zero());
+                }
+                if i == domain.size() - 1 {
+                    assert_eq!(domain.last_lagrange_coeff(x), Fr::one());
+                    assert_eq!(domain.first_lagrange_coeff(x), Fr::zero());
+                    assert_eq!(coset_domain.last_lagrange_coeff(coset_x), Fr::one());
+                    assert_eq!(coset_domain.first_lagrange_coeff(coset_x), Fr::zero());
+                }
+
+                let lagrange_coeffs = domain.evaluate_all_lagrange_coefficients(x);
+                let coset_lagrange_coeffs =
+                    coset_domain.evaluate_all_lagrange_coefficients(coset_x);
+                for _ in 0..10 {
+                    let start = rng.gen_range(0..i + 1);
+                    let end = rng.gen_range(start..domain_size + 1);
+                    assert_eq!(
+                        domain.lagrange_coeffs_for_range(start..end, x),
+                        lagrange_coeffs[start..end]
+                    );
+                    assert_eq!(
+                        coset_domain.lagrange_coeffs_for_range(start..end, coset_x),
+                        coset_lagrange_coeffs[start..end]
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_random_lagrange_coeff() {
+        let mut rng = jf_utils::test_rng();
+        for domain_log_size in 4..9 {
+            let domain_size = 1 << domain_log_size;
+            let domain = Radix2EvaluationDomain::<Fr>::new(domain_size).unwrap();
+            let coset_domain = domain.get_coset(Fr::GENERATOR).unwrap();
+
+            for _ in 0..10 {
+                let x = Fr::rand(&mut rng);
+                let lagrange_coeffs = domain.evaluate_all_lagrange_coefficients(x);
+                let coset_lagrange_coeffs = coset_domain.evaluate_all_lagrange_coefficients(x);
+
+                assert_eq!(domain.first_lagrange_coeff(x), lagrange_coeffs[0]);
+                assert_eq!(
+                    domain.last_lagrange_coeff(x),
+                    lagrange_coeffs[domain_size - 1]
+                );
+                assert_eq!(
+                    coset_domain.first_lagrange_coeff(x),
+                    coset_lagrange_coeffs[0]
+                );
+                assert_eq!(
+                    coset_domain.last_lagrange_coeff(x),
+                    coset_lagrange_coeffs[domain_size - 1]
+                );
+
+                for _ in 0..10 {
+                    let start = rng.gen_range(0..domain_size);
+                    let end = rng.gen_range(start..domain_size + 1);
+                    assert_eq!(
+                        domain.lagrange_coeffs_for_range(start..end, x),
+                        lagrange_coeffs[start..end]
+                    );
+                    assert_eq!(
+                        coset_domain.lagrange_coeffs_for_range(start..end, x),
+                        coset_lagrange_coeffs[start..end]
+                    );
+                }
+            }
+        }
+    }
+}

--- a/plonk/src/lagrange.rs
+++ b/plonk/src/lagrange.rs
@@ -47,9 +47,9 @@ impl<F: FftField> LagrangeCoeffs<F> for Radix2EvaluationDomain<F> {
             // already early-return
             F::zero()
         } else {
-            let denominator = self.size_as_field_element()
-                * offset.pow([self.size() as u64 - 1])
-                * (tau - offset);
+            let offset_pow_size_minus_one = self.coset_offset_pow_size() / offset;
+            let denominator =
+                self.size_as_field_element() * offset_pow_size_minus_one * (tau - offset);
             z_h_at_tau * denominator.inverse().unwrap()
         }
     }
@@ -68,8 +68,9 @@ impl<F: FftField> LagrangeCoeffs<F> for Radix2EvaluationDomain<F> {
             // already early-return
             F::zero()
         } else {
+            let offset_pow_size_minus_one = self.coset_offset_pow_size() / offset;
             let denominator = self.size_as_field_element()
-                * offset.pow([self.size() as u64 - 1])
+                * offset_pow_size_minus_one
                 * (tau - offset * self.group_gen_inv());
             z_h_at_tau * self.group_gen_inv() * denominator.inverse().unwrap()
         }
@@ -118,7 +119,7 @@ impl<F: FftField> LagrangeCoeffs<F> for Radix2EvaluationDomain<F> {
             let start = range.start as u64;
 
             // v_0_inv = n * h^(n-1)
-            let v_0_inv = self.size_as_field_element() * offset.pow([self.size() as u64 - 1]);
+            let v_0_inv = self.size_as_field_element() * self.coset_offset_pow_size() / offset;
             let mut l_i = z_h_at_tau.inverse().unwrap() * v_0_inv * group_gen_inv.pow([start]);
 
             let mut negative_cur_elem = -offset * group_start;

--- a/plonk/src/lib.rs
+++ b/plonk/src/lib.rs
@@ -18,6 +18,7 @@ extern crate derivative;
 pub mod circuit;
 pub mod constants;
 pub mod errors;
+pub(crate) mod lagrange;
 pub mod proof_system;
 pub mod transcript;
 

--- a/plonk/src/proof_system/prover.rs
+++ b/plonk/src/proof_system/prover.rs
@@ -784,9 +784,10 @@ impl<E: Pairing> Prover<E> {
         let m = self.quot_domain.size();
         let domain_size_ratio = m / n;
         let vanish_eval = self.domain.evaluate_vanishing_polynomial(eval_point);
-        let lagrange_n_coeff_div_vanish = self.domain.last_lagrange_coeff(eval_point) / vanish_eval;
-        let lagrange_1_coeff_div_vanish =
-            self.domain.first_lagrange_coeff(eval_point) / vanish_eval;
+        let (lagrange_1_coeff, lagrange_n_coeff) =
+            self.domain.first_and_last_lagrange_coeffs(eval_point);
+        let lagrange_1_coeff_div_vanish = lagrange_1_coeff / vanish_eval;
+        let lagrange_n_coeff_div_vanish = lagrange_n_coeff / vanish_eval;
 
         let mut alpha_power = challenges.alpha * challenges.alpha * challenges.alpha;
 
@@ -1026,8 +1027,8 @@ impl<E: Pairing> Prover<E> {
         let one = E::ScalarField::one();
 
         // compute lagrange_1 and lagrange_n
-        let lagrange_1_eval = self.domain.first_lagrange_coeff(challenges.zeta);
-        let lagrange_n_eval = self.domain.last_lagrange_coeff(challenges.zeta);
+        let (lagrange_1_eval, lagrange_n_eval) =
+            self.domain.first_and_last_lagrange_coeffs(challenges.zeta);
 
         // compute the coefficient for polynomial `prod_lookup_poly`
         let merged_table_eval = eval_merged_table::<E>(

--- a/plonk/src/proof_system/prover.rs
+++ b/plonk/src/proof_system/prover.rs
@@ -783,10 +783,43 @@ impl<E: Pairing> Prover<E> {
         let n = pk.domain_size();
         let m = self.quot_domain.size();
         let domain_size_ratio = m / n;
-        let vanish_eval = self.domain.evaluate_vanishing_polynomial(eval_point);
-        let lagrange_n_coeff_div_vanish = self.domain.last_lagrange_coeff(eval_point) / vanish_eval;
-        let lagrange_1_coeff_div_vanish =
-            self.domain.first_lagrange_coeff(eval_point) / vanish_eval;
+        let zero = E::ScalarField::zero();
+        let one = E::ScalarField::one();
+
+        // NOTE: we didn't use `domain.first/last_lagrange_coeff()` to save more compute
+        // as we only need the value divided by vanish_eval
+        let offset = self.domain.coset_offset();
+        let (lagrange_1_coeff_div_vanish, lagrange_n_coeff_div_vanish) =
+            if eval_point == one * offset {
+                // when eval_point is first element in the domain
+                (
+                    self.domain
+                        .evaluate_vanishing_polynomial(eval_point)
+                        .inverse()
+                        .unwrap(),
+                    zero,
+                )
+            } else if eval_point == self.domain.group_gen_inv() * offset {
+                // when eval_point is last element in the domain
+                (
+                    zero,
+                    self.domain
+                        .evaluate_vanishing_polynomial(eval_point)
+                        .inverse()
+                        .unwrap(),
+                )
+            } else {
+                let size_f = self.domain.size_as_field_element();
+                let h_pow = offset.pow([self.domain.size() as u64 - 1]);
+                let group_gen_inv = self.domain.group_gen_inv();
+                (
+                    (size_f * h_pow * (eval_point - offset)).inverse().unwrap(),
+                    group_gen_inv
+                        * (size_f * h_pow * (eval_point - offset * group_gen_inv))
+                            .inverse()
+                            .unwrap(),
+                )
+            };
 
         let mut alpha_power = challenges.alpha * challenges.alpha * challenges.alpha;
 
@@ -844,7 +877,7 @@ impl<E: Pairing> Prover<E> {
         // The check that p(X) = 1 at point 1.
         //
         // Fp1(X)/Z_H(X) = (L1(X) * (p(X) - 1)) / Z_H(X) = (p(X) - 1) / (n * (X - 1))
-        let term_p_1 = (p_x - E::ScalarField::one()) * lagrange_1_coeff_div_vanish;
+        let term_p_1 = (p_x - one) * lagrange_1_coeff_div_vanish;
         result_2 += alpha_power * term_p_1;
         alpha_power *= challenges.alpha;
 
@@ -852,7 +885,7 @@ impl<E: Pairing> Prover<E> {
         //
         // Fp2(X)/Z_H(X) = (Ln(X) * (p(X) - 1)) / Z_H(X) = (p(X) - 1) * w^{n-1} / (n *
         // (X - w^{n-1}))
-        let term_p_2 = (p_x - E::ScalarField::one()) * lagrange_n_coeff_div_vanish;
+        let term_p_2 = (p_x - one) * lagrange_n_coeff_div_vanish;
         result_2 += alpha_power * term_p_2;
         alpha_power *= challenges.alpha;
 
@@ -863,7 +896,7 @@ impl<E: Pairing> Prover<E> {
         // [gamma*(1+beta) + merged_table(X) + beta * merged_table(Xw)]
         //        - (X - w^{n-1}) * p(Xw) * [gamma(1+beta) + h_1(X) + beta * h_1(Xw)] *
         //          [gamma(1+beta) + h_2(X) + beta * h_2(Xw)]
-        let beta_plus_one = E::ScalarField::one() + challenges.beta;
+        let beta_plus_one = one + challenges.beta;
         let gamma_mul_beta_plus_one = beta_plus_one * challenges.gamma;
         let term_p_3 = (eval_point - self.domain.group_gen_inv)
             * (p_x

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -144,8 +144,8 @@ where
         }
 
         let vanish_eval = self.evaluate_vanishing_poly(&challenges.zeta);
-        let lagrange_1_eval = self.domain.first_lagrange_coeff(challenges.zeta);
-        let lagrange_n_eval = self.domain.last_lagrange_coeff(challenges.zeta);
+        let (lagrange_1_eval, lagrange_n_eval) =
+            self.domain.first_and_last_lagrange_coeffs(challenges.zeta);
 
         // compute the constant term of the linearization polynomial
         let lin_poly_constant = self.compute_lin_poly_constant_term(

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -14,6 +14,7 @@
 use crate::{
     constants::KECCAK256_STATE_SIZE,
     errors::PlonkError,
+    lagrange::LagrangeCoeffs,
     proof_system::{
         structs::{self, BatchProof, PlookupProof, ProofEvaluations, VerifyingKey},
         verifier,
@@ -244,11 +245,12 @@ where
         ),
         PlonkError,
     > {
-        let lagrange_1_eval = self.domain.first_lagrange_coeff(zeta);
-        let lagrange_n_eval = self.domain.last_lagrange_coeff(zeta);
+        let verifier: verifier::Verifier<E> = (*self).clone().into();
+        let lagrange_1_eval = verifier.domain.first_lagrange_coeff(*zeta);
+        let lagrange_n_eval = verifier.domain.last_lagrange_coeff(*zeta);
         // TODO: (alex) remove this, once the `evaluate_pi_poly()` is updated
-        let vanish_eval = self.evaluate_vanishing_poly(&challenges.zeta);
-        let pi_eval = self.evaluate_pi_poly(public_input, zeta, &vanish_eval, false)?;
+        let vanish_eval = verifier.evaluate_vanishing_poly(zeta);
+        let pi_eval = verifier.evaluate_pi_poly(public_input, zeta, &vanish_eval, false)?;
         Ok((vanish_eval, lagrange_1_eval, lagrange_n_eval, pi_eval))
     }
 

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -244,12 +244,11 @@ where
         ),
         PlonkError,
     > {
-        let verifier: verifier::Verifier<E> = (*self).clone().into();
-
-        let vanish_eval = verifier.evaluate_vanishing_poly(zeta);
-        let (lagrange_1_eval, lagrange_n_eval) =
-            verifier.evaluate_lagrange_1_and_n(zeta, &vanish_eval);
-        let pi_eval = verifier.evaluate_pi_poly(public_input, zeta, &vanish_eval, false)?;
+        let lagrange_1_eval = self.domain.first_lagrange_coeff(zeta);
+        let lagrange_n_eval = self.domain.last_lagrange_coeff(zeta);
+        // TODO: (alex) remove this, once the `evaluate_pi_poly()` is updated
+        let vanish_eval = self.evaluate_vanishing_poly(&challenges.zeta);
+        let pi_eval = self.evaluate_pi_poly(public_input, zeta, &vanish_eval, false)?;
         Ok((vanish_eval, lagrange_1_eval, lagrange_n_eval, pi_eval))
     }
 

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -248,9 +248,8 @@ where
         let verifier: verifier::Verifier<E> = (*self).clone().into();
         let lagrange_1_eval = verifier.domain.first_lagrange_coeff(*zeta);
         let lagrange_n_eval = verifier.domain.last_lagrange_coeff(*zeta);
-        // TODO: (alex) remove this, once the `evaluate_pi_poly()` is updated
         let vanish_eval = verifier.evaluate_vanishing_poly(zeta);
-        let pi_eval = verifier.evaluate_pi_poly(public_input, zeta, &vanish_eval, false)?;
+        let pi_eval = verifier.evaluate_pi_poly(public_input, zeta, false)?;
         Ok((vanish_eval, lagrange_1_eval, lagrange_n_eval, pi_eval))
     }
 
@@ -277,7 +276,6 @@ where
         verify_keys: &[&VerifyingKey<E>],
         public_inputs: &[&[E::ScalarField]],
         batch_proof: &BatchProof<E>,
-        vanish_eval: &E::ScalarField,
         lagrange_1_eval: &E::ScalarField,
         lagrange_n_eval: &E::ScalarField,
         alpha_powers: &[E::ScalarField],
@@ -291,7 +289,6 @@ where
                 verify_keys,
                 public_inputs,
                 batch_proof,
-                vanish_eval,
                 lagrange_1_eval,
                 lagrange_n_eval,
                 alpha_powers,

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -246,8 +246,8 @@ where
         PlonkError,
     > {
         let verifier: verifier::Verifier<E> = (*self).clone().into();
-        let lagrange_1_eval = verifier.domain.first_lagrange_coeff(*zeta);
-        let lagrange_n_eval = verifier.domain.last_lagrange_coeff(*zeta);
+        let (lagrange_1_eval, lagrange_n_eval) =
+            verifier.domain.first_and_last_lagrange_coeffs(*zeta);
         let vanish_eval = verifier.evaluate_vanishing_poly(zeta);
         let pi_eval = verifier.evaluate_pi_poly(public_input, zeta, false)?;
         Ok((vanish_eval, lagrange_1_eval, lagrange_n_eval, pi_eval))


### PR DESCRIPTION
closes: #605 

### This PR: 

Executed this plan: https://github.com/EspressoSystems/jellyfish/issues/605#issuecomment-2180773751
and updated all previously lagrange coeffs computation

### This PR does not:

Update anything about recursive circuit, since the occurrence of the challenge `zeta` being one of the domain elements is negligibly small, not sure if we want to burden our recursion circuit to include the extra branch condition.  


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
