### PR TITLE
feat: append G2 point from SRS to transcript

### DIFF
--- a/plonk/src/transcript/mod.rs
+++ b/plonk/src/transcript/mod.rs
@@ -67,6 +67,14 @@ pub trait PlonkTranscript<F> {
             vk.num_inputs.to_le_bytes().as_ref(),
         )?;
 
+        // include [x]_2 G2 point from SRS
+        // all G1 points from SRS are implicit reflected in committed polys
+        <Self as PlonkTranscript<F>>::append_message(
+            self,
+            b"SRS G2 element",
+            &to_bytes!(&vk.open_key.beta_h)?,
+        )?;
+
         for ki in vk.k.iter() {
             <Self as PlonkTranscript<F>>::append_message(
                 self,

--- a/plonk/src/transcript/mod.rs
+++ b/plonk/src/transcript/mod.rs
@@ -72,7 +72,7 @@ pub trait PlonkTranscript<F> {
         <Self as PlonkTranscript<F>>::append_message(
             self,
             b"SRS G2 element",
-            &to_bytes!(&vk.open_key.beta_h)?,
+            &to_bytes!(&vk.open_key.powers_of_h[1])?,
         )?;
 
         for ki in vk.k.iter() {

--- a/plonk/src/transcript/solidity.rs
+++ b/plonk/src/transcript/solidity.rs
@@ -129,7 +129,7 @@ impl<F: PrimeField> PlonkTranscript<F> for SolidityTranscript {
         <Self as PlonkTranscript<F>>::append_message(
             self,
             b"SRS G2 element",
-            &to_bytes!(&vk.open_key.beta_h)?,
+            &to_bytes!(&vk.open_key.powers_of_h[1])?,
         )?;
 
         for ki in vk.k.iter() {


### PR DESCRIPTION
Part of: https://github.com/EspressoSystems/espresso-sequencer/issues/1731


### This PR: 

- add G2 point from KZG SRS to the plonk transcript to restrict the undesirable degree of freedom

This PR is targeting a temp branch `commonprefix-patch` and would eventually be merged to main with a new tag.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] ~Targeted PR against correct branch (main)~
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~
- [x] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
