### PR TITLE
feat: upgrade from nimue to spongefish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Cargo.lock
 *.org
 .pre-commit-config.yaml
 .vscode
+.direnv
 
 # Test coverage (grcov)
 default.profraw

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rand_chacha = { version = "0.3.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = [ "derive", "rc", "alloc" ] }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
+spongefish = { git = "https://github.com/arkworks-rs/spongefish.git", rev = "3ded547f7f56d7f8a1fc4c9a5c0ce965310bba5f", features = ["arkworks-algebra"] }
 itertools = { version = "0.12", default-features = false }
 tagged-base64 = "0.4"
 zeroize = { version = "^1.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,21 @@
 [workspace]
-members = ["aead", "commitment", "crhf", "elgamal", "merkle_tree", "pcs", "plonk", "poseidon2", "prf", "relation", "rescue", "signature", "utilities", "vid", "vrf"]
+members = [
+    "aead",
+    "commitment",
+    "crhf",
+    "elgamal",
+    "merkle_tree",
+    "pcs",
+    "plonk",
+    "poseidon2",
+    "prf",
+    "relation",
+    "rescue",
+    "signature",
+    "utilities",
+    "vid",
+    "vrf",
+]
 resolver = "2"
 
 [workspace.package]
@@ -29,6 +45,7 @@ derivative = { version = "2", features = ["use_core"] }
 digest = { version = "0.10.7", default-features = false, features = [ "alloc" ] }
 displaydoc = { version = "0.2", default-features = false }
 hashbrown = "0.14.3"
+itertools = { version = "0.12", default-features = false }
 merlin = { version = "3.0.0", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
@@ -36,7 +53,6 @@ serde = { version = "1.0", default-features = false, features = [ "derive", "rc"
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 spongefish = { git = "https://github.com/arkworks-rs/spongefish.git", rev = "3ded547f7f56d7f8a1fc4c9a5c0ce965310bba5f", features = ["arkworks-algebra"] }
-itertools = { version = "0.12", default-features = false }
 tagged-base64 = "0.4"
 zeroize = { version = "^1.8" }
 

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -10,6 +10,10 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = []
+std = ["ark-serialize/std", "ark-std/std", "chacha20poly1305/std"]
+
 [dependencies]
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
@@ -26,7 +30,3 @@ serde = { workspace = true }
 bincode = "1.3"
 jf-utils = { path = "../utilities" }
 rand_chacha = { workspace = true }
-
-[features]
-default = []
-std = ["ark-serialize/std", "ark-std/std", "chacha20poly1305/std"]

--- a/aead/Cargo.toml
+++ b/aead/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true }
 
 [dev-dependencies]
 bincode = "1.3"
-jf-utils = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }
+jf-utils = { path = "../utilities" }
 rand_chacha = { workspace = true }
 
 [features]

--- a/aead/src/lib.rs
+++ b/aead/src/lib.rs
@@ -472,7 +472,7 @@ mod test {
             keypair,
             KeyPair::deserialize_compressed(&bytes[..]).unwrap()
         );
-        assert!(KeyPair::deserialize_compressed(&bytes[1..]).is_err());
+        assert!(KeyPair::deserialize_compressed(&bytes[..bytes.len() - 1]).is_err());
 
         let mut bytes = Vec::new();
         CanonicalSerialize::serialize_compressed(&ciphertext, &mut bytes).unwrap();
@@ -480,6 +480,6 @@ mod test {
             ciphertext,
             Ciphertext::deserialize_compressed(&bytes[..]).unwrap()
         );
-        assert!(Ciphertext::deserialize_compressed(&bytes[1..]).is_err());
+        assert!(Ciphertext::deserialize_compressed(&bytes[..bytes.len() - 1]).is_err());
     }
 }

--- a/elgamal/Cargo.toml
+++ b/elgamal/Cargo.toml
@@ -10,6 +10,19 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = [
+    "ark-ec/std",
+    "ark-ff/std",
+    "ark-serialize/std",
+    "ark-std/std",
+    "jf-rescue/std",
+    "zeroize/std",
+]
+gadgets = ["jf-relation", "jf-rescue/gadgets"]
+parallel = ["jf-relation/parallel", "jf-rescue/parallel", "rayon"]
+
 [dependencies]
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
@@ -32,12 +45,3 @@ ark-ed-on-bls12-381-bandersnatch = { workspace = true }
 ark-ed-on-bn254 = { workspace = true }
 # temporarily using path: jf-utils = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5" }
 jf-utils = { path = "../utilities" }
-
-[features]
-default = ["parallel"]
-std = [
-    "ark-ec/std", "ark-ff/std", "ark-serialize/std", "ark-std/std",
-    "jf-rescue/std", "zeroize/std",
-]
-gadgets = ["jf-relation", "jf-rescue/gadgets"]
-parallel = ["jf-relation/parallel", "jf-rescue/parallel", "rayon"]

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746232882,
-        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1757239681,
+        "narHash": "sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "ab82ab08d6bf74085bd328de2a8722c12d97bd9d",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1746239644,
-        "narHash": "sha256-wMvMBMlpS1H8CQdSSgpLeoCWS67ciEkN/GVCcwk7Apc=",
+        "lastModified": 1757298987,
+        "narHash": "sha256-yuFSw6fpfjPtVMmym51ozHYpJQ7SzVOTkk7tUv2JA0U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bd32e88bef6da0e021a42fb4120a8df2150e9b8c",
+        "rev": "cfd63776bde44438ff2936f0c9194c79dd407a5f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -64,8 +64,7 @@
               llvm_15
               typos
               # grcov # TODO uncomment this line after https://github.com/mozilla/grcov/issues/1187#issuecomment-2252214718
-            ] ++ lib.optionals stdenv.isDarwin
-              [ darwin.apple_sdk.frameworks.Security ];
+            ];
 
             CARGO_TARGET_DIR = "target/nix_rustc";
 
@@ -88,11 +87,10 @@
               # by default choose u64_backend
               export RUSTFLAGS='--cfg curve25519_dalek_backend="u64"'
             ''
-            # install pre-commit hooks
-            + self.check.${system}.pre-commit-check.shellHook;
+              # install pre-commit hooks
+              + self.check.${system}.pre-commit-check.shellHook;
           };
-      in
-      with pkgs; {
+      in with pkgs; {
         check = {
           pre-commit-check = pre-commit-hooks.lib.${system}.run {
             src = ./.;
@@ -144,7 +142,6 @@
                 ++ [ cmake cudatoolkit util-linux gcc11 ];
               # CXX is overridden to use gcc as icicle-curves's build scripts need them
               shellHook = oldAttrs.shellHook + ''
-
                 export PATH="${pkgs.gcc11}/bin:${cudatoolkit}/bin:${cudatoolkit}/nvvm/bin:$PATH"
                 export LD_LIBRARY_PATH=${cudatoolkit}/lib
                 export CUDA_PATH=${cudatoolkit}

--- a/merkle_tree/Cargo.toml
+++ b/merkle_tree/Cargo.toml
@@ -10,6 +10,25 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = [
+    "ark-bls12-377/std",
+    "ark-bls12-381/std",
+    "ark-bn254/std",
+    "ark-std/std",
+    "ark-serialize/std",
+    "ark-ff/std",
+    "num-bigint/std",
+    "num-traits/std",
+    "sha3/std",
+    "itertools/use_std",
+    "jf-utils/std",
+    "jf-relation/std",
+]
+gadgets = ["jf-relation", "jf-rescue/gadgets"]
+parallel = ["jf-rescue/parallel", "jf-relation/parallel", "jf-utils/parallel"]
+
 [dependencies]
 ark-bls12-377 = { workspace = true }
 ark-bls12-381 = { workspace = true }
@@ -55,24 +74,3 @@ sha2 = "0.10"
 [[bench]]
 name = "merkle_path"
 harness = false
-
-[features]
-default = ["parallel"]
-std = [
-        "ark-bls12-377/std",
-        "ark-bls12-381/std",
-        "ark-bn254/std",
-        "ark-std/std",
-        "ark-serialize/std",
-        "ark-ff/std",
-        "num-bigint/std",
-        "num-traits/std",
-        "sha3/std",
-        "itertools/use_std",
-        "jf-utils/std",
-        "jf-relation/std",
-]
-gadgets = [
-    "jf-relation", "jf-rescue/gadgets",
-]
-parallel = ["jf-rescue/parallel", "jf-relation/parallel", "jf-utils/parallel"]

--- a/merkle_tree/Cargo.toml
+++ b/merkle_tree/Cargo.toml
@@ -24,22 +24,22 @@ displaydoc = { workspace = true }
 hashbrown = { workspace = true }
 hex = "0.4.3"
 itertools = { workspace = true, features = ["use_alloc"] }
-# temporarily by path
-# jf-crhf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf-crhf-v0.1.1" }
-# TODO: pin to an updated version/tag next time we release a tag
-# jf-poseidon2 = { path = "../poseidon2" }
 # jf-relation = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", optional = true, default-features = false }
 # jf-rescue = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 # jf-utils = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 jf-crhf = { path = "../crhf" }
+# temporarily by path
+# jf-crhf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf-crhf-v0.1.1" }
+# TODO: pin to an updated version/tag next time we release a tag
+jf-poseidon2 = { path = "../poseidon2" }
 jf-relation = { path = "../relation", optional = true }
 jf-rescue = { path = "../rescue" }
 jf-utils = { path = "../utilities" }
-# temporarily removed, only used for poseidon2: nimue = { version = "=0.1.1", features = ["ark"] }
 num-bigint = { workspace = true }
 num-traits = { version = "0.2.15", default-features = false }
 serde = { workspace = true }
 sha3 = { workspace = true }
+spongefish = { workspace = true }
 tagged-base64 = { workspace = true }
 
 [dev-dependencies]

--- a/merkle_tree/src/errors.rs
+++ b/merkle_tree/src/errors.rs
@@ -7,7 +7,7 @@
 
 use ark_std::string::String;
 use displaydoc::Display;
-// use jf_poseidon2::Poseidon2Error;
+use jf_poseidon2::Poseidon2Error;
 use jf_rescue::RescueError;
 
 /// Error type for Merkle tree
@@ -37,8 +37,8 @@ impl From<RescueError> for MerkleTreeError {
     }
 }
 
-// impl From<Poseidon2Error> for MerkleTreeError {
-//     fn from(err: Poseidon2Error) -> Self {
-//         MerkleTreeError::DigestError(ark_std::format!("{}", err))
-//     }
-// }
+impl From<Poseidon2Error> for MerkleTreeError {
+    fn from(err: Poseidon2Error) -> Self {
+        MerkleTreeError::DigestError(ark_std::format!("{}", err))
+    }
+}

--- a/merkle_tree/src/prelude.rs
+++ b/merkle_tree/src/prelude.rs
@@ -25,12 +25,12 @@ use ark_serialize::{
 };
 use ark_std::{fmt, marker::PhantomData, string::ToString, vec, vec::Vec};
 use jf_crhf::CRHF;
-// use jf_poseidon2::{
-//     crhf::FixedLenPoseidon2Hash, sponge::Poseidon2Sponge, Poseidon2,
-// Poseidon2Params, };
+use jf_poseidon2::{
+    crhf::FixedLenPoseidon2Hash, sponge::Poseidon2Sponge, Poseidon2, Poseidon2Params,
+};
 use jf_rescue::{crhf::RescueCRHF, RescueParameter};
-// use nimue::hash::sponge::Sponge;
 use sha3::{Digest, Keccak256, Sha3_256};
+use spongefish::{duplex_sponge::Permutation, Unit};
 
 /// Wrapper for rescue hash function
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -78,33 +78,33 @@ pub type RescueSparseMerkleTree<I, F> = UniversalMerkleTree<F, RescueHash<F>, I,
 // Make `FixedLenPoseidon2Hash<F, S, INPUT_SIZE, 1>` usable as Merkle tree hash
 // for arity INPUT_SIZE - 1. The first input element is used for the domain
 // separation.
-// impl<I, F, S, const INPUT_SIZE: usize> DigestAlgorithm<F, I, F>
-//     for FixedLenPoseidon2Hash<F, S, INPUT_SIZE, 1>
-// where
-//     I: Index,
-//     F: PrimeField + From<I> + nimue::Unit,
-//     S: Sponge<U = F> + Poseidon2Sponge,
-// {
-//     fn digest(data: &[F]) -> Result<F, MerkleTreeError> {
-//         let mut input = vec![internal_hash_dom_sep()];
-//         input.extend(data.iter());
-//         Ok(FixedLenPoseidon2Hash::<F, S, INPUT_SIZE, 1>::evaluate(input)?[0])
-//     }
+impl<I, F, S, const INPUT_SIZE: usize> DigestAlgorithm<F, I, F>
+    for FixedLenPoseidon2Hash<F, S, INPUT_SIZE, 1>
+where
+    I: Index,
+    F: PrimeField + From<I> + Unit,
+    S: Permutation<U = F> + Poseidon2Sponge,
+{
+    fn digest(data: &[F]) -> Result<F, MerkleTreeError> {
+        let mut input = vec![internal_hash_dom_sep()];
+        input.extend(data.iter());
+        Ok(FixedLenPoseidon2Hash::<F, S, INPUT_SIZE, 1>::evaluate(input)?[0])
+    }
 
-//     fn digest_leaf(pos: &I, elem: &F) -> Result<F, MerkleTreeError> {
-//         if INPUT_SIZE < 3 {
-//             return Err(MerkleTreeError::ParametersError(ark_std::format!(
-//                 "INPUT_SIZE {} too short",
-//                 INPUT_SIZE
-//             )));
-//         }
-//         let mut input = vec![F::zero(); INPUT_SIZE];
-//         input[0] = leaf_hash_dom_sep();
-//         input[INPUT_SIZE - 2] = F::from(pos.clone());
-//         input[INPUT_SIZE - 1] = *elem;
-//         Ok(FixedLenPoseidon2Hash::<F, S, INPUT_SIZE, 1>::evaluate(input)?[0])
-//     }
-// }
+    fn digest_leaf(pos: &I, elem: &F) -> Result<F, MerkleTreeError> {
+        if INPUT_SIZE < 3 {
+            return Err(MerkleTreeError::ParametersError(ark_std::format!(
+                "INPUT_SIZE {} too short",
+                INPUT_SIZE
+            )));
+        }
+        let mut input = vec![F::zero(); INPUT_SIZE];
+        input[0] = leaf_hash_dom_sep();
+        input[INPUT_SIZE - 2] = F::from(pos.clone());
+        input[INPUT_SIZE - 1] = *elem;
+        Ok(FixedLenPoseidon2Hash::<F, S, INPUT_SIZE, 1>::evaluate(input)?[0])
+    }
+}
 
 /// Implement Internal node type and implement DigestAlgorithm for a hash
 /// function with 32 bytes output size

--- a/pcs/Cargo.toml
+++ b/pcs/Cargo.toml
@@ -10,6 +10,30 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = [
+    "ark-bls12-381/std",
+    "ark-std/std",
+    "ark-serialize/std",
+    "ark-ff/std",
+    "ark-ec/std",
+    "ark-poly/std",
+    "merlin/std",
+    "itertools/use_std",
+    "jf-utils/std",
+]
+test-srs = []
+parallel = ["ark-ff/parallel", "ark-ec/parallel", "jf-utils/parallel", "rayon"]
+icicle = [
+    "anyhow",
+    "ark-bn254",
+    "icicle-cuda-runtime",
+    "icicle-core",
+    "icicle-bn254",
+    "parallel",
+]
+
 [dependencies]
 anyhow = { version = "1.0", optional = true }
 ark-bn254 = { workspace = true, optional = true }
@@ -50,20 +74,3 @@ name = "kzg-gpu"
 path = "benches/kzg_gpu.rs"
 harness = false
 required-features = ["test-srs", "icicle"]
-
-[features]
-default = ["parallel"]
-std = [
-    "ark-bls12-381/std", "ark-std/std", "ark-serialize/std", 
-    "ark-ff/std", "ark-ec/std", "ark-poly/std", "merlin/std", 
-    "itertools/use_std", "jf-utils/std",
-]
-test-srs = []
-parallel = [
-    "ark-ff/parallel", "ark-ec/parallel", "jf-utils/parallel",
-    "rayon",
-]
-icicle = [
-    "anyhow", "ark-bn254", "icicle-cuda-runtime", "icicle-core",
-    "icicle-bn254", "parallel",
-]

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -7,6 +7,37 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = [
+    "ark-std/std",
+    "ark-serialize/std",
+    "ark-ff/std",
+    "ark-ec/std",
+    "ark-poly/std",
+    "downcast-rs/std",
+    "itertools/use_std",
+    "jf-relation/std",
+    "jf-utils/std",
+    "jf-rescue/std",
+    "merlin/std",
+    "num-bigint/std",
+    "rand_chacha/std",
+    "sha3/std",
+]
+test-apis = [] # exposing apis for testing purpose
+parallel = [
+    "ark-ff/parallel",
+    "ark-ec/parallel",
+    "ark-poly/parallel",
+    "jf-utils/parallel",
+    "jf-pcs/parallel",
+    "jf-relation/parallel",
+    "jf-rescue/parallel",
+    "dep:rayon",
+]
+test-srs = []
+
 [dependencies]
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
@@ -55,37 +86,6 @@ name = "plonk-benches"
 path = "benches/bench.rs"
 harness = false
 required-features = ["test-srs"]
-
-[features]
-default = ["parallel"]
-std = [
-    "ark-std/std",
-    "ark-serialize/std",
-    "ark-ff/std",
-    "ark-ec/std",
-    "ark-poly/std",
-    "downcast-rs/std",
-    "itertools/use_std",
-    "jf-relation/std",
-    "jf-utils/std",
-    "jf-rescue/std",
-    "merlin/std",
-    "num-bigint/std",
-    "rand_chacha/std",
-    "sha3/std",
-]
-test-apis = [] # exposing apis for testing purpose
-parallel = [
-    "ark-ff/parallel",
-    "ark-ec/parallel",
-    "ark-poly/parallel",
-    "jf-utils/parallel",
-    "jf-pcs/parallel",
-    "jf-relation/parallel",
-    "jf-rescue/parallel",
-    "dep:rayon",
-]
-test-srs = []
 
 [[example]]
 name = "proof-of-exp"

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -11,15 +11,15 @@ documentation = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-ark-bls12-381 = { version = "0.4", optional = true }
-ark-bn254 = { version = "0.4", optional = true }
-ark-ff = "0.4"
-ark-std = "0.4"
+ark-bls12-381 = { workspace = true, optional = true }
+ark-bn254 = { workspace = true, optional = true }
+ark-ff = { workspace = true }
+ark-std = { workspace = true }
 displaydoc = { workspace = true }
 hex = "0.4.3"
-jf-crhf = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf-crhf-v0.1.1" }
+jf-crhf = { path = "../crhf" }
+spongefish = { workspace = true }
 lazy_static = "1.5.0"
-nimue = { version = "=0.1.1", features = ["ark"] }
 zeroize = { workspace = true }
 
 [dev-dependencies]

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -18,8 +18,8 @@ ark-std = { workspace = true }
 displaydoc = { workspace = true }
 hex = "0.4.3"
 jf-crhf = { path = "../crhf" }
-spongefish = { workspace = true }
 lazy_static = "1.5.0"
+spongefish = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -10,6 +10,12 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["bls12-381", "bn254"]
+# curve-named features contains constants for scalar fields of that curve
+bls12-381 = ["dep:ark-bls12-381"]
+bn254 = ["dep:ark-bn254"]
+
 [dependencies]
 ark-bls12-381 = { workspace = true, optional = true }
 ark-bn254 = { workspace = true, optional = true }
@@ -24,12 +30,6 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
-
-[features]
-default = ["bls12-381", "bn254"]
-# curve-named features contains constants for scalar fields of that curve
-bls12-381 = ["dep:ark-bls12-381"]
-bn254 = ["dep:ark-bn254"]
 
 [[bench]]
 name = "p2_native"

--- a/poseidon2/src/crhf.rs
+++ b/poseidon2/src/crhf.rs
@@ -5,9 +5,10 @@ use core::marker::PhantomData;
 use ark_ff::{Field, PrimeField};
 use ark_std::{borrow::Borrow, string::ToString, vec::Vec};
 use jf_crhf::CRHF;
-use nimue::{
-    hash::sponge::{DuplexSponge, Sponge},
-    DuplexHash, Unit,
+use spongefish::{
+    duplex_sponge::{DuplexSponge, Permutation},
+    DuplexSpongeInterface,
+    Unit,
 };
 
 use crate::{sponge::Poseidon2Sponge, Poseidon2Error};
@@ -22,7 +23,7 @@ use crate::{sponge::Poseidon2Sponge, Poseidon2Error};
 pub struct FixedLenPoseidon2Hash<F, S, const INPUT_SIZE: usize, const OUTPUT_SIZE: usize>
 where
     F: PrimeField + Unit,
-    S: Sponge<U = F> + Poseidon2Sponge,
+    S: Permutation<U = F> + Poseidon2Sponge,
 {
     _field: PhantomData<F>,
     _sponge: PhantomData<S>,
@@ -31,7 +32,7 @@ where
 impl<F, S, const IN: usize, const OUT: usize> CRHF for FixedLenPoseidon2Hash<F, S, IN, OUT>
 where
     F: PrimeField + Unit,
-    S: Sponge<U = F> + Poseidon2Sponge,
+    S: Permutation<U = F> + Poseidon2Sponge,
 {
     type Input = [F]; // length should be <= IN
     type Output = [F; OUT];
@@ -60,7 +61,7 @@ where
 pub struct VariableLenPoseidon2Hash<F, S, const OUTPUT_SIZE: usize>
 where
     F: PrimeField + Unit,
-    S: Sponge<U = F>,
+    S: Permutation<U = F>,
 {
     _field: PhantomData<F>,
     _sponge: PhantomData<S>,
@@ -69,7 +70,7 @@ where
 impl<F, S, const OUT: usize> CRHF for VariableLenPoseidon2Hash<F, S, OUT>
 where
     F: PrimeField + Unit,
-    S: Sponge<U = F>,
+    S: Permutation<U = F>,
 {
     type Input = [F];
     type Output = [F; OUT];

--- a/poseidon2/src/crhf.rs
+++ b/poseidon2/src/crhf.rs
@@ -7,8 +7,7 @@ use ark_std::{borrow::Borrow, string::ToString, vec::Vec};
 use jf_crhf::CRHF;
 use spongefish::{
     duplex_sponge::{DuplexSponge, Permutation},
-    DuplexSpongeInterface,
-    Unit,
+    DuplexSpongeInterface, Unit,
 };
 
 use crate::{sponge::Poseidon2Sponge, Poseidon2Error};

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -27,6 +27,7 @@ pub mod constants;
 pub mod crhf;
 mod external;
 mod internal;
+pub mod permutation;
 pub mod sponge;
 
 /// Parameters required for a Poseidon2 permutation instance.

--- a/poseidon2/src/permutation.rs
+++ b/poseidon2/src/permutation.rs
@@ -1,0 +1,90 @@
+//! Poseidon2 permutation implementation for spongefish
+
+use crate::{Poseidon2, Poseidon2Params};
+use ark_ff::PrimeField;
+use ark_std::marker::PhantomData;
+use spongefish::duplex_sponge::Permutation;
+use spongefish::Unit;
+use zeroize::Zeroize;
+
+/// A Poseidon2 permutation adaptor for spongefish
+/// 
+/// This struct maintains the sponge state and implements the Permutation trait
+/// required by spongefish's DuplexSponge.
+#[derive(Debug, Clone)]
+pub struct Poseidon2PermutationState<
+    F: PrimeField + Unit,
+    const N: usize,
+    const R: usize,
+    P: Poseidon2Params<F, N>,
+> {
+    /// Internal state of the sponge
+    pub state: [F; N],
+    _params: PhantomData<P>,
+}
+
+impl<F: PrimeField + Unit, const N: usize, const R: usize, P: Poseidon2Params<F, N>> Default
+    for Poseidon2PermutationState<F, N, R, P>
+{
+    fn default() -> Self {
+        Self {
+            state: [F::default(); N],
+            _params: PhantomData,
+        }
+    }
+}
+
+impl<F: PrimeField + Unit, const N: usize, const R: usize, P: Poseidon2Params<F, N>>
+    Permutation for Poseidon2PermutationState<F, N, R, P>
+{
+    type U = F;
+    const N: usize = N;
+    const R: usize = R;
+
+    fn new(iv: [u8; 32]) -> Self {
+        assert!(N >= 2 && R > 0 && N > R);
+        // For security, for b-bit security, field size |F|, C*|F|>=2b:
+        // at least 100 security required
+        assert!((N - R) as u32 * <F as PrimeField>::MODULUS_BIT_SIZE >= 200);
+
+        // fill capacity portion with initial vector IV
+        let mut state = [F::default(); N];
+        state[R] = F::from_be_bytes_mod_order(&iv);
+        Self {
+            state,
+            _params: PhantomData,
+        }
+    }
+
+    fn permute(&mut self) {
+        Poseidon2::permute_mut::<P, N>(&mut self.state);
+    }
+}
+
+impl<F: PrimeField + Unit, const N: usize, const R: usize, P: Poseidon2Params<F, N>> AsRef<[F]>
+    for Poseidon2PermutationState<F, N, R, P>
+{
+    fn as_ref(&self) -> &[F] {
+        &self.state
+    }
+}
+
+impl<F: PrimeField + Unit, const N: usize, const R: usize, P: Poseidon2Params<F, N>> AsMut<[F]>
+    for Poseidon2PermutationState<F, N, R, P>
+{
+    fn as_mut(&mut self) -> &mut [F] {
+        &mut self.state
+    }
+}
+
+impl<F: PrimeField + Unit, const N: usize, const R: usize, P: Poseidon2Params<F, N>> Zeroize
+    for Poseidon2PermutationState<F, N, R, P>
+{
+    fn zeroize(&mut self) {
+        self.state.zeroize();
+    }
+}
+
+/// Convenience type alias for Poseidon2 permutation state
+pub type Poseidon2Perm<F, const N: usize, const R: usize, P> =
+    Poseidon2PermutationState<F, N, R, P>;

--- a/poseidon2/src/sponge.rs
+++ b/poseidon2/src/sponge.rs
@@ -83,8 +83,6 @@ pub(crate) mod tests {
     use ark_std::vec::Vec;
     use spongefish::codecs::arkworks_algebra::*;
 
-    // inspired by:
-    // <https://github.com/arkworks-rs/nimue/blob/bdec8c446b804930a8375a8d2a3703a6071abf6b/nimue-poseidon/src/tests.rs#L16C4-L16C44>
     pub(crate) fn test_sponge<F: PrimeField + Unit, H: DuplexSpongeInterface<F>>() {
         let io = DomainSeparator::<H, F>::new("test")
             .absorb(1, "in")

--- a/poseidon2/src/sponge.rs
+++ b/poseidon2/src/sponge.rs
@@ -1,17 +1,17 @@
 //! Poseidon2-based Cryptographic Sponge
+//!
+//! This module provides clean type aliases following the spongefish-poseidon
+//! pattern.
 
-use crate::{permutation::Poseidon2PermutationState, Poseidon2Params};
+use crate::{permutation::Poseidon2Permutation, Poseidon2Params};
 use ark_ff::PrimeField;
 use spongefish::Unit;
 
 /// Marker trait for the state of Poseidon2-based Cryptographic Sponge
 pub trait Poseidon2Sponge {}
 
-// Re-export the main types for convenience
-pub use crate::permutation::Poseidon2PermutationState as Poseidon2SpongeState;
-
 /// Implement the marker trait for our permutation state
-impl<F, const N: usize, const R: usize, P> Poseidon2Sponge for Poseidon2PermutationState<F, N, R, P>
+impl<F, const N: usize, const R: usize, P> Poseidon2Sponge for Poseidon2Permutation<F, N, R, P>
 where
     F: PrimeField + Unit,
     P: Poseidon2Params<F, N>,
@@ -27,19 +27,19 @@ pub mod bls12_381 {
     use ark_bls12_381::Fr;
     use spongefish::duplex_sponge::DuplexSponge;
     /// State of a sponge over BLS12-381 scalar field, state_size=2, rate=1.
-    pub type Poseidon2SpongeStateBlsN2R1 = Poseidon2SpongeState<Fr, 2, 1, Poseidon2ParamsBls2>;
+    pub type Poseidon2PermutationBlsN2R1 = Poseidon2Permutation<Fr, 2, 1, Poseidon2ParamsBls2>;
     /// A sponge over BLS12-381 scalar field, state_size=2, rate=1.
-    pub type Poseidon2SpongeBlsN2R1 = DuplexSponge<Poseidon2SpongeStateBlsN2R1>;
+    pub type Poseidon2SpongeBlsN2R1 = DuplexSponge<Poseidon2PermutationBlsN2R1>;
 
     /// State of a sponge over BLS12-381 scalar field, state_size=3, rate=1.
-    pub type Poseidon2SpongeStateBlsN3R1 = Poseidon2SpongeState<Fr, 3, 1, Poseidon2ParamsBls3>;
+    pub type Poseidon2PermutationBlsN3R1 = Poseidon2Permutation<Fr, 3, 1, Poseidon2ParamsBls3>;
     /// A sponge over BLS12-381 scalar field, state_size=3, rate=1.
-    pub type Poseidon2SpongeBlsN3R1 = DuplexSponge<Poseidon2SpongeStateBlsN3R1>;
+    pub type Poseidon2SpongeBlsN3R1 = DuplexSponge<Poseidon2PermutationBlsN3R1>;
 
     /// State of a sponge over BLS12-381 scalar field, state_size=3, rate=2.
-    pub type Poseidon2SpongeStateBlsN3R2 = Poseidon2SpongeState<Fr, 3, 2, Poseidon2ParamsBls3>;
+    pub type Poseidon2PermutationBlsN3R2 = Poseidon2Permutation<Fr, 3, 2, Poseidon2ParamsBls3>;
     /// A sponge over BLS12-381 scalar field, state_size=3, rate=2.
-    pub type Poseidon2SpongeBlsN3R2 = DuplexSponge<Poseidon2SpongeStateBlsN3R2>;
+    pub type Poseidon2SpongeBlsN3R2 = DuplexSponge<Poseidon2PermutationBlsN3R2>;
 
     #[test]
     fn test_bls_sponge() {
@@ -59,14 +59,14 @@ pub mod bn254 {
     use ark_bn254::Fr;
     use spongefish::duplex_sponge::DuplexSponge;
     /// State of a sponge over BN254 scalar field, state_size=3, rate=1.
-    pub type Poseidon2SpongeStateBnN3R1 = Poseidon2SpongeState<Fr, 3, 1, Poseidon2ParamsBn3>;
+    pub type Poseidon2PermutationBnN3R1 = Poseidon2Permutation<Fr, 3, 1, Poseidon2ParamsBn3>;
     /// A sponge over BN254 scalar field, state_size=3, rate=1.
-    pub type Poseidon2SpongeBnN3R1 = DuplexSponge<Poseidon2SpongeStateBnN3R1>;
+    pub type Poseidon2SpongeBnN3R1 = DuplexSponge<Poseidon2PermutationBnN3R1>;
 
     /// State of a sponge over BN254 scalar field, state_size=3, rate=2.
-    pub type Poseidon2SpongeStateBnN3R2 = Poseidon2SpongeState<Fr, 3, 2, Poseidon2ParamsBn3>;
+    pub type Poseidon2PermutationBnN3R2 = Poseidon2Permutation<Fr, 3, 2, Poseidon2ParamsBn3>;
     /// A sponge over BN254 scalar field, state_size=3, rate=2.
-    pub type Poseidon2SpongeBnN3R2 = DuplexSponge<Poseidon2SpongeStateBnN3R2>;
+    pub type Poseidon2SpongeBnN3R2 = DuplexSponge<Poseidon2PermutationBnN3R2>;
 
     #[test]
     fn test_bn_sponge() {

--- a/poseidon2/src/sponge.rs
+++ b/poseidon2/src/sponge.rs
@@ -1,125 +1,31 @@
 //! Poseidon2-based Cryptographic Sponge
 
-use crate::{Poseidon2, Poseidon2Params};
+use crate::{permutation::Poseidon2PermutationState, Poseidon2Params};
 use ark_ff::PrimeField;
-use ark_std::marker::PhantomData;
-use nimue::{hash::sponge::Sponge, Unit};
-use zeroize::Zeroize;
+use spongefish::Unit;
 
 /// Marker trait for the state of Poseidon2-based Cryptographic Sponge
 pub trait Poseidon2Sponge {}
-impl<F, const N: usize, const R: usize, P> Poseidon2Sponge for Poseidon2SpongeState<F, N, R, P>
-where
-    F: PrimeField,
-    P: Poseidon2Params<F, N>,
-{
-}
 
-/// the state of Poseidon2-based Cryptographic Sponge
-///
-/// # Generic parameters:
-/// - N: state size = rate (R) + capacity (C)
-/// - R: rate (number of field absorbed/squeezed)
-///
-/// For security, for b=128-bit security, field size |F|, C*|F|>=2b:
-/// i.e. 128-bit for 256-bit fields, C>=1.
-/// This check is being down during `Poseidon2SpongeState::new(&iv)`
-/// (See Poseidon2 paper Page 7 Footnote 5)
-///
-/// For BLS12-381, we choose C=1 for 128 security
-/// For BN254, we choose C=1 for (100<*<128)-security
-#[derive(Clone, Debug)]
-pub struct Poseidon2SpongeState<
-    F: PrimeField,
-    const N: usize,
-    const R: usize,
-    P: Poseidon2Params<F, N>,
-> {
-    /// state of sponge
-    pub(crate) state: [F; N],
-    _rate: PhantomData<[(); R]>,
-    _p: PhantomData<P>,
-}
+// Re-export the main types for convenience
+pub use crate::permutation::Poseidon2PermutationState as Poseidon2SpongeState;
 
-impl<F, const N: usize, const R: usize, P> Sponge for Poseidon2SpongeState<F, N, R, P>
+/// Implement the marker trait for our permutation state
+impl<F, const N: usize, const R: usize, P> Poseidon2Sponge for Poseidon2PermutationState<F, N, R, P>
 where
     F: PrimeField + Unit,
     P: Poseidon2Params<F, N>,
 {
-    type U = F;
-    const N: usize = N;
-    const R: usize = R;
-
-    fn new(iv: [u8; 32]) -> Self {
-        assert!(N >= 2 && R > 0 && N > R);
-        // For security, for b-bit security, field size |F|, C*|F|>=2b:
-        // at least 100 security required
-        assert!((N - R) as u32 * <F as PrimeField>::MODULUS_BIT_SIZE >= 200);
-
-        // fill capacity portion with initial vector IV
-        let mut state = [F::default(); N];
-        state[R] = F::from_be_bytes_mod_order(&iv);
-        Self {
-            state,
-            _rate: PhantomData,
-            _p: PhantomData,
-        }
-    }
-
-    fn permute(&mut self) {
-        Poseidon2::permute_mut::<P, N>(&mut self.state);
-    }
-}
-impl<F, const N: usize, const R: usize, P> Default for Poseidon2SpongeState<F, N, R, P>
-where
-    F: PrimeField,
-    P: Poseidon2Params<F, N>,
-{
-    fn default() -> Self {
-        Self {
-            state: [F::default(); N],
-            _rate: PhantomData,
-            _p: PhantomData,
-        }
-    }
-}
-
-impl<F, const N: usize, const R: usize, P> AsRef<[F]> for Poseidon2SpongeState<F, N, R, P>
-where
-    F: PrimeField,
-    P: Poseidon2Params<F, N>,
-{
-    fn as_ref(&self) -> &[F] {
-        &self.state
-    }
-}
-impl<F, const N: usize, const R: usize, P> AsMut<[F]> for Poseidon2SpongeState<F, N, R, P>
-where
-    F: PrimeField,
-    P: Poseidon2Params<F, N>,
-{
-    fn as_mut(&mut self) -> &mut [F] {
-        &mut self.state
-    }
-}
-
-impl<F, const N: usize, const R: usize, P> Zeroize for Poseidon2SpongeState<F, N, R, P>
-where
-    F: PrimeField,
-    P: Poseidon2Params<F, N>,
-{
-    fn zeroize(&mut self) {
-        self.state.zeroize();
-    }
 }
 
 #[cfg(feature = "bls12-381")]
-mod bls12_381 {
+/// Poseidon2 sponge types for BLS12-381 scalar field
+pub mod bls12_381 {
     #![allow(dead_code)]
     use super::*;
     use crate::constants::bls12_381::*;
     use ark_bls12_381::Fr;
-    use nimue::hash::sponge::DuplexSponge;
+    use spongefish::duplex_sponge::DuplexSponge;
     /// State of a sponge over BLS12-381 scalar field, state_size=2, rate=1.
     pub type Poseidon2SpongeStateBlsN2R1 = Poseidon2SpongeState<Fr, 2, 1, Poseidon2ParamsBls2>;
     /// A sponge over BLS12-381 scalar field, state_size=2, rate=1.
@@ -145,12 +51,13 @@ mod bls12_381 {
 }
 
 #[cfg(feature = "bn254")]
-mod bn254 {
+/// Poseidon2 sponge types for BN254 scalar field
+pub mod bn254 {
     #![allow(dead_code)]
     use super::*;
     use crate::constants::bn254::*;
     use ark_bn254::Fr;
-    use nimue::hash::sponge::DuplexSponge;
+    use spongefish::duplex_sponge::DuplexSponge;
     /// State of a sponge over BN254 scalar field, state_size=3, rate=1.
     pub type Poseidon2SpongeStateBnN3R1 = Poseidon2SpongeState<Fr, 3, 1, Poseidon2ParamsBn3>;
     /// A sponge over BN254 scalar field, state_size=3, rate=1.
@@ -174,17 +81,17 @@ pub(crate) mod tests {
     use super::*;
     use ark_ff::BigInteger;
     use ark_std::vec::Vec;
-    use nimue::{DuplexHash, IOPattern, UnitTranscript};
+    use spongefish::codecs::arkworks_algebra::*;
 
     // inspired by:
     // <https://github.com/arkworks-rs/nimue/blob/bdec8c446b804930a8375a8d2a3703a6071abf6b/nimue-poseidon/src/tests.rs#L16C4-L16C44>
-    pub(crate) fn test_sponge<F: PrimeField + Unit, H: DuplexHash<F>>() {
-        let io = IOPattern::<H, F>::new("test")
+    pub(crate) fn test_sponge<F: PrimeField + Unit, H: DuplexSpongeInterface<F>>() {
+        let io = DomainSeparator::<H, F>::new("test")
             .absorb(1, "in")
             .squeeze(2048, "out");
 
         // prover transcript
-        let mut merlin = io.to_merlin();
+        let mut merlin = io.to_prover_state();
         // prover first message (label: "in")
         merlin.add_units(&[F::from(42u32)]).unwrap();
 
@@ -192,7 +99,7 @@ pub(crate) mod tests {
         merlin.fill_challenge_units(&mut merlin_challenges).unwrap();
 
         // verifier transcript
-        let mut arthur = io.to_arthur(merlin.transcript());
+        let mut arthur = io.to_verifier_state(merlin.narg_string());
         // reading prover's first message labelled "in", since we don't need it, read
         // into a one-time throw-away array
         arthur.fill_next_units(&mut [F::default()]).unwrap();

--- a/prf/Cargo.toml
+++ b/prf/Cargo.toml
@@ -9,12 +9,12 @@ rust-version = { workspace = true }
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
+
+[features]
+default = []
+std = ["ark-std/std", "ark-serialize/std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
-
-[features]
-default = []
-std = ["ark-std/std", "ark-serialize/std"]

--- a/relation/Cargo.toml
+++ b/relation/Cargo.toml
@@ -7,6 +7,31 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = [
+    "ark-bls12-377/std",
+    "ark-bls12-381/std",
+    "ark-bn254/std",
+    "ark-bw6-761/std",
+    "ark-std/std",
+    "ark-serialize/std",
+    "ark-ff/std",
+    "ark-ec/std",
+    "ark-poly/std",
+    "downcast-rs/std",
+    "jf-utils/std",
+    "num-bigint/std",
+    "rand_chacha/std",
+]
+parallel = [
+    "ark-ff/parallel",
+    "ark-ec/parallel",
+    "ark-poly/parallel",
+    "jf-utils/parallel",
+    "dep:rayon",
+]
+
 [dependencies]
 ark-bls12-377 = { workspace = true }
 ark-bls12-381 = { workspace = true }
@@ -34,12 +59,3 @@ ark-ed-on-bls12-377 = { workspace = true }
 ark-ed-on-bls12-381 = { workspace = true }
 ark-ed-on-bls12-381-bandersnatch = { workspace = true }
 ark-ed-on-bn254 = { workspace = true }
-
-[features]
-default = ["parallel"]
-std = ["ark-bls12-377/std", "ark-bls12-381/std", "ark-bn254/std", "ark-bw6-761/std",
-        "ark-std/std", "ark-serialize/std", "ark-ff/std", "ark-ec/std", 
-        "ark-poly/std", "downcast-rs/std", "jf-utils/std", "num-bigint/std",
-        "rand_chacha/std"]
-parallel = ["ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", 
-            "jf-utils/parallel", "dep:rayon" ]

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -10,6 +10,26 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = [
+    "ark-bls12-377/std",
+    "ark-bls12-381/std",
+    "ark-bn254/std",
+    "ark-bw6-761/std",
+    "ark-std/std",
+    "ark-ff/std",
+    "ark-crypto-primitives/std",
+    "ark-ed-on-bls12-377/std",
+    "ark-ed-on-bls12-381/std",
+    "ark-ed-on-bn254/std",
+    "itertools/use_std",
+    "jf-utils/std",
+    "jf-relation/std",
+]
+gadgets = ["jf-relation"]
+parallel = ["jf-relation/parallel"]
+
 [dependencies]
 ark-bls12-377 = { workspace = true }
 ark-bls12-381 = { workspace = true }
@@ -39,15 +59,3 @@ jf-utils = { path = "../utilities" }
 
 [dev-dependencies]
 ark-ed-on-bls12-381-bandersnatch = { workspace = true }
-
-[features]
-default = ["parallel"]
-std = [
-        "ark-bls12-377/std", "ark-bls12-381/std", "ark-bn254/std",
-        "ark-bw6-761/std", "ark-std/std", "ark-ff/std",
-        "ark-crypto-primitives/std", "ark-ed-on-bls12-377/std",
-        "ark-ed-on-bls12-381/std", "ark-ed-on-bn254/std",
-        "itertools/use_std", "jf-utils/std", "jf-relation/std",
-]
-gadgets = ["jf-relation"]
-parallel = ["jf-relation/parallel"]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -23,7 +23,7 @@ digest = { workspace = true }
 displaydoc = { workspace = true }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
-# temporarily using path for the follwing dependencies
+# temporarily using path for the following dependencies
 # jf-crhf = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
 # jf-relation = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", optional = true, default-features = false }
 # jf-rescue = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -10,6 +10,27 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = [
+    "ark-bls12-381/std",
+    "ark-bn254/std",
+    "ark-std/std",
+    "ark-serialize/std",
+    "ark-ff/std",
+    "num-bigint/std",
+    "num-traits/std",
+    "sha3/std",
+    "itertools/use_std",
+    "jf-utils/std",
+    "jf-relation/std",
+    "zeroize/std",
+]
+schnorr = []
+bls = []
+gadgets = ["schnorr", "jf-relation", "jf-rescue/gadgets"]
+parallel = ["jf-rescue/parallel", "jf-relation/parallel", "jf-utils/parallel"]
+
 [dependencies]
 ark-bls12-381 = { workspace = true }
 ark-bn254 = { workspace = true }
@@ -58,28 +79,3 @@ name = "bls-signature"
 path = "benches/bls_signature.rs"
 harness = false
 required-features = ["bls"]
-
-[features]
-default = ["parallel"]
-std = [
-        "ark-bls12-381/std",
-        "ark-bn254/std",
-        "ark-std/std",
-        "ark-serialize/std",
-        "ark-ff/std",
-        "num-bigint/std",
-        "num-traits/std",
-        "sha3/std",
-        "itertools/use_std",
-        "jf-utils/std",
-        "jf-relation/std",
-        "zeroize/std",
-]
-schnorr = []
-bls = []
-gadgets = [
-    "schnorr",
-    "jf-relation",
-    "jf-rescue/gadgets",
-]
-parallel = ["jf-rescue/parallel", "jf-relation/parallel", "jf-utils/parallel"]

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -7,6 +7,26 @@ edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+std = [
+    "ark-ff/std",
+    "ark-std/std",
+    "ark-ec/std",
+    "ark-serialize/std",
+    "ark-poly/std",
+    "digest/std",
+    "rand_chacha/std",
+    "serde/std",
+    "sha2/std",
+]
+parallel = [
+    "ark-ff/parallel",
+    "ark-std/parallel",
+    "ark-ec/parallel",
+    "dep:rayon",
+]
+
 [dependencies]
 ark-ec = { workspace = true }
 ark-ed-on-bls12-377 = { workspace = true }
@@ -29,23 +49,3 @@ ark-bls12-381 = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ed-on-bn254 = { workspace = true }
 criterion = "0.5.1"
-
-[features]
-default = []
-std = [
-    "ark-ff/std",
-    "ark-std/std",
-    "ark-ec/std",
-    "ark-serialize/std",
-    "ark-poly/std",
-    "digest/std",
-    "rand_chacha/std",
-    "serde/std",
-    "sha2/std",
-]
-parallel = [
-    "ark-ff/parallel",
-    "ark-std/parallel",
-    "ark-ec/parallel",
-    "dep:rayon",
-]

--- a/vid/Cargo.toml
+++ b/vid/Cargo.toml
@@ -10,6 +10,34 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = [
+    "ark-std/std",
+    "ark-serialize/std",
+    "ark-ff/std",
+    "ark-ec/std",
+    "ark-poly/std",
+    "itertools/use_std",
+    "jf-utils/std",
+    "jf-pcs/std",
+    "jf-merkle-tree/std",
+]
+test-srs = ["jf-pcs/test-srs"]
+parallel = [
+    "ark-ff/parallel",
+    "ark-ec/parallel",
+    "jf-utils/parallel",
+    "jf-pcs/parallel",
+    "rayon",
+]
+seq-fk-23 = [] # FK23 without parallelism
+gpu-vid = ["jf-pcs/icicle"]
+print-trace = ["ark-std/print-trace"]
+kzg-print-trace = [
+    "print-trace",
+] # leave disabled to reduce pollution in downstream users of KZG (such as VID)
+
 [dependencies]
 anyhow = "1.0"
 ark-ec = "0.4"
@@ -50,22 +78,3 @@ required-features = ["test-srs"]
 name = "advz_multiplicity"
 harness = false
 required-features = ["test-srs"]
-
-[features]
-default = ["parallel"]
-std = [
-    "ark-std/std", "ark-serialize/std", "ark-ff/std",
-    "ark-ec/std", "ark-poly/std", "itertools/use_std",
-    "jf-utils/std", "jf-pcs/std", "jf-merkle-tree/std",
-]
-test-srs = ["jf-pcs/test-srs"]
-parallel = [
-    "ark-ff/parallel", "ark-ec/parallel", "jf-utils/parallel",
-    "jf-pcs/parallel", "rayon",
-]
-seq-fk-23 = [] # FK23 without parallelism
-gpu-vid = ["jf-pcs/icicle"]
-print-trace = ["ark-std/print-trace"]
-kzg-print-trace = [
-        "print-trace",
-] # leave disabled to reduce pollution in downstream users of KZG (such as VID)

--- a/vid/src/lib.rs
+++ b/vid/src/lib.rs
@@ -84,7 +84,7 @@ pub trait VidScheme {
     /// [`VidScheme::Commit`].
     ///
     /// TODO conform to nested result pattern like [`VidScheme::verify_share`].
-    /// Unfortunately, `VidResult<()>` is more user-friently.
+    /// Unfortunately, `VidResult<()>` is more user-friendly.
     fn is_consistent(commit: &Self::Commit, common: &Self::Common) -> VidResult<()>;
 
     /// Extract the payload byte length data from a [`VidScheme::Common`].

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -10,6 +10,11 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["parallel"]
+std = ["ark-std/std", "digest/std", "jf-signature/std", "zeroize/std"]
+parallel = ["jf-signature/parallel"]
+
 [dependencies]
 ark-std = { workspace = true }
 digest = { version = "0.10.1", default-features = false, features = ["alloc"] }
@@ -21,10 +26,3 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 jf-utils = { version = "0.4.4", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", default-features = false }
-
-[features]
-default = ["parallel"]
-std = [
-    "ark-std/std", "digest/std", "jf-signature/std", "zeroize/std",
-]
-parallel = ["jf-signature/parallel"]


### PR DESCRIPTION
closes: #781 


### This PR: 

- Remove all `nimue` usage and upgrade to `spongefish`
- Update `jf-poseidon2`, simplify by maximally leveraging `DuplexSponge` existed in spongefish
- Update `jf-merkle-tree`, uncomment code and pass all tests
- Ran `pre-commit` which format all toml files. also ran `nix flake update` otherwise spongefish can't compile as it requires a newer rustc.
- [ ] consider removing dep on `ark-crypto-primitives` on `jf-rescue`, and use spongefish instead. (Still WIP locally)

### This PR does not:


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added relevant changelog entries to the `CHANGELOG.md` of touched crates.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
