### PR TITLE
refactor!: merkle proof verify accept commitment instead of digest node

### DIFF
--- a/merkle_tree/benches/merkle_path.rs
+++ b/merkle_tree/benches/merkle_path.rs
@@ -10,7 +10,7 @@ extern crate criterion;
 use ark_ed_on_bls12_381::Fq as Fq381;
 use ark_std::rand::Rng;
 use criterion::Criterion;
-use jf_merkle_tree::{prelude::RescueMerkleTree, MerkleCommitment, MerkleTreeScheme};
+use jf_merkle_tree::{prelude::RescueMerkleTree, MerkleTreeScheme};
 use std::time::Duration;
 
 const BENCH_NAME: &str = "merkle_path_height_20";
@@ -25,12 +25,12 @@ fn twenty_hashes(c: &mut Criterion) {
     let leaf: Fq381 = rng.gen();
 
     let mt = RescueMerkleTree::<Fq381>::from_elems(Some(20), [leaf, leaf]).unwrap();
-    let root = mt.commitment().digest();
+    let comm = mt.commitment();
     let (_, proof) = mt.lookup(0).expect_ok().unwrap();
 
     let num_inputs = 0;
     benchmark_group.bench_with_input(BENCH_NAME, &num_inputs, move |b, &_num_inputs| {
-        b.iter(|| RescueMerkleTree::<Fq381>::verify(&root, 0, &proof).unwrap())
+        b.iter(|| RescueMerkleTree::<Fq381>::verify(&comm, 0, &proof).unwrap())
     });
     benchmark_group.finish();
 }

--- a/merkle_tree/src/append_only.rs
+++ b/merkle_tree/src/append_only.rs
@@ -166,11 +166,11 @@ mod mt_tests {
 
         let mt =
             RescueMerkleTree::<F>::from_elems(Some(2), [F::from(3u64), F::from(1u64)]).unwrap();
-        let root = mt.commitment().digest();
+        let commitment = mt.commitment();
         let (elem, proof) = mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, &F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueMerkleTree::<F>::verify(&root, 0u64, &proof)
+        assert!(RescueMerkleTree::<F>::verify(&commitment, 0u64, &proof)
             .unwrap()
             .is_ok());
 
@@ -186,7 +186,7 @@ mod mt_tests {
             unreachable!()
         }
 
-        let result = RescueMerkleTree::<F>::verify(&root, 0, &bad_proof);
+        let result = RescueMerkleTree::<F>::verify(&commitment, 0, &bad_proof);
         assert!(result.unwrap().is_err());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof);
@@ -201,7 +201,7 @@ mod mt_tests {
         } else {
             unreachable!()
         }
-        let result = RescueMerkleTree::<F>::verify(&root, 0, &forge_proof);
+        let result = RescueMerkleTree::<F>::verify(&commitment, 0, &forge_proof);
         assert!(result.unwrap().is_err());
     }
 
@@ -215,7 +215,7 @@ mod mt_tests {
     fn test_mt_forget_remember_helper<F: RescueParameter>() {
         let mut mt =
             RescueMerkleTree::<F>::from_elems(Some(2), [F::from(3u64), F::from(1u64)]).unwrap();
-        let root = mt.commitment().digest();
+        let commitment = mt.commitment();
         let (lookup_elem, lookup_proof) = mt.lookup(0).expect_ok().unwrap();
         let lookup_elem = *lookup_elem;
         let (elem, proof) = mt.forget(0).expect_ok().unwrap();
@@ -223,10 +223,10 @@ mod mt_tests {
         assert_eq!(lookup_proof, proof);
         assert_eq!(elem, F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
-        assert!(RescueMerkleTree::<F>::verify(&root, 0, &lookup_proof)
+        assert!(RescueMerkleTree::<F>::verify(&commitment, 0, &lookup_proof)
             .unwrap()
             .is_ok());
-        assert!(RescueMerkleTree::<F>::verify(&root, 0, &proof)
+        assert!(RescueMerkleTree::<F>::verify(&commitment, 0, &proof)
             .unwrap()
             .is_ok());
 

--- a/merkle_tree/src/hasher.rs
+++ b/merkle_tree/src/hasher.rs
@@ -17,10 +17,9 @@
 //! // payload type is `usize`, hash function is `Sha256`.
 //! let mt = HasherMerkleTree::<Sha256, usize>::from_elems(Some(2), &my_data)?;
 //!
-//! let root = mt.commitment().digest();
 //! let (val, proof) = mt.lookup(2).expect_ok()?;
 //! assert_eq!(val, &3);
-//! assert!(HasherMerkleTree::<Sha256, usize>::verify(root, 2, proof)?.is_ok());
+//! assert!(HasherMerkleTree::<Sha256, usize>::verify(mt.commitment(), 2, proof)?.is_ok());
 //! # Ok(())
 //! # }
 //! ```

--- a/merkle_tree/src/internal.rs
+++ b/merkle_tree/src/internal.rs
@@ -108,6 +108,8 @@ pub struct MerkleTreeCommitment<T: NodeValue> {
 }
 
 impl<T: NodeValue> MerkleTreeCommitment<T> {
+    /// Creates a new merkle tree commitment with the given digest, height and
+    /// number of leaves
     pub fn new(digest: T, height: usize, num_leaves: u64) -> Self {
         MerkleTreeCommitment {
             digest,

--- a/merkle_tree/src/lib.rs
+++ b/merkle_tree/src/lib.rs
@@ -31,7 +31,7 @@ pub mod universal_merkle_tree;
 pub(crate) mod internal;
 
 pub mod prelude;
-pub use crate::errors::MerkleTreeError;
+pub use crate::{errors::MerkleTreeError, internal::MerkleTreeCommitment};
 
 use self::internal::MerkleTreeIter;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};

--- a/merkle_tree/src/lib.rs
+++ b/merkle_tree/src/lib.rs
@@ -223,14 +223,14 @@ pub trait MerkleTreeScheme: Sized {
     ) -> LookupResult<&Self::Element, Self::MembershipProof, ()>;
 
     /// Verify an element is a leaf of a Merkle tree given the proof
-    /// * `root` - a merkle tree root, usually obtained from
-    ///   `Self::commitment().digest()`
+    /// * `commitment` - a merkle tree commitment, obtained from
+    ///   `Self::commitment()`
     /// * `pos` - zero-based index of the leaf in the tree
     /// * `proof` - a merkle tree proof
     /// * `returns` - Ok(true) if the proof is accepted, Ok(false) if not. Err()
     ///   if the proof is not well structured, E.g. not for this merkle tree.
     fn verify(
-        root: impl Borrow<Self::NodeValue>,
+        commitment: impl Borrow<Self::Commitment>,
         pos: impl Borrow<Self::Index>,
         proof: impl Borrow<Self::MembershipProof>,
     ) -> Result<VerificationResult, MerkleTreeError>;
@@ -337,12 +337,13 @@ pub trait UniversalMerkleTreeScheme: MerkleTreeScheme {
     ) -> LookupResult<&Self::Element, Self::MembershipProof, Self::NonMembershipProof>;
 
     /// Verify an index is not in this merkle tree
+    /// * `commitment` - a Merkle Commitment
     /// * `pos` - zero-based index of the leaf in the tree
     /// * `proof` - a merkle tree proof
     /// * `returns` - Ok(true) if the proof is accepted, Ok(false) if not. Err()
     ///   if the proof is not well structured, E.g. not for this merkle tree.
     fn non_membership_verify(
-        &self,
+        commitment: impl Borrow<Self::Commitment>,
         pos: impl Borrow<Self::Index>,
         proof: impl Borrow<Self::NonMembershipProof>,
     ) -> Result<bool, MerkleTreeError>;

--- a/merkle_tree/src/light_weight.rs
+++ b/merkle_tree/src/light_weight.rs
@@ -188,8 +188,9 @@ mod mt_tests {
         let (elem, proof) = mock_mt.lookup(0).expect_ok().unwrap();
         assert_eq!(elem, &F::from(3u64));
         assert_eq!(proof.tree_height(), 3);
+        let commitment = mt.commitment();
         assert!(
-            RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), 0, &proof)
+            RescueLightWeightMerkleTree::<F>::verify(&commitment, 0, &proof)
                 .unwrap()
                 .is_ok()
         );
@@ -206,7 +207,7 @@ mod mt_tests {
             unreachable!()
         }
 
-        let result = RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), 0, &bad_proof);
+        let result = RescueLightWeightMerkleTree::<F>::verify(&commitment, 0, &bad_proof);
         assert!(result.unwrap().is_err());
 
         let mut forge_proof = MerkleProof::new(2, proof.proof);
@@ -221,7 +222,7 @@ mod mt_tests {
         } else {
             unreachable!()
         }
-        let result = RescueLightWeightMerkleTree::<F>::verify(&mt.root.value(), 2, &forge_proof);
+        let result = RescueLightWeightMerkleTree::<F>::verify(&commitment, 2, &forge_proof);
         assert!(result.unwrap().is_err());
     }
 

--- a/merkle_tree/src/namespaced_merkle_tree/mod.rs
+++ b/merkle_tree/src/namespaced_merkle_tree/mod.rs
@@ -212,11 +212,11 @@ where
     }
 
     fn verify(
-        root: impl Borrow<Self::NodeValue>,
+        commitment: impl Borrow<Self::Commitment>,
         pos: impl Borrow<Self::Index>,
         proof: impl Borrow<Self::MembershipProof>,
     ) -> Result<VerificationResult, MerkleTreeError> {
-        <InnerTree<E, H, T, N, ARITY> as MerkleTreeScheme>::verify(root, pos, proof)
+        <InnerTree<E, H, T, N, ARITY> as MerkleTreeScheme>::verify(commitment, pos, proof)
     }
 
     fn iter(&self) -> MerkleTreeIter<Self::Element, Self::Index, Self::NodeValue> {

--- a/merkle_tree/tests/merkle_tree_hasher.rs
+++ b/merkle_tree/tests/merkle_tree_hasher.rs
@@ -1,6 +1,4 @@
-use jf_merkle_tree::{
-    errors::MerkleTreeError, hasher::HasherMerkleTree, MerkleCommitment, MerkleTreeScheme,
-};
+use jf_merkle_tree::{errors::MerkleTreeError, hasher::HasherMerkleTree, MerkleTreeScheme};
 use sha2::Sha256;
 
 #[test]
@@ -10,9 +8,8 @@ fn doctest_example() -> Result<(), MerkleTreeError> {
     // payload type is `usize`, hash function is `Sha256`.
     let mt = HasherMerkleTree::<Sha256, usize>::from_elems(Some(2), my_data)?;
 
-    let root = mt.commitment().digest();
     let (val, proof) = mt.lookup(2).expect_ok()?;
     assert_eq!(val, &3);
-    assert!(HasherMerkleTree::<Sha256, usize>::verify(root, 2, proof)?.is_ok());
+    assert!(HasherMerkleTree::<Sha256, usize>::verify(mt.commitment(), 2, proof)?.is_ok());
     Ok(())
 }

--- a/merkle_tree/tests/proptest_merkle.rs
+++ b/merkle_tree/tests/proptest_merkle.rs
@@ -415,8 +415,7 @@ fn test_verify_never_panics<const ARITY: usize>() {
         pos in 0u64..1000,
         proof in arbitrary_proof::<ARITY>(),
     )| {
-        let root = tree.commitment().digest();
-        let _ = TestUniversalMerkleTree::<ARITY>::verify(&root, &pos, &proof);
+        let _ = TestUniversalMerkleTree::<ARITY>::verify(tree.commitment(), &pos, &proof);
     });
 }
 
@@ -426,7 +425,7 @@ fn test_non_membership_verify_never_panics<const ARITY: usize>() {
         pos in 0u64..1000,
         proof in arbitrary_proof::<ARITY>(),
     )| {
-        let _ = tree.non_membership_verify(&pos, &proof);
+        let _ = TestUniversalMerkleTree::<ARITY>::non_membership_verify(tree.commitment(), &pos, &proof);
     });
 }
 
@@ -459,13 +458,13 @@ fn test_corrupted_membership_proofs_handled_safely<const ARITY: usize>() {
         // Skip test if tree is empty
         prop_assume!(!kvs.is_empty());
 
-        let root = tree.commitment().digest();
+        let commitment = tree.commitment();
 
         let (key, _) = &kvs[0];
         match tree.universal_lookup(key) {
             LookupResult::Ok(_, proof) => {
                 let corrupted_proof = corrupt_proof::<ARITY>(proof, corruption_type);
-                let _ = TestUniversalMerkleTree::<ARITY>::verify(&root, key, &corrupted_proof);
+                let _ = TestUniversalMerkleTree::<ARITY>::verify(commitment, key, &corrupted_proof);
             }
             _ => unreachable!()
         }
@@ -485,7 +484,7 @@ fn test_corrupted_non_membership_proofs_handled_safely<const ARITY: usize>() {
             match tree.universal_lookup(&candidate) {
                 LookupResult::NotFound(proof) => {
                     let corrupted_proof = corrupt_proof::<ARITY>(proof, corruption_type);
-                    let _ = tree.non_membership_verify(&candidate, &corrupted_proof);
+                    let _ = TestUniversalMerkleTree::<ARITY>::non_membership_verify(tree.commitment(), &candidate, &corrupted_proof);
                     found_non_member = true;
                     break;
                 }

--- a/vid/src/advz.rs
+++ b/vid/src/advz.rs
@@ -532,8 +532,23 @@ where
 
         // verify eval proof
         // TODO: check all indices that represents the shares
-        if KzgEvalsMerkleTree::<E, H>::verify(
+        // Create commitment with correct height from the proof
+        let proof_height = share
+            .evals_proof
+            .proof
+            .len()
+            .checked_sub(1)
+            .ok_or_else(|| VidError::Argument("Empty evals proof".to_string()))?;
+
+        // Create a commitment using the public API
+        let evals_commitment = jf_merkle_tree::MerkleTreeCommitment::new(
             common.all_evals_digest,
+            proof_height,
+            share.evals.len() as u64,
+        );
+
+        if KzgEvalsMerkleTree::<E, H>::verify(
+            &evals_commitment,
             &KzgEvalsMerkleTreeIndex::<E, H>::from(share.index as u64),
             &share.evals_proof,
         )


### PR DESCRIPTION
Closes: #805 


### This PR: 

- update the `MerkleTreeScheme` trait so that the `.verify()` function accept the commitment instead of digest root node, and we check the proof length against the `commitment.height()` to prevent extension 
- update the implementation and unit tests to use the new api
- update `vid` crate to use the new api

### This PR does not:

- [ ] tag a new version to both `jf-merkle-tree` and `jf-vid` + update CHANGELOG?

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`release-*`)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
