### PR TITLE
chore: restrict poseidon sponge for p2-based hash

### DIFF
--- a/merkle_tree/Cargo.toml
+++ b/merkle_tree/Cargo.toml
@@ -25,7 +25,8 @@ hashbrown = { workspace = true }
 hex = "0.4.3"
 itertools = { workspace = true, features = ["use_alloc"] }
 jf-crhf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf-crhf-v0.1.1" }
-jf-poseidon2 = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf-poseidon2-v0.1.0" }
+# TODO: pin to an updated version/tag next time we release a tag
+jf-poseidon2 = { path = "../poseidon2" }
 jf-relation = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", optional = true, default-features = false }
 jf-rescue = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 jf-utils = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }

--- a/merkle_tree/src/prelude.rs
+++ b/merkle_tree/src/prelude.rs
@@ -25,7 +25,9 @@ use ark_serialize::{
 };
 use ark_std::{fmt, marker::PhantomData, string::ToString, vec, vec::Vec};
 use jf_crhf::CRHF;
-use jf_poseidon2::{crhf::FixedLenPoseidon2Hash, Poseidon2, Poseidon2Params};
+use jf_poseidon2::{
+    crhf::FixedLenPoseidon2Hash, sponge::Poseidon2Sponge, Poseidon2, Poseidon2Params,
+};
 use jf_rescue::{crhf::RescueCRHF, RescueParameter};
 use nimue::hash::sponge::Sponge;
 use sha3::{Digest, Keccak256, Sha3_256};
@@ -81,7 +83,7 @@ impl<I, F, S, const INPUT_SIZE: usize> DigestAlgorithm<F, I, F>
 where
     I: Index,
     F: PrimeField + From<I> + nimue::Unit,
-    S: Sponge<U = F>,
+    S: Sponge<U = F> + Poseidon2Sponge,
 {
     fn digest(data: &[F]) -> Result<F, MerkleTreeError> {
         let mut input = vec![internal_hash_dom_sep()];

--- a/poseidon2/src/crhf.rs
+++ b/poseidon2/src/crhf.rs
@@ -10,7 +10,7 @@ use nimue::{
     DuplexHash, Unit,
 };
 
-use crate::Poseidon2Error;
+use crate::{sponge::Poseidon2Sponge, Poseidon2Error};
 
 /// Sponge-based CRHF where the Sponge uses Poseidon2 permutation
 /// Input length is fixed: the actual input can be shorter, but will internally
@@ -22,7 +22,7 @@ use crate::Poseidon2Error;
 pub struct FixedLenPoseidon2Hash<F, S, const INPUT_SIZE: usize, const OUTPUT_SIZE: usize>
 where
     F: PrimeField + Unit,
-    S: Sponge<U = F>,
+    S: Sponge<U = F> + Poseidon2Sponge,
 {
     _field: PhantomData<F>,
     _sponge: PhantomData<S>,
@@ -31,7 +31,7 @@ where
 impl<F, S, const IN: usize, const OUT: usize> CRHF for FixedLenPoseidon2Hash<F, S, IN, OUT>
 where
     F: PrimeField + Unit,
-    S: Sponge<U = F>,
+    S: Sponge<U = F> + Poseidon2Sponge,
 {
     type Input = [F]; // length should be <= IN
     type Output = [F; OUT];

--- a/poseidon2/src/external.rs
+++ b/poseidon2/src/external.rs
@@ -10,6 +10,9 @@ use crate::{add_rcs, s_box};
 /// [ 1 1 2 3 ]
 /// [ 3 1 1 2 ]
 ///
+/// NOTE: we use plonky3's matrix instead of that in the original paper
+/// HorizenLab's ref: <https://github.com/Plonky3/Plonky3/blob/main/poseidon2/src/external.rs#L34>
+///
 /// This requires 7 additions and 2 doubles to compute.
 /// credit: Plonky3
 #[derive(Clone, Default)]
@@ -50,6 +53,10 @@ pub(super) fn matmul_external<F: PrimeField, const T: usize>(state: &mut [F; T])
             state[1] += sum;
             state[2] += sum;
         },
+
+        // NOTE: matching plonky3's behavior, differs from the Horizen Labs reference implementation
+        // and the paper's description (Sec 5.1 of https://eprint.iacr.org/2023/323.pdf), in which for T=4,
+        // the circulant matrix is not applied.
 
         // Given a 4x4 MDS matrix M, we multiply by the `4N x 4N` matrix
         // `[[2M M  ... M], [M  2M ... M], ..., [M  M ... 2M]]`.

--- a/poseidon2/src/sponge.rs
+++ b/poseidon2/src/sponge.rs
@@ -6,6 +6,15 @@ use ark_std::marker::PhantomData;
 use nimue::{hash::sponge::Sponge, Unit};
 use zeroize::Zeroize;
 
+/// Marker trait for the state of Poseidon2-based Cryptographic Sponge
+pub trait Poseidon2Sponge {}
+impl<F, const N: usize, const R: usize, P> Poseidon2Sponge for Poseidon2SpongeState<F, N, R, P>
+where
+    F: PrimeField,
+    P: Poseidon2Params<F, N>,
+{
+}
+
 /// the state of Poseidon2-based Cryptographic Sponge
 ///
 /// # Generic parameters:


### PR DESCRIPTION
closes: #XXXX

> In FixedLenPoseidon2Hash and VariableLenPoseidon2Hash, the documentation misleadingly states that this sponge-based CRHF uses the Poseidon2 permutation. However, there is nothing about these structs that require use of the Poseidon2 permutation. It will use the Poseidon2 permutation only if it is parameterized by a Poseidon2 Sponge S.

### This PR: 

Fix the above issue, caught external review

### This PR does not:

Not yet release the next tag, so okay to use a non-pinned dependency

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
