### PR TITLE
fix: fix typo, `ForgettenSubtree` -> `ForgottenSubtree`

### DIFF
--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -20,7 +20,6 @@ We take inspiration from [keep changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 
 - [#559](https://github.com/EspressoSystems/jellyfish/pull/559) (`jf-primitives`) GPU-accelerated `batch_commit()` now doesn't require the input polynomials to be of the same degree.
-- [#636](https://github.com/EspressoSystems/jellyfish/pull/637) (`jf-merkle-tree`) Fix typo, `ForgettenSubtree` to `ForgottenSubtree`
 
 ### Removed
 

--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -20,6 +20,7 @@ We take inspiration from [keep changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 
 - [#559](https://github.com/EspressoSystems/jellyfish/pull/559) (`jf-primitives`) GPU-accelerated `batch_commit()` now doesn't require the input polynomials to be of the same degree.
+- [#636](https://github.com/EspressoSystems/jellyfish/pull/637) (`jf-merkle-tree`) Fix typo, `ForgettenSubtree` to `ForgottenSubtree`
 
 ### Removed
 

--- a/merkle_tree/CHANGELOG.md
+++ b/merkle_tree/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.0
 
-- Initial release. 
+- Initial release.
 - Various (including namespace) Merkle tree trait definitions and implementations.
 - Turn on `gadgets` for circuit implementations.
+- Fix typo, `ForgettenSubtree` to `ForgottenSubtree`

--- a/merkle_tree/src/gadgets/mod.rs
+++ b/merkle_tree/src/gadgets/mod.rs
@@ -602,7 +602,7 @@ mod test {
 
             if let MerkleNode::Branch { value: _, children } = &mut bad_proof.proof[1] {
                 let left_sib = if uid % 3 == 0 { 1 } else { 0 };
-                children[left_sib] = Arc::new(MerkleNode::ForgettenSubtree { value: F::zero() });
+                children[left_sib] = Arc::new(MerkleNode::ForgottenSubtree { value: F::zero() });
             }
             let path_vars: Merkle3AryMembershipProofVar =
                 MerkleTreeGadget::<RescueMerkleTree<F>>::create_membership_proof_variable(

--- a/merkle_tree/src/macros.rs
+++ b/merkle_tree/src/macros.rs
@@ -143,7 +143,7 @@ macro_rules! impl_forgetable_merkle_tree_scheme {
             fn from_commitment(com: impl Borrow<Self::Commitment>) -> Self {
                 let com = com.borrow();
                 $name {
-                    root: Arc::new(MerkleNode::ForgettenSubtree {
+                    root: Arc::new(MerkleNode::ForgottenSubtree {
                         value: com.digest(),
                     }),
                     height: com.height(),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

closes: #636 
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->

### This PR: 
- Fixes typo for the identifier bu changing it from `ForgettenSubtree` to `ForgottenSubtree`
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
