### PR TITLE
fix: typos in documentation files

### DIFF
--- a/poseidon2/src/sponge.rs
+++ b/poseidon2/src/sponge.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroize;
 ///
 /// # Generic parameters:
 /// - N: state size = rate (R) + capacity (C)
-/// - R: rate (number of field abosrbed/squeezed)
+/// - R: rate (number of field absorbed/squeezed)
 ///
 /// For security, for b=128-bit security, field size |F|, C*|F|>=2b:
 /// i.e. 128-bit for 256-bit fields, C>=1.


### PR DESCRIPTION
Corrected `abosrbed` to `absorbed`