### PR TITLE
chore: use tag for inter-dep among member crates

### DIFF
--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true }
 
 [dev-dependencies]
 bincode = "1.3"
-jf-utils = { path = "../utilities" }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }
 rand_chacha = { workspace = true }
 
 [features]

--- a/elgamal/Cargo.toml
+++ b/elgamal/Cargo.toml
@@ -17,8 +17,8 @@ ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 derivative = { workspace = true }
 displaydoc = { workspace = true }
-jf-relation = { path = "../relation", optional = true, default-features = false }
-jf-rescue = { path = "../rescue", default-features = false }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", optional = true, default-features = false }
+jf-rescue = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 rayon = { version = "1.5.0", optional = true }
 zeroize = { version = "1.5", default-features = false }
 
@@ -27,7 +27,7 @@ ark-ed-on-bls12-377 = "0.4.0"
 ark-ed-on-bls12-381 = "0.4.0"
 ark-ed-on-bls12-381-bandersnatch = "0.4.0"
 ark-ed-on-bn254 = "0.4.0"
-jf-utils = { path = "../utilities" }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }
 
 [features]
 default = ["parallel"]

--- a/merkle_tree/Cargo.toml
+++ b/merkle_tree/Cargo.toml
@@ -23,9 +23,9 @@ digest = { workspace = true }
 displaydoc = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true, features = ["use_alloc"] }
-jf-relation = { path = "../relation", optional = true, default-features = false }
-jf-rescue = { path = "../rescue", default-features = false }
-jf-utils = { path = "../utilities", default-features = false }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", optional = true, default-features = false }
+jf-rescue = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 num-bigint = { workspace = true }
 num-traits = { version = "0.2.15", default-features = false }
 serde = { workspace = true }

--- a/pcs/Cargo.toml
+++ b/pcs/Cargo.toml
@@ -24,7 +24,7 @@ icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5
 icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.1", optional = true }
 icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.5.1", optional = true }
 itertools = { workspace = true, features = ["use_alloc"] }
-jf-utils = { path = "../utilities", default-features = false }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 merlin = { workspace = true }
 rayon = { version = "1.5.0", optional = true }
 

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -20,11 +20,11 @@ dyn-clone = "^1.0"
 espresso-systems-common = { git = "https://github.com/espressosystems/espresso-systems-common", tag = "0.4.0" }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
-jf-crhf = { path = "../crhf", default-features = false }
-jf-pcs = { path = "../pcs", default-features = false }
-jf-relation = { path = "../relation", default-features = false }
-jf-rescue = { path = "../rescue", default-features = false, features = ["gadgets"] }
-jf-utils = { path = "../utilities", default-features = false }
+jf-crhf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-pcs = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-rescue = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false, features = ["gadgets"] }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 merlin = { workspace = true }
 num-bigint = { workspace = true }
 rand_chacha = { workspace = true }

--- a/relation/Cargo.toml
+++ b/relation/Cargo.toml
@@ -23,7 +23,7 @@ downcast-rs = { version = "1.2.0", default-features = false }
 dyn-clone = "^1.0"
 hashbrown = { workspace = true }
 itertools = { workspace = true }
-jf-utils = { path = "../utilities", default-features = false }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 num-bigint = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { version = "1.5.0", optional = true }

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -25,11 +25,11 @@ ark-ff = { workspace = true }
 ark-std = { workspace = true }
 displaydoc = { workspace = true }
 itertools = { workspace = true }
-jf-commitment = { path = "../commitment", default-features = false }
-jf-crhf = { path = "../crhf", default-features = false }
-jf-prf = { path = "../prf", default-features = false }
-jf-relation = { path = "../relation", optional = true, default-features = false }
-jf-utils = { path = "../utilities", default-features = false }
+jf-commitment = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-crhf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-prf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", optional = true, default-features = false }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 
 [dev-dependencies]
 ark-ed-on-bls12-381-bandersnatch = "0.4.0"

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -23,10 +23,10 @@ digest = { workspace = true }
 displaydoc = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
-jf-crhf = { path = "../crhf", default-features = false }
-jf-relation = { path = "../relation", optional = true, default-features = false }
-jf-rescue = { path = "../rescue", default-features = false }
-jf-utils = { path = "../utilities", default-features = false }
+jf-crhf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-relation = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", optional = true, default-features = false }
+jf-rescue = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 num-bigint = { workspace = true }
 num-traits = { version = "0.2.15", default-features = false }
 serde = { workspace = true }

--- a/vid/Cargo.toml
+++ b/vid/Cargo.toml
@@ -24,9 +24,9 @@ generic-array = { version = "0", features = [
         "serde",
 ] } # not a direct dependency, but we need serde
 itertools = { workspace = true, features = ["use_alloc"] }
-jf-merkle-tree = { path = "../merkle_tree", default-features = false }
-jf-pcs = { path = "../pcs", default-features = false }
-jf-utils = { path = "../utilities", default-features = false }
+jf-merkle-tree = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-pcs = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 rayon = { version = "1.5.0", optional = true }
 serde = { workspace = true }
 tagged-base64 = { workspace = true }
@@ -38,7 +38,7 @@ ark-ed-on-bls12-377 = "0.4.0"
 ark-ed-on-bls12-381 = "0.4.0"
 ark-ed-on-bn254 = "0.4.0"
 criterion = "0.5.1"
-jf-pcs = { path = "../pcs", features = ["test-srs"] }
+jf-pcs = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", features = ["test-srs"] }
 sha2 = "0.10"
 
 [[bench]]

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -14,13 +14,13 @@ repository = { workspace = true }
 ark-std = { workspace = true }
 digest = { version = "0.10.1", default-features = false, features = ["alloc"] }
 displaydoc = { workspace = true }
-jf-signature = { path = "../signature", default-features = false, features = [ "bls" ] }
+jf-signature = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false, features = [ "bls" ] }
 serde = { workspace = true }
 sha2 = { workspace = true }
 zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]
-jf-utils = { path = "../utilities", default-features = false }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 
 [features]
 default = ["parallel"]


### PR DESCRIPTION
### This PR: 

I encounter type compatibility error when trying to point to previously tagged `jf-plonk-v0.5.0`; where I realized that we are still using relative path `path = "../xx"` for inter-depenecy among member crates, which points to the head instead of a tagged version. 

Since we made the decision in #556 to have independent version management/bumping among crates, we forgot to reflect that in our dependency declaration and this PR fixed that. 

- [ ] re-tag `jf-plonk-v0.5.0` to the latest `main` once this PR is merged.