### PR TITLE
ypo Fix in `sponge.rs`

### DIFF
--- a/poseidon2/src/sponge.rs
+++ b/poseidon2/src/sponge.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroize;
 ///
 /// # Generic parameters:
 /// - N: state size = rate (R) + capacity (C)
-/// - R: rate (number of field abosrbed/squeezed)
+/// - R: rate (number of field absorbed/squeezed)
 ///
 /// For security, for b=128-bit security, field size |F|, C*|F|>=2b:
 /// i.e. 128-bit for 256-bit fields, C>=1.


### PR DESCRIPTION
## Typo Fix in `sponge.rs`

This pull request corrects a typographical error in the `sponge.rs` file. The comment regarding the "rate" was mistakenly written as "number of field abosrbed/squeezed" and has been fixed to "number of field absorbed/squeezed."

### Changes:
- Corrected the typo from "abosrbed" to "absorbed" in the comment describing the "rate."

### Checklist:
- [x] Corrected the typographical error in the comment.
- [x] Changes reviewed and tested.
