### PR TITLE
chore: bump crhf version and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For general discussions on Jellyfish PLONK, please join our [Discord channel](ht
 - ['jf-utils'](utilities): utilities and helper functions.
 
 ### Primitives
-- ['jf-prf'](prf): trait definitions for pesudorandom function (PRF).
+- ['jf-prf'](prf): trait definitions for pseudorandom function (PRF).
 - ['jf-crhf'](crhf): trait definitions for collision-resistant hash function (CRHF).
 - ['jf-commitment'](commitment): trait definitions for cryptographic commitment scheme.
 - ['jf-rescue'](rescue): Rescue hash function, and its subsequent PRF, CRHF, commitment scheme implementations.

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -95,7 +95,7 @@ impl EncKey {
         // generate an ephemeral key pair as the virtual sender to derive the crypto box
         let ephemeral_keypair = crypto_kx::Keypair::generate(&mut rng);
         // `crypto_kx` generates a pair of shared secrets, see <https://libsodium.gitbook.io/doc/key_exchange>
-        // we use the transimission key of the ephemeral sender (equals to the receiving
+        // we use the transmission key of the ephemeral sender (equals to the receiving
         // key of the server) as the shared secret.
         let shared_secret = ephemeral_keypair.session_keys_to(&self.0).tx;
         let cipher = XChaCha20Poly1305::new(shared_secret.as_ref().into());

--- a/crhf/Cargo.toml
+++ b/crhf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jf-crhf"
-version = "0.1.0"
+version = "0.1.1"
 description = "Collision-resistant hash function (CRHF)"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/elgamal/src/gadgets.rs
+++ b/elgamal/src/gadgets.rs
@@ -58,7 +58,7 @@ where
     /// in each call, and the nonce is initialized to zero.
     /// * `key_var` - variables corresponding to the symmetric key
     /// * `data_vars` - the variables for the data to be encrypted. The format
-    ///   of this input is a list of variable of arbitrary length
+    ///   of this input is a list of variables of arbitrary length
     /// * `returns` - the variables that map to the ciphertext contents. The
     ///   output size is the same as the length of data_vars
     fn apply_counter_mode_stream(
@@ -166,7 +166,7 @@ where
     F: PrimeField,
     P: TECurveConfig<BaseField = F>,
 {
-    /// Compute the gadget that check a correct Elgamal encryption
+    /// Compute the gadget that checks a correct Elgamal encryption
     /// * `pk_vars` - variables corresponding to the encryption public key
     /// * `data_vars` - variables corresponding to the plaintext. Can be of
     ///   arbitrary length.

--- a/merkle_tree/src/append_only.rs
+++ b/merkle_tree/src/append_only.rs
@@ -310,7 +310,7 @@ mod mt_tests {
         assert!(mt.forget(1).expect_ok().is_ok());
         // Number of leaves shall not change
         assert_eq!(mt.num_leaves(), 3);
-        // Leaves that are forgotten doesn't appear here
+        // Leaves that are forgotten don't appear here
         let leaves = mt.into_iter().collect::<Vec<_>>();
         assert_eq!(leaves, [(0, F::from(0u64)), (2, F::from(2u64))]);
 

--- a/merkle_tree/src/lib.rs
+++ b/merkle_tree/src/lib.rs
@@ -130,7 +130,7 @@ where
     fn digest_leaf(pos: &I, elem: &E) -> Result<T, MerkleTreeError>;
 }
 
-/// An trait for Merkle tree index type.
+/// A trait for Merkle tree index type.
 pub trait ToTraversalPath<const ARITY: usize> {
     /// Convert the given index to a vector of branch indices given tree height
     /// and ARITY.
@@ -170,8 +170,8 @@ pub trait MerkleProof<T: NodeValue>:
 }
 
 /// Basic functionalities for a merkle tree implementation. Abstracted as an
-/// accumulator for fixed-length array. Supports generate membership proof at a
-/// given position and verify a membership proof.
+/// accumulator for fixed-length array. Supports generating membership proof at
+/// a given position and verify a membership proof.
 pub trait MerkleTreeScheme: Sized {
     /// Merkle tree element type
     type Element: Element;
@@ -231,7 +231,7 @@ pub trait MerkleTreeScheme: Sized {
     // ) -> Result<(), MerkleTreeError>;
 
     /// Return an iterator that iterates through all element that are not
-    /// forgetton
+    /// forgotten
     fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue>;
 }
 

--- a/pcs/src/multilinear_kzg/mod.rs
+++ b/pcs/src/multilinear_kzg/mod.rs
@@ -181,7 +181,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     ///
     /// This function takes 2^{num_var +1} number of scalar multiplications over
     /// G1:
-    /// - it prodceeds with `num_var` number of rounds,
+    /// - it proceeds with `num_var` number of rounds,
     /// - at round i, we compute an MSM for `2^{num_var - i + 1}` number of G2
     ///   elements.
     fn open(
@@ -197,11 +197,11 @@ impl<E: Pairing> PolynomialCommitmentScheme for MultilinearKzgPCS<E> {
     /// - the prover parameters for multilinear KZG,
     /// - a list of polynomials,
     /// - a (batch) commitment to all polynomials,
-    /// - and a same number of points,
+    /// - and the same number of points,
     /// compute a batch opening for all the polynomials.
     ///
     /// For simplicity, this API requires each MLE to have only one point. If
-    /// the caller wish to use more than one points per MLE, it should be
+    /// the caller wish to use more than one point per MLE, it should be
     /// handled at the caller layer.
     ///
     /// Returns an error if the lengths do not match.

--- a/pcs/src/univariate_kzg/mod.rs
+++ b/pcs/src/univariate_kzg/mod.rs
@@ -178,7 +178,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for UnivariateKzgPCS<E> {
         Ok((Self::Proof { proof }, eval))
     }
 
-    /// Input a list of polynomials, and a same number of points,
+    /// Input a list of polynomials, and the same number of points,
     /// compute a multi-opening for all the polynomials.
     // This is a naive approach
     // TODO: to implement the more efficient batch opening algorithm

--- a/poseidon2/src/sponge.rs
+++ b/poseidon2/src/sponge.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroize;
 ///
 /// # Generic parameters:
 /// - N: state size = rate (R) + capacity (C)
-/// - R: rate (number of field abosrbed/squeezed)
+/// - R: rate (number of field absorbed/squeezed)
 ///
 /// For security, for b=128-bit security, field size |F|, C*|F|>=2b:
 /// i.e. 128-bit for 256-bit fields, C>=1.

--- a/relation/src/constraint_system.rs
+++ b/relation/src/constraint_system.rs
@@ -251,7 +251,7 @@ pub trait Arithmetization<F: FftField>: Circuit<F> {
     }
 
     /// Compute and return the polynomial that interpolates the table domain
-    /// sepration ids. Return an error if the circuit does not support
+    /// separation ids. Return an error if the circuit does not support
     /// lookup or has not been finalized.
     fn compute_table_dom_sep_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
         Err(CircuitError::LookupUnsupported)

--- a/vrf/src/lib.rs
+++ b/vrf/src/lib.rs
@@ -59,7 +59,7 @@ pub trait Vrf {
     // FIXME: the API looks a bit strange when the default generator is used.
     // For example:
     //   `S::param_gen::<StdRng>(None)`
-    // wheere `StdRng` is redundant.
+    // where `StdRng` is redundant.
     fn param_gen<R: CryptoRng + RngCore>(
         &self,
         prng: Option<&mut R>,


### PR DESCRIPTION
Bumping `jf-crhf` to `0.1.1`

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
