### PR TITLE
fix: add missing Read/Write imports Update lib.rs

### DIFF
--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -284,6 +284,7 @@ pub struct Ciphertext {
 // Tracking issue: <https://github.com/EspressoSystems/jellyfish/issues/288>
 mod canonical_serde {
     use super::*;
+    use std::io::{Read, Write};
 
     impl CanonicalSerialize for EncKey {
         fn serialize_with_mode<W: Write>(


### PR DESCRIPTION
Description:
This PR resolves a compilation error in the canonical_serde submodule where the traits Read and Write (from std::io) were not imported. Because of this omission, any attempt to compile the file failed with messages like:

error[E0412]: cannot find type `Write` in this scope
error[E0412]: cannot find type `Read` in this scope

Changes:

Added use std::io::{Read, Write}; at the top of mod canonical_serde.

No other behavior or logic has been modified—the only impact is that serde-based serialization/deserialization and CanonicalSerialize/CanonicalDeserialize implementations now compile successfully.

With these imports in place, cargo build and cargo test both pass without errors.