### PR TITLE
fix Update hasher.rs

### DIFF
--- a/merkle_tree/src/hasher.rs
+++ b/merkle_tree/src/hasher.rs
@@ -18,7 +18,7 @@
 //! let mt = HasherMerkleTree::<Sha256, usize>::from_elems(Some(2), &my_data)?;
 //!
 //! let commitment = mt.commitment();
-//! let (val, proof) = mt.lookup(2).expect_ok()?;
+//! let (val, proof) = mt.lookup(2)?.expect("Element not found");
 //! assert_eq!(val, &3);
 //! assert!(HasherMerkleTree::<Sha256, usize>::verify(commitment, 2, val, proof)?.is_ok());
 //! # Ok(())


### PR DESCRIPTION
Fixed incorrect method usage (expect_ok() ---> .expect(...) or .ok_or(...)). The method expect_ok() does not exist for the Option type. The correct methods are .ok_or(...) or .expect(...).


