### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For general discussions on Jellyfish PLONK, please join our [Discord channel](ht
 - ['jf-utils'](utilities): utilities and helper functions.
 
 ### Primitives
-- ['jf-prf'](prf): trait definitions for pesudorandom function (PRF).
+- ['jf-prf'](prf): trait definitions for pseudorandom function (PRF).
 - ['jf-crhf'](crhf): trait definitions for collision-resistant hash function (CRHF).
 - ['jf-commitment'](commitment): trait definitions for cryptographic commitment scheme.
 - ['jf-rescue'](rescue): Rescue hash function, and its subsequent PRF, CRHF, commitment scheme implementations.
@@ -75,7 +75,7 @@ Jellyfish is `no_std` compliant and compilable to WASM target environment, just 
 
 ### Backends
 
-To choose different backends for arithmetics of `curve25519-dalek`, which is currently
+To choose different backends for arithmetic of `curve25519-dalek`, which is currently
 used by `jf-primitives/aead`, set the environment variable:
 
 ```
@@ -96,7 +96,7 @@ RUSTFLAGS='--cfg curve25519_dalek_bits="SIZE"'
 cargo test --release
 ```
 
-Note that by default the _release_ mode does not check integers overflow.
+Note that, by default, the _release_ mode does not check for integer overflow. 
 In order to enforce this check run:
 
 ```


### PR DESCRIPTION
### "pesudorandom" → "pseudorandom"
Corrected the misspelling of "pseudorandom."

### "arithmetics" → "arithmetic"
Changed "arithmetics" to "arithmetic" for correct usage in a technical context.

### Revised sentence for grammatical correctness and clarity

Original: "Note that by default the release mode does not check integers overflow."
Updated: "Note that, by default, the release mode does not check for integer overflow."

**Explanation:**

-Corrected the preposition: "check for" instead of "check."
-Fixed the noun form: "integer overflow" instead of "integers overflow."
-Added a comma after "Note that" to improve readability and flow.
