### PR TITLE
chore: bump jf-merkle-tree to 0.2.1

### DIFF
--- a/merkle_tree/CHANGELOG.md
+++ b/merkle_tree/CHANGELOG.md
@@ -3,6 +3,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2025-01-13)
+- [#716](https://github.com/EspressoSystems/jellyfish/pull/716) Poseidon2-based Merkle Tree available.
+
 ## 0.2.0 (2024-10-21)
 
 - [#692](https://github.com/EspressoSystems/jellyfish/pull/692) Major refactor for ergonomics reason

--- a/merkle_tree/Cargo.toml
+++ b/merkle_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jf-merkle-tree"
-version = "0.2.0"
+version = "0.2.1"
 description = "Various Merkle tree implementations."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -25,9 +25,7 @@ hashbrown = { workspace = true }
 hex = "0.4.3"
 itertools = { workspace = true, features = ["use_alloc"] }
 jf-crhf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf-crhf-v0.1.1" }
-# TODO: switch to this once jf-poseidon2 cut a release
-# jf-poseidon2 = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish" }
-jf-poseidon2 = { path = "../poseidon2" }
+jf-poseidon2 = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf-poseidon2-v0.1.0" }
 jf-relation = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", optional = true, default-features = false }
 jf-rescue = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 jf-utils = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }


### PR DESCRIPTION
New release for `jf-merkle-tree` to `0.2.1`

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
