### PR TITLE
feat: make bls12-381 curve optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Check Bench
-        run: cargo bench --features "test-srs bls schnorr gadgets" --no-run
+        run: cargo bench --features "test-srs bls bls12-381 schnorr gadgets" --no-run
 
       - name: Check all tests and binaries compilation
         run: |

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -74,4 +74,4 @@ sha2 = "0.10"
 name = "bls-signature"
 path = "benches/bls_signature.rs"
 harness = false
-required-features = ["bls"]
+required-features = ["bls", "bls12-381"]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -28,6 +28,7 @@ std = [
 ]
 schnorr = ["jf-rescue"]
 bls = []
+bls12-381 = ["blst"]
 gadgets = ["schnorr", "jf-relation", "jf-rescue/gadgets"]
 parallel = ["jf-rescue/parallel", "jf-relation/parallel", "jf-utils/parallel"]
 
@@ -38,7 +39,7 @@ ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
-blst = { version = "0.3.13", default-features = false }
+blst = { version = "0.3.13", default-features = false, optional = true }
 derive-where = { workspace = true }
 digest = { workspace = true }
 displaydoc = { workspace = true }

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -11,7 +11,7 @@ documentation = { workspace = true }
 repository = { workspace = true }
 
 [features]
-default = ["parallel"]
+default = ["bls12-381", "parallel"]
 std = [
     "ark-bls12-381/std",
     "ark-bn254/std",

--- a/signature/src/bls_over_bls12381.rs
+++ b/signature/src/bls_over_bls12381.rs
@@ -70,6 +70,7 @@
 //! ```
 //!
 //! [zeroize]: https://github.com/RustCrypto/utils/tree/master/zeroize
+#![cfg(feature = "bls12-381")]
 
 use super::SignatureScheme;
 use crate::{

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -26,11 +26,7 @@ pub mod gadgets;
 #[cfg(any(test, feature = "schnorr"))]
 pub mod schnorr;
 
-use ark_std::{
-    format,
-    string::{String, ToString},
-};
-use blst::BLST_ERROR;
+use ark_std::string::String;
 use core::fmt::Debug;
 use displaydoc::Display;
 use serde::{Deserialize, Serialize};
@@ -54,14 +50,18 @@ pub enum SignatureError {
 
 impl ark_std::error::Error for SignatureError {}
 
-impl From<BLST_ERROR> for SignatureError {
-    fn from(e: BLST_ERROR) -> Self {
+#[cfg(feature = "bls12-381")]
+impl From<blst::BLST_ERROR> for SignatureError {
+    fn from(e: blst::BLST_ERROR) -> Self {
+        use ark_std::string::ToString;
         match e {
-            BLST_ERROR::BLST_SUCCESS => {
+            blst::BLST_ERROR::BLST_SUCCESS => {
                 Self::ParameterError("Expecting an error, but got a success.".to_string())
             },
-            BLST_ERROR::BLST_VERIFY_FAIL => Self::VerificationError(format!("{e:?}")),
-            _ => Self::ParameterError(format!("{e:?}")),
+            blst::BLST_ERROR::BLST_VERIFY_FAIL => {
+                Self::VerificationError(ark_std::format!("{e:?}"))
+            },
+            _ => Self::ParameterError(ark_std::format!("{e:?}")),
         }
     }
 }


### PR DESCRIPTION
This adds a feature flag (default off) to opt into compilation of the bls12-381 curve. This curve requires a dependency on the `blst` crate. Due to the way this crate binds to compiled C and assembly, it cannot be built on certain targets (in particular, I'm targetting RISC-V for use with Succinct Labs' SP1 VM). With this flag, it is possible to compile the `jf-signature` crate without this dependency, and it now compiles using SP1.
