### PR TITLE
fix: typos in documentation files

### DIFF
--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -1,10 +1,10 @@
 # CHANGELOG
 
-**WARNING**: this repository is under active development. Unlike [semantic versioning](https://semver.org/), we do expect backward incompatible changes when upgrading PATCH version.
+**WARNING**: this repository is under active development. Unlike [semantic versioning](https://semver.org/), we do expect backward-incompatible changes when upgrading PATCH version.
 
 We take inspiration from [keep changelog](https://keepachangelog.com/en/1.0.0/) and [arkworks](https://github.com/arkworks-rs/algebra/blob/master/CHANGELOG.md).
 
-**Breaking Changes** and **Fixed** contain backward incompatible changes, bug fixes, and security patches;
+**Breaking Changes** and **Fixed** contain backward-incompatible changes, bug fixes, and security patches;
 **Added, Changed, Removed, Deprecated** contain backward compatible improvements or new features.
 
 ## [Unreleased](https://github.com/EspressoSystems/jellyfish/compare/0.4.0...main)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For general discussions on Jellyfish PLONK, please join our [Discord channel](ht
 - ['jf-utils'](utilities): utilities and helper functions.
 
 ### Primitives
-- ['jf-prf'](prf): trait definitions for pesudorandom function (PRF).
+- ['jf-prf'](prf): trait definitions for pseudorandom function (PRF).
 - ['jf-crhf'](crhf): trait definitions for collision-resistant hash function (CRHF).
 - ['jf-commitment'](commitment): trait definitions for cryptographic commitment scheme.
 - ['jf-rescue'](rescue): Rescue hash function, and its subsequent PRF, CRHF, commitment scheme implementations.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.
Description correction:
Corrected "pesudorandom" to "pseudorandom" and added hyphens in words.

Please review the changes and let me know if any additional changes are needed.