### PR TITLE
feat: multiplicity depend on payload size

### DIFF
--- a/vid/src/advz.rs
+++ b/vid/src/advz.rs
@@ -912,18 +912,6 @@ where
         DenseUVPolynomial::from_coefficients_vec(evals_vec)
     }
 
-    // TODO delete this method?
-    fn polynomial<I>(&self, evals: I, multiplicity: usize) -> KzgPolynomial<E>
-    where
-        I: Iterator,
-        I::Item: Borrow<KzgEval<E>>,
-    {
-        Self::polynomial_internal(
-            evals,
-            usize::try_from(self.recovery_threshold).unwrap() * multiplicity,
-        )
-    }
-
     fn min_multiplicity(&self, payload_byte_len: usize) -> u32 {
         let elem_bytes_len = bytes_to_field::elem_byte_capacity::<<E as Pairing>::ScalarField>();
         let elems: u32 = payload_byte_len

--- a/vid/src/advz.rs
+++ b/vid/src/advz.rs
@@ -589,13 +589,7 @@ where
             usize::try_from(common.multiplicity * self.recovery_threshold).map_err(vid)?;
         let num_polys = common.poly_commits.len();
         let elems_capacity = num_polys * chunk_size;
-        let fft_domain =
-            Radix2EvaluationDomain::<KzgPoint<E>>::new(chunk_size).ok_or_else(|| {
-                VidError::Internal(anyhow::anyhow!(
-                    "fail to construct domain of size {}",
-                    chunk_size
-                ))
-            })?;
+        let fft_domain = Self::eval_domain(chunk_size)?;
 
         let mut elems = Vec::with_capacity(elems_capacity);
         let mut evals = Vec::with_capacity(num_evals);
@@ -889,11 +883,7 @@ where
                 domain_size
             )));
         }
-        let domain = Radix2EvaluationDomain::<KzgPoint<E>>::new(domain_size).ok_or_else(|| {
-            VidError::Internal(anyhow::anyhow!(
-                "fail to construct domain of size {domain_size}",
-            ))
-        })?;
+        let domain = Self::eval_domain(domain_size)?;
 
         domain.ifft_in_place(&mut evals_vec);
 
@@ -981,6 +971,16 @@ where
         let code_word_size = usize::try_from(multiplicity * self.num_storage_nodes).map_err(vid)?;
         UnivariateKzgPCS::<E>::multi_open_rou_eval_domain(chunk_size - 1, code_word_size)
             .map_err(vid)
+    }
+
+    fn eval_domain(
+        domain_size: usize,
+    ) -> VidResult<Radix2EvaluationDomain<<E as Pairing>::ScalarField>> {
+        Radix2EvaluationDomain::<KzgPoint<E>>::new(domain_size).ok_or_else(|| {
+            VidError::Internal(anyhow::anyhow!(
+                "fail to construct domain of size {domain_size}"
+            ))
+        })
     }
 }
 

--- a/vid/src/advz.rs
+++ b/vid/src/advz.rs
@@ -829,13 +829,13 @@ where
         E: Pairing,
     {
         let elem_bytes_len = bytes_to_field::elem_byte_capacity::<<E as Pairing>::ScalarField>();
-        let chunk_size =
+        let domain_size =
             usize::try_from(self.min_multiplicity(payload.len()) * self.recovery_threshold)
                 .unwrap();
 
-        parallelizable_chunks(payload, chunk_size * elem_bytes_len)
+        parallelizable_chunks(payload, domain_size * elem_bytes_len)
             .map(|chunk| {
-                Self::polynomial_internal(bytes_to_field::<_, KzgEval<E>>(chunk), chunk_size)
+                Self::polynomial_internal(bytes_to_field::<_, KzgEval<E>>(chunk), domain_size)
             })
             .collect()
     }

--- a/vid/src/advz.rs
+++ b/vid/src/advz.rs
@@ -613,7 +613,6 @@ where
             // TODO TEMPORARY: use FFT to encode polynomials in eval form
             // Remove these FFTs after we get KZG in eval form
             // https://github.com/EspressoSystems/jellyfish/issues/339
-            // TODO GUS fix this comment
             fft_domain.fft_in_place(&mut coeffs);
 
             elems.append(&mut coeffs);

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -106,10 +106,10 @@ where
             .into_iter()
             .enumerate()
         {
-            let poly = Self::polynomial_internal(
+            let poly = Self::interpolate_polynomial(
                 evals_iter,
                 (self.recovery_threshold * multiplicity) as usize,
-            );
+            )?;
             let points_range = Range {
                 // first polynomial? skip to the start of the proof range
                 start: if i == 0 { offset_elem } else { 0 },
@@ -280,10 +280,10 @@ where
                 .chunks(self.recovery_threshold as usize)
                 .into_iter(),
         ) {
-            let poly = Self::polynomial_internal(
+            let poly = Self::interpolate_polynomial(
                 evals_iter,
                 (stmt.common.multiplicity * self.recovery_threshold) as usize,
-            );
+            )?;
             let poly_commit = UnivariateKzgPCS::commit(&self.ck, &poly).map_err(vid)?;
             if poly_commit != stmt.common.poly_commits[commit_index] {
                 return Ok(Err(()));

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -91,6 +91,8 @@ where
 
         // prepare list of input points
         let multiplicity = self.min_multiplicity(payload.len());
+
+        // TODO GUS delete `points`!!!
         let points: Vec<_> =
             Radix2EvaluationDomain::new((self.recovery_threshold * multiplicity) as usize)
                 .expect("TODO return error instead")

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -90,7 +90,7 @@ where
             self.final_poly_points_range_end(range_elem.len(), offset_elem);
 
         // prepare list of input points
-        let multiplicity = self.min_multiplicity(payload.len());
+        let multiplicity = self.min_multiplicity(payload.len())?;
 
         // TODO GUS delete `points`!!!
         let points: Vec<_> =

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -90,7 +90,7 @@ where
             self.final_poly_points_range_end(range_elem.len(), offset_elem);
 
         // prepare list of input points
-        let multiplicity = self.min_multiplicity(payload.len() as u32, self.max_multiplicity); // TODO tidy
+        let multiplicity = self.min_multiplicity(payload.len());
         let points: Vec<_> =
             Radix2EvaluationDomain::new((self.recovery_threshold * multiplicity) as usize)
                 .expect("TODO return error instead")

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -91,10 +91,11 @@ where
 
         // prepare list of input points
         let multiplicity = self.min_multiplicity(payload.len() as u32, self.max_multiplicity); // TODO tidy
-        let points: Vec<_> = Radix2EvaluationDomain::new(multiplicity as usize)
-            .expect("TODO return error instead")
-            .elements()
-            .collect(); // perf: we might not need all these points
+        let points: Vec<_> =
+            Radix2EvaluationDomain::new((self.recovery_threshold * multiplicity) as usize)
+                .expect("TODO return error instead")
+                .elements()
+                .collect(); // perf: we might not need all these points
 
         let elems_iter = bytes_to_field::<_, KzgEval<E>>(&payload[range_poly_byte]);
         let mut proofs = Vec::with_capacity(range_poly.len() * points.len());
@@ -163,10 +164,12 @@ where
             self.final_poly_points_range_end(range_elem.len(), offset_elem);
 
         // prepare list of input points
-        let points: Vec<_> = Radix2EvaluationDomain::new(stmt.common.multiplicity as usize)
-            .expect("TODO return error instead")
-            .elements()
-            .collect(); // perf: we might not need all these points
+        let points: Vec<_> = Radix2EvaluationDomain::new(
+            (self.recovery_threshold * stmt.common.multiplicity) as usize,
+        )
+        .expect("TODO return error instead")
+        .elements()
+        .collect(); // perf: we might not need all these points
 
         // verify proof
         let mut cur_proof_index = 0;

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -106,7 +106,10 @@ where
             .into_iter()
             .enumerate()
         {
-            let poly = self.polynomial(evals_iter, multiplicity as usize);
+            let poly = Self::polynomial_internal(
+                evals_iter,
+                (self.recovery_threshold * multiplicity) as usize,
+            );
             let points_range = Range {
                 // first polynomial? skip to the start of the proof range
                 start: if i == 0 { offset_elem } else { 0 },
@@ -277,7 +280,10 @@ where
                 .chunks(self.recovery_threshold as usize)
                 .into_iter(),
         ) {
-            let poly = self.polynomial(evals_iter, stmt.common.multiplicity as usize);
+            let poly = Self::polynomial_internal(
+                evals_iter,
+                (stmt.common.multiplicity * self.recovery_threshold) as usize,
+            );
             let poly_commit = UnivariateKzgPCS::commit(&self.ck, &poly).map_err(vid)?;
             if poly_commit != stmt.common.poly_commits[commit_index] {
                 return Ok(Err(()));

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -115,7 +115,6 @@ where
                     points.len()
                 },
             };
-            ark_std::println!("points.len {}", points.len());
             proofs.extend(
                 UnivariateKzgPCS::multi_open(&self.ck, &poly, &points[points_range])
                     .expect("GUS WTF")

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -91,13 +91,11 @@ where
 
         // prepare list of input points
         let multiplicity = self.min_multiplicity(payload.len())?;
-
-        // TODO GUS delete `points`!!!
-        let points: Vec<_> =
-            Radix2EvaluationDomain::new((self.recovery_threshold * multiplicity) as usize)
-                .expect("TODO return error instead")
-                .elements()
-                .collect(); // perf: we might not need all these points
+        let points: Vec<_> = Self::eval_domain(
+            usize::try_from(self.recovery_threshold * multiplicity).map_err(vid)?,
+        )?
+        .elements()
+        .collect(); // perf: we might not need all these points
 
         let elems_iter = bytes_to_field::<_, KzgEval<E>>(&payload[range_poly_byte]);
         let mut proofs = Vec::with_capacity(range_poly.len() * points.len());
@@ -168,10 +166,9 @@ where
             self.final_poly_points_range_end(range_elem.len(), offset_elem);
 
         // prepare list of input points
-        let points: Vec<_> = Radix2EvaluationDomain::new(
-            (self.recovery_threshold * stmt.common.multiplicity) as usize,
-        )
-        .expect("TODO return error instead")
+        let points: Vec<_> = Self::eval_domain(
+            usize::try_from(self.recovery_threshold * stmt.common.multiplicity).map_err(vid)?,
+        )?
         .elements()
         .collect(); // perf: we might not need all these points
 

--- a/vid/src/advz/payload_prover.rs
+++ b/vid/src/advz/payload_prover.rs
@@ -120,8 +120,7 @@ where
             };
             proofs.extend(
                 UnivariateKzgPCS::multi_open(&self.ck, &poly, &points[points_range])
-                    .expect("GUS WTF")
-                    // .map_err(vid)?
+                    .map_err(vid)?
                     .0,
             );
         }
@@ -489,7 +488,7 @@ mod tests {
                     };
 
                     let small_range_proof: SmallRangeProof<_> =
-                        advz.payload_proof(&payload, range.clone()).unwrap(); // TODO this fails!
+                        advz.payload_proof(&payload, range.clone()).unwrap();
                     advz.payload_verify(stmt.clone(), &small_range_proof)
                         .unwrap()
                         .unwrap();

--- a/vid/src/advz/precomputable.rs
+++ b/vid/src/advz/precomputable.rs
@@ -39,8 +39,7 @@ where
         B: AsRef<[u8]>,
     {
         let payload = payload.as_ref();
-        let payload_byte_len = payload.len().try_into().map_err(vid)?;
-        let multiplicity = self.min_multiplicity(payload_byte_len, self.max_multiplicity);
+        let multiplicity = self.min_multiplicity(payload.len());
         let chunk_size = (multiplicity * self.recovery_threshold) as usize;
         let polys = self.bytes_to_polys(payload, chunk_size);
         let poly_commits: Vec<Commitment<E>> =
@@ -60,13 +59,12 @@ where
         B: AsRef<[u8]>,
     {
         let payload = payload.as_ref();
-        let payload_byte_len = payload.len().try_into().map_err(vid)?;
         let disperse_time = start_timer!(|| ark_std::format!(
             "(PRECOMPUTE): VID disperse {} payload bytes to {} nodes",
             payload_byte_len,
             self.num_storage_nodes
         ));
-        let multiplicity = self.min_multiplicity(payload_byte_len, self.max_multiplicity);
+        let multiplicity = self.min_multiplicity(payload.len());
         let chunk_size = multiplicity * self.recovery_threshold;
         let code_word_size = multiplicity * self.num_storage_nodes;
 
@@ -97,6 +95,7 @@ where
             "(PRECOMPUTE): compute {} KZG commitments",
             polys.len()
         ));
+        let payload_byte_len = payload.len().try_into().map_err(vid)?;
         let common = Common {
             poly_commits: data.poly_commits.clone(),
             all_evals_digest: all_evals_commit.commitment().digest(),

--- a/vid/src/advz/precomputable.rs
+++ b/vid/src/advz/precomputable.rs
@@ -40,8 +40,7 @@ where
     {
         let payload = payload.as_ref();
         let multiplicity = self.min_multiplicity(payload.len());
-        let chunk_size = (multiplicity * self.recovery_threshold) as usize;
-        let polys = self.bytes_to_polys(payload, chunk_size);
+        let polys = self.bytes_to_polys(payload);
         let poly_commits: Vec<Commitment<E>> =
             UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
         Ok((
@@ -71,7 +70,7 @@ where
         // partition payload into polynomial coefficients
         // and count `elems_len` for later
         let bytes_to_polys_time = start_timer!(|| "encode payload bytes into polynomials");
-        let polys = self.bytes_to_polys(payload, chunk_size as usize);
+        let polys = self.bytes_to_polys(payload);
         end_timer!(bytes_to_polys_time);
 
         // evaluate polynomials

--- a/vid/src/advz/precomputable.rs
+++ b/vid/src/advz/precomputable.rs
@@ -40,7 +40,7 @@ where
     {
         let payload = payload.as_ref();
         let multiplicity = self.min_multiplicity(payload.len());
-        let polys = self.bytes_to_polys(payload);
+        let polys = self.bytes_to_polys(payload)?;
         let poly_commits: Vec<Commitment<E>> =
             UnivariateKzgPCS::batch_commit(&self.ck, &polys).map_err(vid)?;
         Ok((
@@ -58,7 +58,7 @@ where
         B: AsRef<[u8]>,
     {
         let payload = payload.as_ref();
-        let polys = self.bytes_to_polys(payload);
+        let polys = self.bytes_to_polys(payload)?;
         let poly_commits = data.poly_commits.clone();
 
         self.disperse_with_polys_and_commits(payload, polys, poly_commits)

--- a/vid/src/advz/precomputable.rs
+++ b/vid/src/advz/precomputable.rs
@@ -58,93 +58,10 @@ where
         B: AsRef<[u8]>,
     {
         let payload = payload.as_ref();
-        let disperse_time = start_timer!(|| ark_std::format!(
-            "(PRECOMPUTE): VID disperse {} payload bytes to {} nodes",
-            payload_byte_len,
-            self.num_storage_nodes
-        ));
-        let multiplicity = self.min_multiplicity(payload.len());
-        let chunk_size = multiplicity * self.recovery_threshold;
-        let code_word_size = multiplicity * self.num_storage_nodes;
-
-        // partition payload into polynomial coefficients
-        // and count `elems_len` for later
-        let bytes_to_polys_time = start_timer!(|| "encode payload bytes into polynomials");
         let polys = self.bytes_to_polys(payload);
-        end_timer!(bytes_to_polys_time);
+        let poly_commits = data.poly_commits.clone();
 
-        // evaluate polynomials
-        let all_storage_node_evals_timer = start_timer!(|| ark_std::format!(
-            "compute all storage node evals for {} polynomials with {} coefficients",
-            polys.len(),
-            chunk_size
-        ));
-        let all_storage_node_evals = self.evaluate_polys(&polys, code_word_size as usize)?;
-        end_timer!(all_storage_node_evals_timer);
-
-        // vector commitment to polynomial evaluations
-        // TODO why do I need to compute the height of the merkle tree?
-        let all_evals_commit_timer =
-            start_timer!(|| "compute merkle root of all storage node evals");
-        let all_evals_commit =
-            KzgEvalsMerkleTree::<E, H>::from_elems(None, &all_storage_node_evals).map_err(vid)?;
-        end_timer!(all_evals_commit_timer);
-
-        let common_timer = start_timer!(|| ark_std::format!(
-            "(PRECOMPUTE): compute {} KZG commitments",
-            polys.len()
-        ));
-        let payload_byte_len = payload.len().try_into().map_err(vid)?;
-        let common = Common {
-            poly_commits: data.poly_commits.clone(),
-            all_evals_digest: all_evals_commit.commitment().digest(),
-            payload_byte_len,
-            num_storage_nodes: self.num_storage_nodes,
-            multiplicity,
-        };
-        end_timer!(common_timer);
-
-        let commit = Self::derive_commit(
-            &common.poly_commits,
-            payload_byte_len,
-            self.num_storage_nodes,
-        )?;
-        let pseudorandom_scalar = Self::pseudorandom_scalar(&common, &commit)?;
-
-        // Compute aggregate polynomial as a pseudorandom linear combo of polynomial via
-        // evaluation of the polynomial whose coefficients are polynomials and whose
-        // input point is the pseudorandom scalar.
-        let aggregate_poly =
-            polynomial_eval(polys.iter().map(PolynomialMultiplier), pseudorandom_scalar);
-
-        let agg_proofs_timer = start_timer!(|| ark_std::format!(
-            "compute aggregate proofs for {} storage nodes",
-            self.num_storage_nodes
-        ));
-        let aggregate_proofs = UnivariateKzgPCS::multi_open_rou_proofs(
-            &self.ck,
-            &aggregate_poly,
-            code_word_size as usize,
-            &self.multi_open_domain,
-        )
-        .map_err(vid)?;
-        end_timer!(agg_proofs_timer);
-
-        let assemblage_timer = start_timer!(|| "assemble shares for dispersal");
-        let shares = self.assemble_shares(
-            all_storage_node_evals,
-            aggregate_proofs,
-            all_evals_commit,
-            multiplicity,
-        )?;
-        end_timer!(assemblage_timer);
-        end_timer!(disperse_time);
-
-        Ok(VidDisperse {
-            shares,
-            common,
-            commit,
-        })
+        self.disperse_with_polys_and_commits(payload, polys, poly_commits)
     }
 }
 

--- a/vid/src/advz/test.rs
+++ b/vid/src/advz/test.rs
@@ -368,8 +368,8 @@ fn max_multiplicity() {
     let recovery_threshold = 4;
     let max_multiplicity = 1 << 10; // intentionally large so as to fit many payload sizes into a single polynomial
 
-    // TODO add payload byte len 0 to this test
-    let payload_byte_lens = [1, 100, 1_000, 10_000, 100_000, 1_000_000];
+    // let payload_byte_lens = [0, 1, 100, 1_000, 10_000, 100_000, 1_000_000];
+    let payload_byte_lens = [1, 100, 1_000];
     type E = Bls12_381;
 
     // more items as a function of the above
@@ -427,6 +427,11 @@ fn max_multiplicity() {
                 "derived multiplicity should equal max_multiplicity for large payload"
             );
         }
+
+        // sanity: recover payload
+        // let bytes_recovered = advz.recover_payload(&shares, &common).unwrap();
+        // assert_eq!(bytes_recovered, payload);
+
         // sanity: verify shares
         for share in shares {
             advz.verify_share(&share, &common, &commit)
@@ -435,7 +440,7 @@ fn max_multiplicity() {
         }
     }
 
-    assert!(found_large_payload, "missing test for large payload");
+    // assert!(found_large_payload, "missing test for large payload");
     assert!(found_small_payload, "missing test for small payload");
 }
 

--- a/vid/src/advz/test.rs
+++ b/vid/src/advz/test.rs
@@ -366,10 +366,9 @@ fn max_multiplicity() {
     // play with these items
     let num_storage_nodes = 6;
     let recovery_threshold = 4;
-    let max_multiplicity = 1 << 10; // intentionally large so as to fit many payload sizes into a single polynomial
+    let max_multiplicity = 1 << 5; // intentionally large so as to fit many payload sizes into a single polynomial
 
-    // let payload_byte_lens = [0, 1, 100, 1_000, 10_000, 100_000, 1_000_000];
-    let payload_byte_lens = [1, 100, 1_000];
+    let payload_byte_lens = [0, 1, 100, 10_000];
     type E = Bls12_381;
 
     // more items as a function of the above
@@ -402,21 +401,28 @@ fn max_multiplicity() {
                 "derived multiplicity too small"
             );
 
-            // TODO TEMPORARY: multiplicity, recovery_threshold must be a power
-            // of 2 https://github.com/EspressoSystems/jellyfish/issues/668
-            //
-            // After this issue is fixed the following test should use
-            // `common.multiplicity - 1` instead of `common.multiplicity / 2`.
-            assert!(
-                num_payload_elems > common.multiplicity / 2 * advz.recovery_threshold,
-                "derived multiplicity too large: payload_byte_len {}, common.multiplicity {}",
-                payload_byte_len,
-                common.multiplicity
-            );
+            if num_payload_elems > 0 {
+                // TODO TEMPORARY: enforce power-of-2
+                // https://github.com/EspressoSystems/jellyfish/issues/668
+                //
+                // After this issue is fixed the following test should use
+                // `common.multiplicity - 1` instead of `common.multiplicity / 2`.
+                assert!(
+                    num_payload_elems > common.multiplicity / 2 * advz.recovery_threshold,
+                    "derived multiplicity too large: payload_byte_len {}, common.multiplicity {}",
+                    payload_byte_len,
+                    common.multiplicity
+                );
+            } else {
+                assert_eq!(
+                    common.multiplicity, 1,
+                    "zero-length payload should have multiplicity 1, found {}",
+                    common.multiplicity
+                );
+            }
 
-            assert_eq!(
-                common.poly_commits.len(),
-                1,
+            assert!(
+                common.poly_commits.len() <= 1,
                 "small payload should fit into a single polynomial"
             );
         } else {
@@ -440,7 +446,7 @@ fn max_multiplicity() {
         }
     }
 
-    // assert!(found_large_payload, "missing test for large payload");
+    assert!(found_large_payload, "missing test for large payload");
     assert!(found_small_payload, "missing test for small payload");
 }
 

--- a/vid/src/advz/test.rs
+++ b/vid/src/advz/test.rs
@@ -427,8 +427,6 @@ fn max_multiplicity() {
                 "derived multiplicity should equal max_multiplicity for large payload"
             );
         }
-        assert!(found_large_payload && found_small_payload, "missing tests");
-
         // sanity: verify shares
         for share in shares {
             advz.verify_share(&share, &common, &commit)
@@ -436,6 +434,9 @@ fn max_multiplicity() {
                 .unwrap();
         }
     }
+
+    assert!(found_large_payload, "missing test for large payload");
+    assert!(found_small_payload, "missing test for small payload");
 }
 
 struct AdvzParams {

--- a/vid/src/advz/test.rs
+++ b/vid/src/advz/test.rs
@@ -235,8 +235,9 @@ fn sad_path_recover_payload_corrupt_shares() {
     // corrupted index, out of bounds
     {
         let mut shares_bad_indices = shares.clone();
+        let multi_open_domain_size = advz.multi_open_domain(common.multiplicity).unwrap().size();
         for i in 0..shares_bad_indices.len() {
-            shares_bad_indices[i].index += u32::try_from(advz.multi_open_domain.size()).unwrap();
+            shares_bad_indices[i].index += u32::try_from(multi_open_domain_size).unwrap();
             advz.recover_payload(&shares_bad_indices, &common)
                 .expect_err("recover_payload should fail when indices are out of bounds");
         }

--- a/vid/src/advz/test.rs
+++ b/vid/src/advz/test.rs
@@ -248,7 +248,7 @@ fn verify_share_with_multiplicity() {
     let advz_params = AdvzParams {
         recovery_threshold: 16,
         num_storage_nodes: 20,
-        multiplicity: 4,
+        max_multiplicity: 4,
         payload_len: 4000,
     };
     let (mut advz, payload) = advz_init_with(advz_params);
@@ -267,7 +267,7 @@ fn sad_path_verify_share_with_multiplicity() {
     let advz_params = AdvzParams {
         recovery_threshold: 16,
         num_storage_nodes: 20,
-        multiplicity: 32, // payload fitting into a single polynomial
+        max_multiplicity: 32, // payload fitting into a single polynomial
         payload_len: 8200,
     };
     let (mut advz, payload) = advz_init_with(advz_params);
@@ -362,7 +362,7 @@ fn verify_share_with_different_multiplicity_helper<E, H>(
 struct AdvzParams {
     recovery_threshold: u32,
     num_storage_nodes: u32,
-    multiplicity: u32,
+    max_multiplicity: u32,
     payload_len: usize,
 }
 
@@ -375,7 +375,7 @@ pub(super) fn advz_init() -> (Advz<Bls12_381, Sha256>, Vec<u8>) {
     let advz_params = AdvzParams {
         recovery_threshold: 16,
         num_storage_nodes: 20,
-        multiplicity: 1,
+        max_multiplicity: 1,
         payload_len: 4000,
     };
     advz_init_with(advz_params)
@@ -383,17 +383,17 @@ pub(super) fn advz_init() -> (Advz<Bls12_381, Sha256>, Vec<u8>) {
 
 fn advz_init_with(advz_params: AdvzParams) -> (Advz<Bls12_381, Sha256>, Vec<u8>) {
     let mut rng = jf_utils::test_rng();
-    let poly_len = advz_params.recovery_threshold * advz_params.multiplicity;
+    let poly_len = advz_params.recovery_threshold * advz_params.max_multiplicity;
     let srs = init_srs(poly_len as usize, &mut rng);
     assert_ne!(
-        advz_params.multiplicity, 0,
+        advz_params.max_multiplicity, 0,
         "multiplicity should not be zero"
     );
-    let advz = if advz_params.multiplicity > 1 {
+    let advz = if advz_params.max_multiplicity > 1 {
         Advz::with_multiplicity(
             advz_params.num_storage_nodes,
             advz_params.recovery_threshold,
-            advz_params.multiplicity,
+            advz_params.max_multiplicity,
             srs,
         )
         .unwrap()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

closes: #663 
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->

### This PR: 
This PR replaces #667. Thanks to @akonring for getting this PR started.

The fix for issue #663 has many knock-on tasks, most of which are also resolved here.
- `multiplicity` arg for `Advz` constructor is now `max_multiplicity`. The user no longer specifies the multiplicity that is used for *all* payloads. Instead, the user specifies the *maximum* multiplicity that may be used. The actual multiplicity is now selected at `disperse`-time as a function of payload size. Thus, as per #663, a small payload with large multiplicity will no longer have wastefully-large share size.
- new test `max_multiplicity` that ensures small multiplicity for small payloads
- As noted in https://github.com/EspressoSystems/jellyfish/pull/667#issuecomment-2310881049, it is insufficient merely to set multiplicity at `disperse`-time. We must also set the size of the FFT domains at `disperse`-time.
- Prior to this PR those domains were stored in fields `eval_domain`, `multi_open_domain` of the `Advz` struct. Now that these domains are set at `disperse`-time there is no need to store them in the `Advz` struct, so I removed them. They are now computed on-the-fly as needed, just like multiplicity.
- Implementing these changes was tedious. It became clear to me that we have some tech debt. Thus, I also did some code clean-up in this PR. This clean-up did not cost much extra time because I had to do 90% of the work anyway just to implement the changes needed for this PR.
- Tech debt:
  - `disperse_precompute` is mostly copy-pasted code from `disperse`. I refactored these two functions into `disperse_with_polys_and_commits`.
  - Lots of low-level helpers were messy: `polynomial`, `polynomial_internal`, `bytes_to_polys`, etc
- Posted new issue #668 and linked to it in several places in code comments.

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->
 
### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  --> 
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that it is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
