### PR TITLE
**Fix Typo in `constraint_system.rs`**

### DIFF
--- a/relation/src/constraint_system.rs
+++ b/relation/src/constraint_system.rs
@@ -251,7 +251,7 @@ pub trait Arithmetization<F: FftField>: Circuit<F> {
     }
 
     /// Compute and return the polynomial that interpolates the table domain
-    /// sepration ids. Return an error if the circuit does not support
+    /// separation ids. Return an error if the circuit does not support
     /// lookup or has not been finalized.
     fn compute_table_dom_sep_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
         Err(CircuitError::LookupUnsupported)


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `constraint_system.rs`**

## Description  
This pull request fixes a typo in the documentation within the `constraint_system.rs` file, enhancing clarity and correctness.

### Changes Made:
- **File Modified:** `relation/src/constraint_system.rs`
- **Summary of Changes:**
  - Corrected the typo "sepration" to "separation" in the comment describing table domain separation IDs.

## Related Issues  
N/A

## Checklist  
- [x] Corrected the typo in the comment.
- [x] Confirmed no impact on functionality or logic of the code.

## Testing  
N/A (Typo fix in comments)

## Additional Notes  
This update ensures the code comments are clear and professional, aiding in code comprehension.

---

**Allow edits by maintainers:** [x]
