### PR TITLE
Fix logical error in VerifyingKey merge operation

### DIFF
--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -808,7 +808,7 @@ impl<E: Pairing> VerifyingKey<E> {
 
         Ok(Self {
             domain_size: self.domain_size,
-            num_inputs: self.num_inputs + other_vk.num_inputs,
+            num_inputs: self.num_inputs,
             sigma_comms,
             selector_comms,
             k: self.k.clone(),


### PR DESCRIPTION


### Description

Fixed a logical inconsistency in `VerifyingKey::merge()` where the method first validates that both keys have equal `num_inputs`, but then incorrectly sums them in the result.

