### PR TITLE
feat: Add grcov to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
               clangStdenv
               llvm_15
               typos
+              grcov
             ] ++ lib.optionals stdenv.isDarwin
               [ darwin.apple_sdk.frameworks.Security ];
 


### PR DESCRIPTION
Part of #614 

### This PR: 
On my machine grcov is not installed. By updating flake.nix the test coverage script works.

### This PR does not:

This PR does not solve #614 entirely, only a part.

### Key places to review:

`flake.nix` file.
