### PR TITLE
Add constructor for jf_vdf::MinRootElement

### DIFF
--- a/vdf/src/minroot.rs
+++ b/vdf/src/minroot.rs
@@ -57,6 +57,13 @@ pub struct MinRootPP {
 )]
 pub struct MinRootElement<F: MinRootField>(F, F);
 
+impl <F: MinRootField> MinRootElement<F> {
+    /// Constructor
+    pub fn new(x: F, y: F) -> Self {
+        Self(x, y)
+    }
+}
+
 impl<F, T> From<T> for MinRootElement<F>
 where
     T: AffineRepr<BaseField = F>,


### PR DESCRIPTION
Can't create MinRootElement Object when use jf-vdf crate