### PR TITLE
refactor!: refactored transcript traits and impls

### DIFF
--- a/plonk/src/circuit/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/plonk_verifier/gadgets.rs
@@ -225,25 +225,25 @@ where
         transcript_var.append_commitments_vars(b"witness_poly_comms", wires_poly_comms)?;
     }
 
-    let beta = transcript_var.get_and_append_challenge_var::<E>(b"beta", circuit)?;
-    let gamma = transcript_var.get_and_append_challenge_var::<E>(b"gamma", circuit)?;
+    let beta = transcript_var.get_challenge_var::<E>(b"beta", circuit)?;
+    let gamma = transcript_var.get_challenge_var::<E>(b"gamma", circuit)?;
     for prod_perm_poly_comm in batch_proof.prod_perm_poly_comms_vec.iter() {
         transcript_var.append_commitment_var(b"perm_poly_comms", prod_perm_poly_comm)?;
     }
 
-    let alpha = transcript_var.get_and_append_challenge_var::<E>(b"alpha", circuit)?;
+    let alpha = transcript_var.get_challenge_var::<E>(b"alpha", circuit)?;
     transcript_var
         .append_commitments_vars(b"quot_poly_comms", &batch_proof.split_quot_poly_comms)?;
-    let zeta = transcript_var.get_and_append_challenge_var::<E>(b"zeta", circuit)?;
+    let zeta = transcript_var.get_challenge_var::<E>(b"zeta", circuit)?;
     for poly_evals in batch_proof.poly_evals_vec.iter() {
         transcript_var.append_proof_evaluations_vars(circuit, poly_evals)?;
     }
 
-    let v = transcript_var.get_and_append_challenge_var::<E>(b"v", circuit)?;
+    let v = transcript_var.get_challenge_var::<E>(b"v", circuit)?;
     transcript_var.append_commitment_var(b"open_proof", &batch_proof.opening_proof)?;
     transcript_var
         .append_commitment_var(b"shifted_open_proof", &batch_proof.shifted_opening_proof)?;
-    let u = transcript_var.get_and_append_challenge_var::<E>(b"u", circuit)?;
+    let u = transcript_var.get_challenge_var::<E>(b"u", circuit)?;
 
     // convert challenge vars into FpElemVars
     let challenge_var = ChallengesVar {

--- a/plonk/src/circuit/transcript.rs
+++ b/plonk/src/circuit/transcript.rs
@@ -137,16 +137,6 @@ where
         Ok(())
     }
 
-    // Append a challenge variable to the transcript.
-    // For efficiency purpose, label is not used for rescue FS.
-    pub(crate) fn append_challenge_var(
-        &mut self,
-        _label: &'static [u8],
-        challenge_var: &Variable,
-    ) -> Result<(), CircuitError> {
-        self.append_variable(_label, challenge_var)
-    }
-
     // Append the proof evaluation to the transcript
     pub(crate) fn append_proof_evaluations_vars(
         &mut self,
@@ -171,7 +161,7 @@ where
     // For efficiency purpose, label is not used for rescue FS.
     // Note that this function currently only supports bls12-377
     // curve due to its decomposition method.
-    pub(crate) fn get_and_append_challenge_var<E>(
+    pub(crate) fn get_challenge_var<E>(
         &mut self,
         _label: &'static [u8],
         circuit: &mut PlonkCircuit<F>,
@@ -193,7 +183,7 @@ where
         // This algorithm takes in 3 steps
         // 1. state: [F: STATE_SIZE] = hash(state|transcript)
         // 2. challenge = state[0] in Fr
-        // 3. transcript = vec![challenge]
+        // 3. transcript = vec![]
         // ==================================
 
         // step 1. state: [F: STATE_SIZE] = hash(state|transcript)
@@ -210,7 +200,6 @@ where
         // finish and update the states
         self.state_var.copy_from_slice(&res_var[0..STATE_SIZE]);
         self.transcript_var = Vec::new();
-        self.append_challenge_var(_label, &challenge_var)?;
 
         Ok(challenge_var)
     }
@@ -267,10 +256,10 @@ mod tests {
                     .unwrap();
             }
 
-            let challenge = transcript.get_and_append_challenge::<E>(label).unwrap();
+            let challenge = transcript.get_challenge::<E>(label).unwrap();
 
             let challenge_var = transcript_var
-                .get_and_append_challenge_var::<E>(label, &mut circuit)
+                .get_challenge_var::<E>(label, &mut circuit)
                 .unwrap();
 
             assert_eq!(
@@ -329,10 +318,10 @@ mod tests {
             .append_vk_and_pub_input_vars::<E>(&mut circuit, &dummy_vk_var, &[])
             .unwrap();
 
-        let challenge = transcript.get_and_append_challenge::<E>(label).unwrap();
+        let challenge = transcript.get_challenge::<E>(label).unwrap();
 
         let challenge_var = transcript_var
-            .get_and_append_challenge_var::<E>(label, &mut circuit)
+            .get_challenge_var::<E>(label, &mut circuit)
             .unwrap();
 
         assert_eq!(
@@ -398,10 +387,10 @@ mod tests {
                 .append_vk_and_pub_input_vars::<E>(&mut circuit, &vk_var, &input_fp_elem_vars)
                 .unwrap();
 
-            let challenge = transcript.get_and_append_challenge::<E>(label).unwrap();
+            let challenge = transcript.get_challenge::<E>(label).unwrap();
 
             let challenge_var = transcript_var
-                .get_and_append_challenge_var::<E>(label, &mut circuit)
+                .get_challenge_var::<E>(label, &mut circuit)
                 .unwrap();
 
             assert_eq!(

--- a/plonk/src/circuit/transcript.rs
+++ b/plonk/src/circuit/transcript.rs
@@ -161,6 +161,8 @@ where
     // For efficiency purpose, label is not used for rescue FS.
     // Note that this function currently only supports bls12-377
     // curve due to its decomposition method.
+    //
+    // `_label` is omitted for efficiency.
     pub(crate) fn get_challenge_var<E>(
         &mut self,
         _label: &'static [u8],

--- a/plonk/src/constants.rs
+++ b/plonk/src/constants.rs
@@ -18,3 +18,6 @@ pub(crate) const EXTRA_TRANSCRIPT_MSG_LABEL: &[u8] = b"extra info";
 pub(crate) const fn domain_size_ratio(n: usize, num_wire_types: usize) -> usize {
     (num_wire_types * (n + 1) + 2) / n + 1
 }
+
+/// Keccak-256 have a 32 byte state size.
+pub const KECCAK256_STATE_SIZE: usize = 32;

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -255,7 +255,7 @@ where
         // Plookup: compute and interpolate the sorted concatenation of the (merged)
         // lookup table and the (merged) witness values
         if circuits.iter().any(|c| C::support_lookup(c)) {
-            challenges.tau = Some(transcript.get_and_append_challenge::<E>(b"tau")?);
+            challenges.tau = Some(transcript.get_challenge::<E>(b"tau")?);
         } else {
             challenges.tau = None;
         }
@@ -284,8 +284,8 @@ where
         }
 
         // Round 2
-        challenges.beta = transcript.get_and_append_challenge::<E>(b"beta")?;
-        challenges.gamma = transcript.get_and_append_challenge::<E>(b"gamma")?;
+        challenges.beta = transcript.get_challenge::<E>(b"beta")?;
+        challenges.gamma = transcript.get_challenge::<E>(b"gamma")?;
         let mut prod_perm_poly_comms_vec = vec![];
         for i in 0..circuits.len() {
             let (prod_perm_poly_comm, prod_perm_poly) =
@@ -318,7 +318,7 @@ where
         }
 
         // Round 3
-        challenges.alpha = transcript.get_and_append_challenge::<E>(b"alpha")?;
+        challenges.alpha = transcript.get_challenge::<E>(b"alpha")?;
         let (split_quot_poly_comms, split_quot_polys) = prover.run_3rd_round(
             prng,
             &prove_keys[0].commit_key,
@@ -330,7 +330,7 @@ where
         transcript.append_commitments(b"quot_poly_comms", &split_quot_poly_comms)?;
 
         // Round 4
-        challenges.zeta = transcript.get_and_append_challenge::<E>(b"zeta")?;
+        challenges.zeta = transcript.get_challenge::<E>(b"zeta")?;
         let mut poly_evals_vec = vec![];
         for i in 0..circuits.len() {
             let poly_evals = prover.compute_evaluations(
@@ -389,7 +389,7 @@ where
         }
 
         // Round 5
-        challenges.v = transcript.get_and_append_challenge::<E>(b"v")?;
+        challenges.v = transcript.get_challenge::<E>(b"v")?;
         let (opening_proof, shifted_opening_proof) = prover.compute_opening_proofs(
             &prove_keys[0].commit_key,
             prove_keys,

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -214,9 +214,9 @@ where
             // protocol transcript. This approach is more secure as `r` depends not only
             // on the proofs, but also the list of public inputs and verifying keys.
             for pcs_info in pcs_infos {
-                transcript.append_challenge::<E>(b"u", &pcs_info.u)?;
+                transcript.append_field::<E>(b"u", &pcs_info.u)?;
             }
-            transcript.get_and_append_challenge::<E>(b"r")?
+            transcript.get_challenge::<E>(b"r")?
         };
 
         // Compute A := A0 + r * A1 + ... + r^{m-1} * Am
@@ -287,7 +287,7 @@ where
             transcript.append_commitments(b"witness_poly_comms", wires_poly_comms)?;
         }
         let tau = if verify_keys.iter().any(|vk| vk.plookup_vk.is_some()) {
-            Some(transcript.get_and_append_challenge::<E>(b"tau")?)
+            Some(transcript.get_challenge::<E>(b"tau")?)
         } else {
             None
         };
@@ -298,8 +298,8 @@ where
             }
         }
 
-        let beta = transcript.get_and_append_challenge::<E>(b"beta")?;
-        let gamma = transcript.get_and_append_challenge::<E>(b"gamma")?;
+        let beta = transcript.get_challenge::<E>(b"beta")?;
+        let gamma = transcript.get_challenge::<E>(b"gamma")?;
         for prod_perm_poly_comm in batch_proof.prod_perm_poly_comms_vec.iter() {
             transcript.append_commitment(b"perm_poly_comms", prod_perm_poly_comm)?;
         }
@@ -310,9 +310,9 @@ where
             }
         }
 
-        let alpha = transcript.get_and_append_challenge::<E>(b"alpha")?;
+        let alpha = transcript.get_challenge::<E>(b"alpha")?;
         transcript.append_commitments(b"quot_poly_comms", &batch_proof.split_quot_poly_comms)?;
-        let zeta = transcript.get_and_append_challenge::<E>(b"zeta")?;
+        let zeta = transcript.get_challenge::<E>(b"zeta")?;
         for poly_evals in batch_proof.poly_evals_vec.iter() {
             transcript.append_proof_evaluations::<E>(poly_evals)?;
         }
@@ -322,10 +322,10 @@ where
             }
         }
 
-        let v = transcript.get_and_append_challenge::<E>(b"v")?;
+        let v = transcript.get_challenge::<E>(b"v")?;
         transcript.append_commitment(b"open_proof", &batch_proof.opening_proof)?;
         transcript.append_commitment(b"shifted_open_proof", &batch_proof.shifted_opening_proof)?;
-        let u = transcript.get_and_append_challenge::<E>(b"u")?;
+        let u = transcript.get_challenge::<E>(b"u")?;
         Ok(Challenges {
             tau,
             alpha,

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -214,7 +214,7 @@ where
             // protocol transcript. This approach is more secure as `r` depends not only
             // on the proofs, but also the list of public inputs and verifying keys.
             for pcs_info in pcs_infos {
-                transcript.append_field::<E>(b"u", &pcs_info.u)?;
+                transcript.append_field_elem::<E>(b"u", &pcs_info.u)?;
             }
             transcript.get_challenge::<E>(b"r")?
         };

--- a/plonk/src/testing_apis.rs
+++ b/plonk/src/testing_apis.rs
@@ -12,6 +12,7 @@
 #![allow(missing_docs)]
 
 use crate::{
+    constants::KECCAK256_STATE_SIZE,
     errors::PlonkError,
     lagrange::LagrangeCoeffs,
     proof_system::{
@@ -379,12 +380,12 @@ where
 /// exposing the internal states for testing purposes
 impl SolidityTranscript {
     /// Create a new transcript from specific internal states.
-    pub fn from_internal(transcript: Vec<u8>) -> Self {
-        Self { transcript }
+    pub fn from_internal(state: [u8; KECCAK256_STATE_SIZE], transcript: Vec<u8>) -> Self {
+        Self { state, transcript }
     }
 
     /// Returns the internal states
-    pub fn internal(&self) -> Vec<u8> {
-        self.transcript.clone()
+    pub fn internal(&self) -> ([u8; KECCAK256_STATE_SIZE], Vec<u8>) {
+        (self.state.clone(), self.transcript.clone())
     }
 }

--- a/plonk/src/transcript/mod.rs
+++ b/plonk/src/transcript/mod.rs
@@ -75,15 +75,14 @@ pub trait PlonkTranscript<F> {
             &to_bytes!(&vk.open_key.powers_of_h[1])?,
         )?;
 
-        self.append_fields::<E>(b"wire subsets separators", &vk.k)?;
+        self.append_field_elems::<E>(b"wire subsets separators", &vk.k)?;
         self.append_commitments(b"selector commitments", &vk.selector_comms)?;
         self.append_commitments(b"sigma commitments", &vk.sigma_comms)?;
-        self.append_fields::<E>(b"public input", pub_input)?;
+        self.append_field_elems::<E>(b"public input", pub_input)?;
 
         Ok(())
     }
 
-    // TODO: (alex) accept &str instead of &[u8]
     /// Append the message to the transcript.
     fn append_message(&mut self, label: &'static [u8], msg: &[u8]) -> Result<(), PlonkError>;
 
@@ -97,7 +96,6 @@ pub trait PlonkTranscript<F> {
         E: Pairing<BaseField = F, G1Affine = Affine<P>>,
         P: SWParam<BaseField = F>,
     {
-        // TODO: (alex) append index to the label for each commitment
         for comm in comms.iter() {
             self.append_commitment(label, comm)?;
         }
@@ -118,7 +116,7 @@ pub trait PlonkTranscript<F> {
     }
 
     /// Append a field element to the transcript.
-    fn append_field<E>(
+    fn append_field_elem<E>(
         &mut self,
         label: &'static [u8],
         field: &E::ScalarField,
@@ -130,7 +128,7 @@ pub trait PlonkTranscript<F> {
     }
 
     /// Append a list of field elements to the transcript
-    fn append_fields<E>(
+    fn append_field_elems<E>(
         &mut self,
         label: &'static [u8],
         fields: &[E::ScalarField],
@@ -139,7 +137,7 @@ pub trait PlonkTranscript<F> {
         E: Pairing<BaseField = F>,
     {
         for f in fields {
-            self.append_field::<E>(label, f)?;
+            self.append_field_elem::<E>(label, f)?;
         }
         Ok(())
     }
@@ -149,9 +147,9 @@ pub trait PlonkTranscript<F> {
         &mut self,
         evals: &ProofEvaluations<E::ScalarField>,
     ) -> Result<(), PlonkError> {
-        self.append_fields::<E>(b"wire_evals", &evals.wires_evals)?;
-        self.append_fields::<E>(b"wire_sigma_evals", &evals.wire_sigma_evals)?;
-        self.append_field::<E>(b"perm_next_eval", &evals.perm_next_eval)
+        self.append_field_elems::<E>(b"wire_evals", &evals.wires_evals)?;
+        self.append_field_elems::<E>(b"wire_sigma_evals", &evals.wire_sigma_evals)?;
+        self.append_field_elem::<E>(b"perm_next_eval", &evals.perm_next_eval)
     }
 
     /// Append the plookup evaluation to the transcript.
@@ -159,12 +157,12 @@ pub trait PlonkTranscript<F> {
         &mut self,
         evals: &PlookupEvaluations<E::ScalarField>,
     ) -> Result<(), PlonkError> {
-        self.append_field::<E>(b"lookup_table_eval", &evals.range_table_eval)?;
-        self.append_field::<E>(b"h_1_eval", &evals.h_1_eval)?;
-        self.append_field::<E>(b"prod_next_eval", &evals.prod_next_eval)?;
-        self.append_field::<E>(b"lookup_table_next_eval", &evals.range_table_next_eval)?;
-        self.append_field::<E>(b"h_1_next_eval", &evals.h_1_next_eval)?;
-        self.append_field::<E>(b"h_2_next_eval", &evals.h_2_next_eval)
+        self.append_field_elem::<E>(b"lookup_table_eval", &evals.range_table_eval)?;
+        self.append_field_elem::<E>(b"h_1_eval", &evals.h_1_eval)?;
+        self.append_field_elem::<E>(b"prod_next_eval", &evals.prod_next_eval)?;
+        self.append_field_elem::<E>(b"lookup_table_next_eval", &evals.range_table_next_eval)?;
+        self.append_field_elem::<E>(b"h_1_next_eval", &evals.h_1_next_eval)?;
+        self.append_field_elem::<E>(b"h_2_next_eval", &evals.h_2_next_eval)
     }
 
     /// Generate a single challenge for the current round
@@ -172,7 +170,7 @@ pub trait PlonkTranscript<F> {
     where
         E: Pairing<BaseField = F>;
 
-    /// Generate multiple challenge for the current round
+    /// Generate multiple challenges for the current round
     /// Implementers should be careful about domain separation for each
     /// challenge The default implementation assume `self.get_challenge()`
     /// already implements proper domain separation for each challenge

--- a/plonk/src/transcript/mod.rs
+++ b/plonk/src/transcript/mod.rs
@@ -24,6 +24,7 @@ use ark_ec::{
     short_weierstrass::{Affine, SWCurveConfig as SWParam},
 };
 use ark_ff::PrimeField;
+use ark_std::vec::Vec;
 use jf_pcs::prelude::Commitment;
 use jf_utils::to_bytes;
 
@@ -51,8 +52,7 @@ pub trait PlonkTranscript<F> {
         E: Pairing<BaseField = F, G1Affine = Affine<P>>,
         P: SWParam<BaseField = F>,
     {
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
+        self.append_message(
             b"field size in bits",
             E::ScalarField::MODULUS_BIT_SIZE.to_le_bytes().as_ref(),
         )?;
@@ -75,40 +75,15 @@ pub trait PlonkTranscript<F> {
             &to_bytes!(&vk.open_key.powers_of_h[1])?,
         )?;
 
-        for ki in vk.k.iter() {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"wire subsets separators",
-                &to_bytes!(ki)?,
-            )?;
-        }
-        for selector_com in vk.selector_comms.iter() {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"selector commitments",
-                &to_bytes!(selector_com)?,
-            )?;
-        }
-
-        for sigma_comms in vk.sigma_comms.iter() {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"sigma commitments",
-                &to_bytes!(sigma_comms)?,
-            )?;
-        }
-
-        for input in pub_input.iter() {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"public input",
-                &to_bytes!(input)?,
-            )?;
-        }
+        self.append_fields::<E>(b"wire subsets separators", &vk.k)?;
+        self.append_commitments(b"selector commitments", &vk.selector_comms)?;
+        self.append_commitments(b"sigma commitments", &vk.sigma_comms)?;
+        self.append_fields::<E>(b"public input", pub_input)?;
 
         Ok(())
     }
 
+    // TODO: (alex) accept &str instead of &[u8]
     /// Append the message to the transcript.
     fn append_message(&mut self, label: &'static [u8], msg: &[u8]) -> Result<(), PlonkError>;
 
@@ -122,6 +97,7 @@ pub trait PlonkTranscript<F> {
         E: Pairing<BaseField = F, G1Affine = Affine<P>>,
         P: SWParam<BaseField = F>,
     {
+        // TODO: (alex) append index to the label for each commitment
         for comm in comms.iter() {
             self.append_commitment(label, comm)?;
         }
@@ -141,83 +117,77 @@ pub trait PlonkTranscript<F> {
         <Self as PlonkTranscript<F>>::append_message(self, label, &to_bytes!(comm)?)
     }
 
-    /// Append a challenge to the transcript.
-    fn append_challenge<E>(
+    /// Append a field element to the transcript.
+    fn append_field<E>(
         &mut self,
         label: &'static [u8],
-        challenge: &E::ScalarField,
+        field: &E::ScalarField,
     ) -> Result<(), PlonkError>
     where
         E: Pairing<BaseField = F>,
     {
-        <Self as PlonkTranscript<F>>::append_message(self, label, &to_bytes!(challenge)?)
+        <Self as PlonkTranscript<F>>::append_message(self, label, &to_bytes!(field)?)
+    }
+
+    /// Append a list of field elements to the transcript
+    fn append_fields<E>(
+        &mut self,
+        label: &'static [u8],
+        fields: &[E::ScalarField],
+    ) -> Result<(), PlonkError>
+    where
+        E: Pairing<BaseField = F>,
+    {
+        for f in fields {
+            self.append_field::<E>(label, f)?;
+        }
+        Ok(())
     }
 
     /// Append a proof evaluation to the transcript.
-    fn append_proof_evaluations<E: Pairing>(
+    fn append_proof_evaluations<E: Pairing<BaseField = F>>(
         &mut self,
         evals: &ProofEvaluations<E::ScalarField>,
     ) -> Result<(), PlonkError> {
-        for w_eval in &evals.wires_evals {
-            <Self as PlonkTranscript<F>>::append_message(self, b"wire_evals", &to_bytes!(w_eval)?)?;
-        }
-        for sigma_eval in &evals.wire_sigma_evals {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"wire_sigma_evals",
-                &to_bytes!(sigma_eval)?,
-            )?;
-        }
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
-            b"perm_next_eval",
-            &to_bytes!(&evals.perm_next_eval)?,
-        )
+        self.append_fields::<E>(b"wire_evals", &evals.wires_evals)?;
+        self.append_fields::<E>(b"wire_sigma_evals", &evals.wire_sigma_evals)?;
+        self.append_field::<E>(b"perm_next_eval", &evals.perm_next_eval)
     }
 
     /// Append the plookup evaluation to the transcript.
-    fn append_plookup_evaluations<E: Pairing>(
+    fn append_plookup_evaluations<E: Pairing<BaseField = F>>(
         &mut self,
         evals: &PlookupEvaluations<E::ScalarField>,
     ) -> Result<(), PlonkError> {
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
-            b"lookup_table_eval",
-            &to_bytes!(&evals.range_table_eval)?,
-        )?;
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
-            b"h_1_eval",
-            &to_bytes!(&evals.h_1_eval)?,
-        )?;
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
-            b"prod_next_eval",
-            &to_bytes!(&evals.prod_next_eval)?,
-        )?;
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
-            b"lookup_table_next_eval",
-            &to_bytes!(&evals.range_table_next_eval)?,
-        )?;
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
-            b"h_1_next_eval",
-            &to_bytes!(&evals.h_1_next_eval)?,
-        )?;
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
-            b"h_2_next_eval",
-            &to_bytes!(&evals.h_2_next_eval)?,
-        )
+        self.append_field::<E>(b"lookup_table_eval", &evals.range_table_eval)?;
+        self.append_field::<E>(b"h_1_eval", &evals.h_1_eval)?;
+        self.append_field::<E>(b"prod_next_eval", &evals.prod_next_eval)?;
+        self.append_field::<E>(b"lookup_table_next_eval", &evals.range_table_next_eval)?;
+        self.append_field::<E>(b"h_1_next_eval", &evals.h_1_next_eval)?;
+        self.append_field::<E>(b"h_2_next_eval", &evals.h_2_next_eval)
     }
 
-    /// Generate the challenge for the current transcript,
-    /// and then append it to the transcript.
-    fn get_and_append_challenge<E>(
-        &mut self,
-        label: &'static [u8],
-    ) -> Result<E::ScalarField, PlonkError>
+    /// Generate a single challenge for the current round
+    fn get_challenge<E>(&mut self, label: &'static [u8]) -> Result<E::ScalarField, PlonkError>
     where
         E: Pairing<BaseField = F>;
+
+    /// Generate multiple challenge for the current round
+    /// Implementers should be careful about domain separation for each
+    /// challenge The default implementation assume `self.get_challenge()`
+    /// already implements proper domain separation for each challenge
+    /// generation, thus simply call it multiple times.
+    fn get_n_challenges<E>(
+        &mut self,
+        labels: &[&'static [u8]],
+    ) -> Result<Vec<E::ScalarField>, PlonkError>
+    where
+        E: Pairing<BaseField = F>,
+    {
+        let mut challenges = Vec::new();
+        for label in labels {
+            challenges.push(self.get_challenge::<E>(label)?);
+        }
+        Ok(challenges)
+    }
 }

--- a/plonk/src/transcript/rescue.rs
+++ b/plonk/src/transcript/rescue.rs
@@ -123,7 +123,7 @@ where
         Ok(())
     }
 
-    fn append_field<E>(
+    fn append_field_elem<E>(
         &mut self,
         _label: &'static [u8],
         challenge: &E::ScalarField,

--- a/plonk/src/transcript/rescue.rs
+++ b/plonk/src/transcript/rescue.rs
@@ -33,7 +33,7 @@ use jf_utils::{bytes_to_field_elements, field_switching, fq_to_fr_with_mask};
 ///
 /// 1. state: \[F: STATE_SIZE\] = hash(state|transcript)
 /// 2. challenge = state\[0\]
-/// 3. transcript = vec!\[challenge\]
+/// 3. transcript = vec!\[\]
 pub struct RescueTranscript<F>
 where
     F: RescueParameter,
@@ -123,9 +123,7 @@ where
         Ok(())
     }
 
-    /// Append a challenge to the transcript. `_label` is omitted for
-    /// efficiency.
-    fn append_challenge<E>(
+    fn append_field<E>(
         &mut self,
         _label: &'static [u8],
         challenge: &E::ScalarField,
@@ -165,12 +163,8 @@ where
     }
 
     /// Generate the challenge for the current transcript,
-    /// and then append it to the transcript. `_label` is omitted for
-    /// efficiency.
-    fn get_and_append_challenge<E>(
-        &mut self,
-        _label: &'static [u8],
-    ) -> Result<E::ScalarField, PlonkError>
+    /// `_label` is omitted for efficiency.
+    fn get_challenge<E>(&mut self, _label: &'static [u8]) -> Result<E::ScalarField, PlonkError>
     where
         E: Pairing<BaseField = F>,
     {
@@ -183,7 +177,6 @@ where
         let challenge = fq_to_fr_with_mask::<F, E::ScalarField>(&tmp[0]);
         self.state.copy_from_slice(&tmp);
         self.transcript = Vec::new();
-        self.transcript.push(field_switching(&challenge));
 
         Ok(challenge)
     }

--- a/plonk/src/transcript/solidity.rs
+++ b/plonk/src/transcript/solidity.rs
@@ -116,6 +116,11 @@ impl<F: PrimeField> PlonkTranscript<F> for SolidityTranscript {
             b"input size",
             vk.num_inputs.to_be_bytes().as_ref(),
         )?;
+        <Self as PlonkTranscript<F>>::append_message(
+            self,
+            b"EVM word alignment padding",
+            &[0u8; 12],
+        )?;
 
         // include [x]_2 G2 point from SRS
         // all G1 points from SRS are implicit reflected in committed polys

--- a/plonk/src/transcript/solidity.rs
+++ b/plonk/src/transcript/solidity.rs
@@ -7,8 +7,7 @@
 //! This module implements solidity transcript.
 use super::PlonkTranscript;
 use crate::{
-    errors::PlonkError,
-    proof_system::structs::{ProofEvaluations, VerifyingKey},
+    constants::KECCAK256_STATE_SIZE, errors::PlonkError, proof_system::structs::VerifyingKey,
 };
 use ark_ec::{
     pairing::Pairing,
@@ -23,15 +22,15 @@ use sha3::{Digest, Keccak256};
 
 /// Transcript with `keccak256` hash function.
 ///
-/// It is currently implemented simply as
-/// - an append only vector of field elements
+/// We append new elements to the transcript vector,
+/// and when a challenge is generated, the state is updated and transcript is
+/// emptied.
 ///
-/// We keep appending new elements to the transcript vector,
-/// and when a challenge is generated they are appended too.
-///
-/// 1. challenge = hash(transcript)
-/// 2. transcript = transcript || challenge
+/// 1. state = hash(state | transcript)
+/// 2. transcript = Vec::new()
+/// 3. challenge = bytes_to_field(state)
 pub struct SolidityTranscript {
+    pub(crate) state: [u8; KECCAK256_STATE_SIZE],
     pub(crate) transcript: Vec<u8>,
 }
 
@@ -39,6 +38,7 @@ impl<F: PrimeField> PlonkTranscript<F> for SolidityTranscript {
     /// Create a new plonk transcript. `label` is omitted for efficiency.
     fn new(_label: &'static [u8]) -> Self {
         SolidityTranscript {
+            state: [0u8; KECCAK256_STATE_SIZE],
             transcript: Vec::new(),
         }
     }
@@ -76,14 +76,13 @@ impl<F: PrimeField> PlonkTranscript<F> for SolidityTranscript {
     }
 
     // override default implementation since we want to use BigEndian serialization
-    fn append_challenge<E>(
+    fn append_field<E>(
         &mut self,
         label: &'static [u8],
         challenge: &E::ScalarField,
     ) -> Result<(), PlonkError>
     where
         E: Pairing<BaseField = F>,
-        E::ScalarField: PrimeField,
     {
         <Self as PlonkTranscript<F>>::append_message(
             self,
@@ -132,82 +131,29 @@ impl<F: PrimeField> PlonkTranscript<F> for SolidityTranscript {
             &to_bytes!(&vk.open_key.powers_of_h[1])?,
         )?;
 
-        for ki in vk.k.iter() {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"wire subsets separators",
-                &ki.into_bigint().to_bytes_be(),
-            )?;
-        }
-        <Self as PlonkTranscript<F>>::append_commitments(
-            self,
-            b"selector commitments",
-            &vk.selector_comms,
-        )?;
-        <Self as PlonkTranscript<F>>::append_commitments(
-            self,
-            b"sigma commitments",
-            &vk.sigma_comms,
-        )?;
-
-        for input in pub_input.iter() {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"public input",
-                &input.into_bigint().to_bytes_be(),
-            )?;
-        }
-
-        Ok(())
+        self.append_fields::<E>(b"wire subsets separators", &vk.k)?;
+        self.append_commitments(b"selector commitments", &vk.selector_comms)?;
+        self.append_commitments(b"sigma commitments", &vk.sigma_comms)?;
+        self.append_fields::<E>(b"public input", pub_input)
     }
 
-    fn append_proof_evaluations<E: Pairing>(
-        &mut self,
-        evals: &ProofEvaluations<E::ScalarField>,
-    ) -> Result<(), PlonkError>
-    where
-        E::ScalarField: PrimeField,
-    {
-        for w_eval in &evals.wires_evals {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"wire_evals",
-                &w_eval.into_bigint().to_bytes_be(),
-            )?;
-        }
-        for sigma_eval in &evals.wire_sigma_evals {
-            <Self as PlonkTranscript<F>>::append_message(
-                self,
-                b"wire_sigma_evals",
-                &sigma_eval.into_bigint().to_bytes_be(),
-            )?;
-        }
-        <Self as PlonkTranscript<F>>::append_message(
-            self,
-            b"perm_next_eval",
-            &evals.perm_next_eval.into_bigint().to_bytes_be(),
-        )
-    }
-
-    /// Generate the challenge for the current transcript,
-    /// and then append it to the transcript. `_label` is omitted for
-    /// efficiency.
-    fn get_and_append_challenge<E>(
-        &mut self,
-        label: &'static [u8],
-    ) -> Result<E::ScalarField, PlonkError>
+    fn get_challenge<E>(&mut self, _label: &'static [u8]) -> Result<E::ScalarField, PlonkError>
     where
         E: Pairing<BaseField = F>,
         E::ScalarField: PrimeField,
     {
+        // 1. state = hash(state | transcript)
         let mut hasher = Keccak256::new();
+        hasher.update(self.state);
         hasher.update(&self.transcript);
         let buf = hasher.finalize();
+        self.state.copy_from_slice(&buf);
 
-        let challenge = E::ScalarField::from_be_bytes_mod_order(&buf);
-        <Self as PlonkTranscript<F>>::append_challenge::<E>(self, label, &challenge)?;
+        // 2. transcript = Vec::new()
+        self.transcript = Vec::new();
 
-        Ok(challenge)
+        // 3. challenge = bytes_to_field(state)
+        Ok(E::ScalarField::from_be_bytes_mod_order(&buf))
     }
 }
 

--- a/plonk/src/transcript/standard.rs
+++ b/plonk/src/transcript/standard.rs
@@ -9,7 +9,6 @@ use super::PlonkTranscript;
 use crate::errors::PlonkError;
 use ark_ec::pairing::Pairing;
 use ark_ff::PrimeField;
-use jf_utils::to_bytes;
 use merlin::Transcript;
 
 /// A wrapper of `merlin::Transcript`.
@@ -28,19 +27,13 @@ impl<F> PlonkTranscript<F> for StandardTranscript {
         Ok(())
     }
 
-    // generate the challenge for the current transcript
-    // and append it to the transcript
-    fn get_and_append_challenge<E>(
-        &mut self,
-        label: &'static [u8],
-    ) -> Result<E::ScalarField, PlonkError>
+    fn get_challenge<E>(&mut self, label: &'static [u8]) -> Result<E::ScalarField, PlonkError>
     where
         E: Pairing,
     {
         let mut buf = [0u8; 64];
         self.0.challenge_bytes(label, &mut buf);
         let challenge = E::ScalarField::from_le_bytes_mod_order(&buf);
-        self.0.append_message(label, &to_bytes!(&challenge)?);
         Ok(challenge)
     }
 }


### PR DESCRIPTION
As observed in https://www.notion.so/espressosys/Fiat-Shamir-Transcript-f29ccc7a23c94178aac5cfa5d336fd63 and discussed on Zulip, we decide to remove `get_and_append_challenge()` and only use `get_challenge()` and also introduce back `state` for solidity transcript as most other projects do. 

This partially undone some changes made in https://github.com/EspressoSystems/jellyfish/pull/619.

### This PR: 

- Updated `trait Transcript`
  - change `get_and_append_challenge()` to `get_challenge()`
  - add `get_n_challenges()` for multiple challenges for the same rounds
  - rename `append_challenge()` to `append_field()`
  - add `append_fields()`
- Updated `struct SolidityTranscript`: adding back `state` and squeeze logic (see code comment)


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] ~Targeted PR against correct branch (main)~
- [x] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [x] ~Wrote unit tests~
- [x] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
