### PR TITLE
refactor: use BigEndian for SolidityTranscript

### DIFF
--- a/plonk/CHANGELOG.md
+++ b/plonk/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2024-07-02)
+
+### Breaking Changes
+
+- [#619](https://github.com/EspressoSystems/jellyfish/pull/619) `SolidityTranscript` removed `state`, making challenge `tau` only for lookup-enabled proofs
+
+### Fixed
+
+- [#611](https://github.com/EspressoSystems/jellyfish/pull/611) Lagrange coefficient computation for domain elements
+
 ## 0.4.4
 
 - See `CHANGELOG_OLD.md` for all previous changes.

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jf-plonk"
 description = "TurboPlonk and UntraPlonk implementation."
-version = { workspace = true }
+version = "0.5.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/plonk/src/circuit/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/plonk_verifier/gadgets.rs
@@ -224,7 +224,11 @@ where
     for wires_poly_comms in batch_proof.wires_poly_comms_vec.iter() {
         transcript_var.append_commitments_vars(b"witness_poly_comms", wires_poly_comms)?;
     }
-    let tau = transcript_var.get_and_append_challenge_var::<E>(b"tau", circuit)?;
+    let tau = if verify_keys.iter().any(|vk| vk.support_lookup) {
+        transcript_var.get_and_append_challenge_var::<E>(b"tau", circuit)?
+    } else {
+        circuit.one()
+    };
 
     let beta = transcript_var.get_and_append_challenge_var::<E>(b"beta", circuit)?;
     let gamma = transcript_var.get_and_append_challenge_var::<E>(b"gamma", circuit)?;

--- a/plonk/src/circuit/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/plonk_verifier/gadgets.rs
@@ -224,11 +224,6 @@ where
     for wires_poly_comms in batch_proof.wires_poly_comms_vec.iter() {
         transcript_var.append_commitments_vars(b"witness_poly_comms", wires_poly_comms)?;
     }
-    let tau = if verify_keys.iter().any(|vk| vk.support_lookup) {
-        transcript_var.get_and_append_challenge_var::<E>(b"tau", circuit)?
-    } else {
-        circuit.one()
-    };
 
     let beta = transcript_var.get_and_append_challenge_var::<E>(b"beta", circuit)?;
     let gamma = transcript_var.get_and_append_challenge_var::<E>(b"gamma", circuit)?;
@@ -252,7 +247,6 @@ where
 
     // convert challenge vars into FpElemVars
     let challenge_var = ChallengesVar {
-        tau,
         alpha,
         beta,
         gamma,

--- a/plonk/src/circuit/plonk_verifier/mod.rs
+++ b/plonk/src/circuit/plonk_verifier/mod.rs
@@ -50,6 +50,9 @@ pub struct VerifyingKeyVar<E: Pairing> {
     /// The constants K0, ..., K_num_wire_types that ensure wire subsets are
     /// disjoint.
     k: Vec<E::ScalarField>,
+
+    /// flag to indicate if this circuit supports lookup argument
+    support_lookup: bool,
 }
 
 impl<E: Pairing> VerifyingKeyVar<E> {
@@ -80,6 +83,7 @@ impl<E: Pairing> VerifyingKeyVar<E> {
             domain_size: verify_key.domain_size,
             num_inputs: verify_key.num_inputs,
             k: verify_key.k.clone(),
+            support_lookup: circuit.support_lookup(),
         })
     }
 
@@ -141,6 +145,7 @@ impl<E: Pairing> VerifyingKeyVar<E> {
             domain_size: self.domain_size,
             num_inputs: self.num_inputs + other.num_inputs,
             k: self.k.clone(),
+            support_lookup: circuit.support_lookup(),
         })
     }
 

--- a/plonk/src/circuit/plonk_verifier/mod.rs
+++ b/plonk/src/circuit/plonk_verifier/mod.rs
@@ -50,9 +50,6 @@ pub struct VerifyingKeyVar<E: Pairing> {
     /// The constants K0, ..., K_num_wire_types that ensure wire subsets are
     /// disjoint.
     k: Vec<E::ScalarField>,
-
-    /// flag to indicate if this circuit supports lookup argument
-    support_lookup: bool,
 }
 
 impl<E: Pairing> VerifyingKeyVar<E> {
@@ -83,7 +80,6 @@ impl<E: Pairing> VerifyingKeyVar<E> {
             domain_size: verify_key.domain_size,
             num_inputs: verify_key.num_inputs,
             k: verify_key.k.clone(),
-            support_lookup: circuit.support_lookup(),
         })
     }
 
@@ -145,7 +141,6 @@ impl<E: Pairing> VerifyingKeyVar<E> {
             domain_size: self.domain_size,
             num_inputs: self.num_inputs + other.num_inputs,
             k: self.k.clone(),
-            support_lookup: circuit.support_lookup(),
         })
     }
 

--- a/plonk/src/circuit/plonk_verifier/structs.rs
+++ b/plonk/src/circuit/plonk_verifier/structs.rs
@@ -17,7 +17,6 @@ use jf_relation::{
 /// Plonk IOP verifier challenges.
 #[derive(Debug, Default)]
 pub(crate) struct ChallengesVar {
-    pub(crate) tau: Variable,
     pub(crate) alpha: Variable,
     pub(crate) beta: Variable,
     pub(crate) gamma: Variable,
@@ -29,7 +28,6 @@ pub(crate) struct ChallengesVar {
 /// Plonk IOP verifier challenges.
 #[derive(Debug, Default)]
 pub(crate) struct ChallengesFpElemVar<F: PrimeField> {
-    pub(crate) _tau: FpElemVar<F>,
     pub(crate) alphas: [FpElemVar<F>; 3],
     pub(crate) beta: FpElemVar<F>,
     pub(crate) gamma: FpElemVar<F>,
@@ -61,12 +59,6 @@ pub(crate) fn challenge_var_to_fp_elem_var<F: PrimeField>(
     )?;
 
     Ok(ChallengesFpElemVar {
-        _tau: FpElemVar::new_unchecked(
-            circuit,
-            challenge_var.tau,
-            non_native_field_info.m,
-            non_native_field_info.two_power_m,
-        )?,
         alphas: [alpha_fp_elem_var, alpha_2_fp_elem_var, alpha_3_fp_elem_var],
         beta: FpElemVar::new_unchecked(
             circuit,

--- a/plonk/src/constants.rs
+++ b/plonk/src/constants.rs
@@ -18,6 +18,3 @@ pub(crate) const EXTRA_TRANSCRIPT_MSG_LABEL: &[u8] = b"extra info";
 pub(crate) const fn domain_size_ratio(n: usize, num_wire_types: usize) -> usize {
     (num_wire_types * (n + 1) + 2) / n + 1
 }
-
-/// Keccak-256 have a 32 byte state size.
-pub const KECCAK256_STATE_SIZE: usize = 32;

--- a/plonk/src/proof_system/prover.rs
+++ b/plonk/src/proof_system/prover.rs
@@ -163,7 +163,7 @@ impl<E: Pairing> Prover<E> {
         let prod_lookup_poly = self.mask_polynomial(
             prng,
             cs.compute_lookup_prod_polynomial(
-                &challenges.tau,
+                &challenges.tau.unwrap(),
                 &challenges.beta,
                 &challenges.gamma,
                 merged_lookup_table.unwrap(),
@@ -807,7 +807,7 @@ impl<E: Pairing> Prover<E> {
         let key_table_xw = key_table_coset_fft[(i + domain_size_ratio) % m];
         let table_dom_sep_xw = table_dom_sep_coset_fft[(i + domain_size_ratio) % m];
         let merged_table_x = eval_merged_table::<E>(
-            challenges.tau,
+            challenges.tau.unwrap(),
             range_table_x,
             key_table_x,
             q_lookup_coset_fft[i],
@@ -816,7 +816,7 @@ impl<E: Pairing> Prover<E> {
             table_dom_sep_x,
         );
         let merged_table_xw = eval_merged_table::<E>(
-            challenges.tau,
+            challenges.tau.unwrap(),
             range_table_xw,
             key_table_xw,
             q_lookup_coset_fft[(i + domain_size_ratio) % m],
@@ -825,7 +825,7 @@ impl<E: Pairing> Prover<E> {
             table_dom_sep_xw,
         );
         let merged_lookup_x = eval_merged_lookup_witness::<E>(
-            challenges.tau,
+            challenges.tau.unwrap(),
             w[5],
             w[0],
             w[1],
@@ -1032,7 +1032,7 @@ impl<E: Pairing> Prover<E> {
 
         // compute the coefficient for polynomial `prod_lookup_poly`
         let merged_table_eval = eval_merged_table::<E>(
-            challenges.tau,
+            challenges.tau.unwrap(),
             plookup_evals.range_table_eval,
             plookup_evals.key_table_eval,
             plookup_evals.q_lookup_eval,
@@ -1041,7 +1041,7 @@ impl<E: Pairing> Prover<E> {
             plookup_evals.table_dom_sep_eval,
         );
         let merged_table_next_eval = eval_merged_table::<E>(
-            challenges.tau,
+            challenges.tau.unwrap(),
             plookup_evals.range_table_next_eval,
             plookup_evals.key_table_next_eval,
             plookup_evals.q_lookup_next_eval,
@@ -1050,7 +1050,7 @@ impl<E: Pairing> Prover<E> {
             plookup_evals.table_dom_sep_next_eval,
         );
         let merged_lookup_eval = eval_merged_lookup_witness::<E>(
-            challenges.tau,
+            challenges.tau.unwrap(),
             w_evals[5],
             w_evals[0],
             w_evals[1],

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -255,10 +255,11 @@ where
         // Plookup: compute and interpolate the sorted concatenation of the (merged)
         // lookup table and the (merged) witness values
         if circuits.iter().any(|c| C::support_lookup(c)) {
-            challenges.tau = transcript.get_and_append_challenge::<E>(b"tau")?;
+            challenges.tau = Some(transcript.get_and_append_challenge::<E>(b"tau")?);
         } else {
-            challenges.tau = E::ScalarField::one();
+            challenges.tau = None;
         }
+
         let mut h_poly_comms_vec = vec![];
         let mut sorted_vec_list = vec![];
         let mut merged_table_list = vec![];
@@ -269,7 +270,7 @@ where
                         prng,
                         &prove_keys[i].commit_key,
                         circuits[i],
-                        challenges.tau,
+                        challenges.tau.unwrap(),
                     )?;
                 online_oracles[i].plookup_oracles.h_polys = h_polys;
                 transcript.append_commitments(b"h_poly_comms", &h_poly_comms)?;
@@ -1429,7 +1430,7 @@ pub mod test {
             let point = domain.element(i);
             let next_point = point * domain.group_gen;
             let merged_lookup_wire_eval = eval_merged_lookup_witness::<E>(
-                challenges.tau,
+                challenges.tau.unwrap(),
                 oracles.wire_polys[5].evaluate(&point),
                 oracles.wire_polys[0].evaluate(&point),
                 oracles.wire_polys[1].evaluate(&point),
@@ -1438,7 +1439,7 @@ pub mod test {
                 q_dom_sep_poly_ref.evaluate(&point),
             );
             let merged_table_eval = eval_merged_table::<E>(
-                challenges.tau,
+                challenges.tau.unwrap(),
                 range_table_poly_ref.evaluate(&point),
                 key_table_poly_ref.evaluate(&point),
                 pk.q_lookup_poly()?.evaluate(&point),
@@ -1447,7 +1448,7 @@ pub mod test {
                 table_dom_sep_poly_ref.evaluate(&point),
             );
             let merged_table_next_eval = eval_merged_table::<E>(
-                challenges.tau,
+                challenges.tau.unwrap(),
                 range_table_poly_ref.evaluate(&next_point),
                 key_table_poly_ref.evaluate(&next_point),
                 pk.q_lookup_poly()?.evaluate(&next_point),

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -254,7 +254,11 @@ where
         // Round 1.5
         // Plookup: compute and interpolate the sorted concatenation of the (merged)
         // lookup table and the (merged) witness values
-        challenges.tau = transcript.get_and_append_challenge::<E>(b"tau")?;
+        if circuits.iter().any(|c| C::support_lookup(c)) {
+            challenges.tau = transcript.get_and_append_challenge::<E>(b"tau")?;
+        } else {
+            challenges.tau = E::ScalarField::one();
+        }
         let mut h_poly_comms_vec = vec![];
         let mut sorted_vec_list = vec![];
         let mut merged_table_list = vec![];

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -831,7 +831,7 @@ impl<E: Pairing> VerifyingKey<E> {
 /// Plonk IOP verifier challenges.
 #[derive(Debug, Default)]
 pub(crate) struct Challenges<F: Field> {
-    pub(crate) tau: F,
+    pub(crate) tau: Option<F>,
     pub(crate) alpha: F,
     pub(crate) beta: F,
     pub(crate) gamma: F,

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -286,7 +286,11 @@ where
         for wires_poly_comms in batch_proof.wires_poly_comms_vec.iter() {
             transcript.append_commitments(b"witness_poly_comms", wires_poly_comms)?;
         }
-        let tau = transcript.get_and_append_challenge::<E>(b"tau")?;
+        let tau = if verify_keys.iter().any(|vk| vk.plookup_vk.is_some()) {
+            transcript.get_and_append_challenge::<E>(b"tau")?
+        } else {
+            E::ScalarField::one()
+        };
 
         for plookup_proof in batch_proof.plookup_proofs_vec.iter() {
             if let Some(proof_lkup) = plookup_proof.as_ref() {

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -287,9 +287,9 @@ where
             transcript.append_commitments(b"witness_poly_comms", wires_poly_comms)?;
         }
         let tau = if verify_keys.iter().any(|vk| vk.plookup_vk.is_some()) {
-            transcript.get_and_append_challenge::<E>(b"tau")?
+            Some(transcript.get_and_append_challenge::<E>(b"tau")?)
         } else {
-            E::ScalarField::one()
+            None
         };
 
         for plookup_proof in batch_proof.plookup_proofs_vec.iter() {
@@ -632,7 +632,7 @@ where
             if let Some(lookup_proof) = batch_proof.plookup_proofs_vec[i].as_ref() {
                 let lookup_evals = &lookup_proof.poly_evals;
                 let merged_lookup_x = eval_merged_lookup_witness::<E>(
-                    challenges.tau,
+                    challenges.tau.unwrap(),
                     w_evals[5],
                     w_evals[0],
                     w_evals[1],
@@ -641,7 +641,7 @@ where
                     lookup_evals.q_dom_sep_eval,
                 );
                 let merged_table_x = eval_merged_table::<E>(
-                    challenges.tau,
+                    challenges.tau.unwrap(),
                     lookup_evals.range_table_eval,
                     lookup_evals.key_table_eval,
                     lookup_evals.q_lookup_eval,
@@ -650,7 +650,7 @@ where
                     lookup_evals.table_dom_sep_eval,
                 );
                 let merged_table_xw = eval_merged_table::<E>(
-                    challenges.tau,
+                    challenges.tau.unwrap(),
                     lookup_evals.range_table_next_eval,
                     lookup_evals.key_table_next_eval,
                     lookup_evals.q_lookup_next_eval,

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -35,7 +35,7 @@ use jf_rescue::RescueParameter;
 /// A wrapper of crate::proof_system::structs::Challenges
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
 pub struct Challenges<F: Field> {
-    pub tau: F,
+    pub tau: Option<F>,
     pub alpha: F,
     pub beta: F,
     pub gamma: F,

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -12,7 +12,6 @@
 #![allow(missing_docs)]
 
 use crate::{
-    constants::KECCAK256_STATE_SIZE,
     errors::PlonkError,
     proof_system::{
         structs::{self, BatchProof, PlookupProof, ProofEvaluations, VerifyingKey},
@@ -382,12 +381,12 @@ where
 /// exposing the internal states for testing purposes
 impl SolidityTranscript {
     /// Create a new transcript from specific internal states.
-    pub fn from_internal(transcript: Vec<u8>, state: [u8; KECCAK256_STATE_SIZE]) -> Self {
-        Self { transcript, state }
+    pub fn from_internal(transcript: Vec<u8>) -> Self {
+        Self { transcript }
     }
 
     /// Returns the internal states
-    pub fn internal(&self) -> (Vec<u8>, [u8; KECCAK256_STATE_SIZE]) {
-        (self.transcript.clone(), self.state.clone())
+    pub fn internal(&self) -> Vec<u8> {
+        self.transcript.clone()
     }
 }


### PR DESCRIPTION
closes: #618 


### This PR: 

Changes behavior of `SolidityTranscript`, see the linked issue for description

### This PR does not:

Question: should we also optionally append `tau` for circuits that does support lookup? currently in contract, we have to do [a useless `get_and_append_challenge` call ](https://github.com/EspressoSystems/espresso-sequencer/blob/main/contracts/src/libraries/PlonkVerifier.sol#L192-L194)for this unused challenge.

@chancharles92 @philippecamacho 


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
