### PR TITLE
fix: add mising imports Update bench.rs

### DIFF
--- a/plonk/benches/bench.rs
+++ b/plonk/benches/bench.rs
@@ -20,6 +20,8 @@ use jf_plonk::{
     PlonkType,
 };
 use jf_relation::{Circuit, PlonkCircuit};
+use jf_utils::test_rng;      // ← Import test_rng from jf_utils
+use std::vec;                // ← Import vec! macro
 use std::time::Instant;
 
 const NUM_REPETITIONS: usize = 10;


### PR DESCRIPTION
Description: 
This PR resolves two compilation errors in the Plonk benchmarking code by adding the necessary use statements:  The call to jf_utils::test_rng() requires importing test_rng from the jf_utils crate.  

The use of vec![] inside the plonk_batch_verify_bench! macro requires importing std::vec (or using the fully qualified std::vec![]). 
 
Without these imports, the compiler reports “undeclared crate or module jf_utils” and “cannot find macro vec”.

 This patch adds the missing use declarations so that the code compiles successfully.

