### PR TITLE
fix: Remove extra space in error message formatting

### DIFF
--- a/plonk/src/proof_system/batch_arg.rs
+++ b/plonk/src/proof_system/batch_arg.rs
@@ -89,7 +89,7 @@ where
     {
         if instances_type_a.len() != instances_type_b.len() {
             return Err(ParameterError(format!(
-                "the number of type A instances {} is different from the number of type B instances {}.", 
+                "the number of type A instances {} is different from the number of type B instances {}.",
                 instances_type_a.len(),
                 instances_type_b.len())
             ).into());


### PR DESCRIPTION
closes: #N/A
<!-- If there is no issue number make sure to describe clearly why this PR is necessary. -->
This PR is necessary to maintain consistent code formatting and improve code quality. Extra spaces in string formatting can potentially cause readability issues and indicate inconsistent coding style.
### This PR:
<!-- Describe what this PR adds to this repo and why -->
Fixes a formatting issue by removing an extra space after a comma in an error message in plonk/src/proof_system/batch_arg.rs
Improves code style consistency
### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
Address other potential formatting inconsistencies throughout the codebase (those would be handled in separate PRs if needed)
### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
plonk/src/proof_system/batch_arg.rs, line 92 - removing the extra space after the comma in the error message
---
Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.
[x] Targeted PR against correct branch (main)
[x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
[ ] Wrote unit tests (N/A - This is a formatting change that doesn't affect functionality)
[ ] Updated relevant documentation in the code (N/A - No documentation change needed for formatting fix)
[ ] Added relevant changelog entries to the CHANGELOG.md of touched crates. (N/A - Minor formatting fix doesn't warrant a changelog entry)
[x] Re-reviewed Files changed in the GitHub PR explorer