### PR TITLE
fix: add PrimeField bound Update prelude.rs

### DIFF
--- a/merkle_tree/src/prelude.rs
+++ b/merkle_tree/src/prelude.rs
@@ -53,7 +53,7 @@ pub(crate) const LEAF_HASH_DOM_SEP: &'static [u8; 1] = b"1";
 /// domain separator of byte-oriented hash, for the internal node
 pub(crate) const INTERNAL_HASH_DOM_SEP: &'static [u8; 1] = b"0";
 
-impl<I: Index, F: RescueParameter + From<I>> DigestAlgorithm<F, I, F> for RescueHash<F> {
+impl<I: Index, F: PrimeField + RescueParameter + From<I>> DigestAlgorithm<F, I, F> for RescueHash<F> {
     fn digest(data: &[F]) -> Result<F, MerkleTreeError> {
         let mut input = vec![internal_hash_dom_sep()];
         input.extend(data.iter());


### PR DESCRIPTION
Description:
This PR addresses a compilation error in the RescueHash implementation of the DigestAlgorithm trait. Specifically, the helper functions leaf_hash_dom_sep::<F>() and internal_hash_dom_sep::<F>() require F: PrimeField, but the original impl signature only constrained F: RescueParameter + From<I>. As a result, any attempt to call RescueHash::digest or RescueHash::digest_leaf failed to compile due to the missing PrimeField bound.

In this change, we simply add + PrimeField to the F constraint for RescueHash, ensuring that internal_hash_dom_sep::<F>() and leaf_hash_dom_sep::<F>() can be called without error. No other functionality is affected.

Verification:

Confirmed that cargo check now passes for any F: PrimeField + RescueParameter.

Existing tests (including extension-attack) continue to pass without modification.

Notes:

No other trait bounds or functionality were modified. This change merely ensures that the two domain‐separator helper functions compile correctly by requiring F: PrimeField.

