### PR TITLE
fix: incorrect update of `negative_cur_elem` in `lagrange_coeffs_for_range`

### DIFF
--- a/plonk/src/lagrange.rs
+++ b/plonk/src/lagrange.rs
@@ -167,7 +167,7 @@ impl<F: FftField> LagrangeCoeffs<F> for Radix2EvaluationDomain<F> {
                 *coeff = l_i * r_i;
                 // Increment l_i and negative_cur_elem
                 l_i *= &group_gen_inv;
-                negative_cur_elem *= &group_gen;
+                negative_cur_elem = negative_cur_elem * group_gen_inv;
             }
             ark_ff::fields::batch_inversion(lagrange_coefficients_inverse.as_mut_slice());
             lagrange_coefficients_inverse


### PR DESCRIPTION
### **This PR:**  
Fixes an incorrect update of `negative_cur_elem` in `lagrange_coeffs_for_range`. The variable was mistakenly updated with `group_gen` instead of `group_gen_inv`, which led to incorrect coefficient calculations.  

### **Key places to review:**  
- `lagrange_coeffs_for_range`:  
  - The original update:  
    ```rust
    negative_cur_elem *= &group_gen;
    ```  
  - Fixed version:  
    ```rust
    negative_cur_elem = negative_cur_elem * group_gen_inv;
    ```  
  - This ensures the value decreases as expected based on its initial definition.  

---

- [x] Targeted PR against correct branch (main)  
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.  
- [ ] Wrote unit tests  
- [ ] Updated relevant documentation in the code  
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.  
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer  