### PR TITLE
chore(ci): replace deprecated GitHub Actions to supported alternatives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           profile: default
           toolchain: stable
@@ -34,7 +34,7 @@ jobs:
             wasm32-unknown-unknown
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           profile: minimal
           toolchain: nightly-2024-06-25
@@ -52,12 +52,12 @@ jobs:
         run: cargo +nightly-2024-06-25 fmt -- --check
 
       - name: Clippy
-        uses: actions-rs/clippy-check@v1
+        uses: clechasseur/rs-clippy-check@v4.0.3
         with:
           token: ${{ github.token }}
 
       - name: Audit
-        uses: actions-rs/audit-check@v1
+        uses: actions-rust-lang/audit@v1.2.4
         with:
           token: ${{ github.token }}
 

--- a/.github/workflows/periodic_checks.yml
+++ b/.github/workflows/periodic_checks.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           profile: minimal
           toolchain: nightly


### PR DESCRIPTION

### This PR: 
This PR updates our GitHub workflow files to replace the deprecated and archived `actions-rs` GitHub Actions with their maintained alternatives:

- Replace `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@v1`
  (https://github.com/dtolnay/rust-toolchain/releases/tag/v1)

- Replace `actions-rs/clippy-check@v1` with `clechasseur/rs-clippy-check@v4.0.3`
  (https://github.com/clechasseur/rs-clippy-check/releases/tag/v4.0.3)

- Replace `actions-rs/audit-check@v1` with `actions-rust-lang/audit@v1.2.4`
  (https://github.com/actions-rust-lang/audit/releases/tag/v1.2.4)

These changes are necessary because the entire `actions-rs` organization was archived on October 13, 2023, and these Actions are no longer maintained. The replacements are recommended by the Rust community and provide the same functionality with ongoing support and security updates.

- [x] Targeted PR against correct branch (main)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
