### PR TITLE
fix Update transcript.rs

### DIFF
--- a/pcs/src/transcript.rs
+++ b/pcs/src/transcript.rs
@@ -15,7 +15,7 @@ mod errors {
     pub enum TranscriptError {
         /// Invalid Transcript: {0}
         InvalidTranscript(String),
-        /// An error during (de)serialization: {0}
+        /// An error during (de)serialization: {:?}
         SerializationError(ark_serialize::SerializationError),
     }
 


### PR DESCRIPTION
The type ToTraversalPath was incorrectly written as ToTreversalPath. The correct type name is ToTraversalPath, but it was incorrectly written as ToTreversalPath. Such a typo can confuse readers and potentially cause misunderstandings.


